### PR TITLE
[feat] Add classification fine-tuning utilities

### DIFF
--- a/examples/flava/callbacks/multimodal_eval.py
+++ b/examples/flava/callbacks/multimodal_eval.py
@@ -7,7 +7,7 @@
 import logging
 
 import torch
-from data import default_text_transform, default_image_transforms
+from data import default_text_transform
 from imagenet_zeroshot_data import imagenet_classnames, openai_imagenet_template
 from pytorch_lightning import Callback, LightningDataModule
 from pytorch_lightning.utilities import rank_zero_only

--- a/examples/flava/data.py
+++ b/examples/flava/data.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import random
 import warnings
 from dataclasses import dataclass, field
@@ -19,13 +20,22 @@ from datasets.utils.file_utils import get_datasets_user_agent
 from PIL import Image, UnidentifiedImageError
 from pytorch_lightning import LightningDataModule
 from torchvision.datasets import ImageFolder
-from transformers import BertTokenizer, DataCollatorForLanguageModeling
+from transformers import (
+    BertTokenizer,
+    DefaultDataCollator,
+    DataCollatorForLanguageModeling,
+    TRANSFORMERS_CACHE,
+)
 from transforms import (
     RandomResizedCropAndInterpolationWithTwoPic,
     MaskingGenerator,
     map_pixels,
     convert_to_rgb,
 )
+
+
+PRETRAINING_IMAGE_MEAN = (0.48145466, 0.4578275, 0.40821073)
+PRETRAINING_IMAGE_STD = (0.26862954, 0.26130258, 0.27577711)
 
 
 class MaskedImageModelingTransform:
@@ -36,8 +46,8 @@ class MaskedImageModelingTransform:
         scale: Tuple[float, float] = (0.9, 1.0),
         encoder_interpolation: str = "bicubic",
         codebook_interpolation: str = "lanczos",
-        image_mean: Tuple[float, float, float] = (0.48145466, 0.4578275, 0.40821073),
-        image_std: Tuple[float, float, float] = (0.26862954, 0.26130258, 0.27577711),
+        image_mean: Tuple[float, float, float] = PRETRAINING_IMAGE_MEAN,
+        image_std: Tuple[float, float, float] = PRETRAINING_IMAGE_STD,
         mask_window_size: int = 14,
         mask_num_patches: int = 75,
         mask_max_patches: Optional[int] = None,
@@ -97,7 +107,7 @@ class MaskedImageModelingTransform:
             return self.transform(images)
 
 
-def default_image_transforms():
+def default_image_pretraining_transforms():
     return MaskedImageModelingTransform(), MaskedImageModelingTransform()
 
 
@@ -117,9 +127,9 @@ class ImageDataModule(LightningDataModule):
         val_root: str,
         transforms: Optional[Tuple[Callable, Callable]] = None,
         use_subset_sampler: bool = False,
-        batch_size=32,
-        num_workers=4,
-        allow_uneven_batches=False,
+        batch_size: int = 32,
+        num_workers: int = 4,
+        allow_uneven_batches: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -131,7 +141,7 @@ class ImageDataModule(LightningDataModule):
         self.use_subset_sampler = use_subset_sampler
 
         if transforms is None:
-            transforms = default_image_transforms()
+            transforms = default_image_pretraining_transforms()
 
         self.train_transform, self.test_transform = transforms
 
@@ -168,6 +178,7 @@ class ImageDataModule(LightningDataModule):
             batch_size=self.batch_size,
             num_workers=self.num_workers,
             sampler=sampler,
+            shuffle=True,
             # uneven batches can cause distributed issues,
             # drop last batch to prevent those.
             # ideally, we don't need to drop these for unimodal cases
@@ -181,6 +192,7 @@ class ImageDataModule(LightningDataModule):
             batch_size=self.batch_size,
             num_workers=self.num_workers,
             sampler=None,
+            shuffle=False,
             # uneven batches can cause distributed issues,
             # drop last batch to prevent those.
             # ideally, we don't need to drop these for unimodal cases
@@ -204,7 +216,7 @@ def _default_split_key_mapping():
 
 
 @dataclass
-class HFDatasetsInfo:
+class HFDatasetInfo:
     key: str
     subset: str
     remove_columns: Optional[List[str]] = None
@@ -215,9 +227,17 @@ class HFDatasetsInfo:
     )
 
 
-def _build_datasets_from_info(
-    dataset_infos: List[HFDatasetsInfo], split: str = "train"
-):
+@dataclass
+class TorchVisionDatasetInfo:
+    key: str
+    class_ptr: torch.utils.data.Dataset
+    train_split: str = "train"
+    val_split: str = "val"
+    has_val: bool = True
+    test_split: str = "test"
+
+
+def _build_datasets_from_info(dataset_infos: List[HFDatasetInfo], split: str = "train"):
     dataset_list = []
     for dataset_info in dataset_infos:
         current_dataset = load_dataset(
@@ -246,27 +266,23 @@ def _encode_text(text, tokenizer, *args, **kwargs):
     return tokenizer(text, *args, **kwargs)
 
 
-class MLMDataModule(LightningDataModule):
+class TextDataModule(LightningDataModule):
     def __init__(
         self,
-        dataset_infos: List[HFDatasetsInfo],
+        dataset_infos: List[HFDatasetInfo],
         tokenizer: Optional[Callable] = None,
-        mlm_probablity: float = 0.15,
         max_length: int = 512,
-        batch_size=32,
-        num_workers=4,
-        ignore_index=-1,
-        allow_uneven_batches=False,
+        batch_size: int = 32,
+        num_workers: int = 4,
+        allow_uneven_batches: bool = False,
         **kwargs,
     ):
         super().__init__()
         self.dataset_infos = dataset_infos
         self.tokenizer = tokenizer
-        self.mlm_probability = mlm_probablity
         self.max_length = max_length
         self.batch_size = batch_size
         self.num_workers = num_workers
-        self.ignore_index = ignore_index
         self.allow_uneven_batches = allow_uneven_batches
 
     def setup(self, stage=None):
@@ -292,37 +308,24 @@ class MLMDataModule(LightningDataModule):
         self.val_dataset.set_transform(transform)
 
     def train_dataloader(self):
-        return torch.utils.data.DataLoader(
-            self.train_dataset,
-            batch_size=self.batch_size,
-            num_workers=self.num_workers,
-            sampler=None,
-            collate_fn=self._build_collator(),
-            # uneven batches can cause distributed issues,
-            # drop last batch to prevent those.
-            # ideally, we don't need to drop these for unimodal cases
-            # but just to be safe
-            drop_last=True,
-        )
+        return self._build_dataloader(self.train_dataset)
 
     def val_dataloader(self):
+        return self._build_dataloader(self.val_dataset, shuffle=False)
+
+    def _build_dataloader(self, dataset, drop_last=False, shuffle=True):
         return torch.utils.data.DataLoader(
-            self.val_dataset,
+            dataset,
             batch_size=self.batch_size,
             num_workers=self.num_workers,
             sampler=None,
+            shuffle=shuffle,
             collate_fn=self._build_collator(),
-            # uneven batches can cause distributed issues,
-            # drop last batch to prevent those.
-            # ideally, we don't need to drop these for unimodal cases
-            # but just to be safe
-            drop_last=True,
+            drop_last=drop_last,
         )
 
     def _build_collator(self):
-        return DataCollatorForLanguageModeling(
-            self.tokenizer, mlm_probability=self.mlm_probability
-        )
+        return DefaultDataCollator()
 
     def on_before_batch_transfer(self, batch, *args):
         batch.pop("token_type_ids", None)
@@ -330,6 +333,35 @@ class MLMDataModule(LightningDataModule):
         if mask.size(0) < self.batch_size and not self.allow_uneven_batches:
             batch = pad_batch(batch, self.batch_size)
         return batch
+
+    def on_after_batch_transfer(self, batch, *args):
+        batch["text_masked"] = batch.pop("input_ids")
+        return batch
+
+
+class MLMDataModule(TextDataModule):
+    def __init__(
+        self,
+        dataset_infos: List[HFDatasetInfo],
+        mlm_probability: float = 0.15,
+        ignore_index: int = -1,
+        **kwargs: Any,
+    ):
+        super().__init__(dataset_infos, **kwargs)
+        self.mlm_probability = mlm_probability
+        self.ignore_index = ignore_index
+
+    def _build_dataloader(self, dataset, drop_last=True):
+        # uneven batches can cause distributed issues,
+        # drop last batch to prevent those.
+        # ideally, we don't need to drop these for unimodal cases
+        # but just to be safe
+        return self._build_dataloader(dataset, drop_last=drop_last)
+
+    def _build_collator(self):
+        return DataCollatorForLanguageModeling(
+            self.tokenizer, mlm_probability=self.mlm_probability
+        )
 
     def on_after_batch_transfer(self, batch, *args):
         batch["text_masked"] = batch.pop("input_ids")
@@ -404,8 +436,8 @@ def fetch_images(sample, timeout):
 class VLDataModule(LightningDataModule):
     def __init__(
         self,
-        train_dataset_infos: List[HFDatasetsInfo],
-        val_dataset_infos: List[HFDatasetsInfo],
+        train_dataset_infos: List[HFDatasetInfo],
+        val_dataset_infos: List[HFDatasetInfo],
         text_tokenizer: Optional[Callable] = None,
         image_transforms: Optional[Tuple[Callable, Callable]] = None,
         mlm_probablity: float = 0.15,
@@ -414,7 +446,7 @@ class VLDataModule(LightningDataModule):
         num_workers: int = 4,
         ignore_index: int = -1,
         itm_probability: float = 0.1,
-        allow_uneven_batches=False,
+        allow_uneven_batches: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -423,7 +455,7 @@ class VLDataModule(LightningDataModule):
         self.val_dataset_infos = val_dataset_infos
 
         if image_transforms is None:
-            image_transforms = default_image_transforms()
+            image_transforms = default_image_pretraining_transforms()
 
         self.train_image_transform, self.test_image_transform = image_transforms
         self.text_tokenizer = text_tokenizer
@@ -488,6 +520,7 @@ class VLDataModule(LightningDataModule):
             batch_size=self.batch_size,
             num_workers=self.num_workers,
             sampler=None,
+            shuffle=True,
             collate_fn=self._build_collator(),
             # uneven batches can cause distributed issues,
             # drop last batch to prevent those.
@@ -500,6 +533,7 @@ class VLDataModule(LightningDataModule):
             batch_size=self.batch_size,
             num_workers=self.num_workers,
             sampler=None,
+            shuffle=False,
             collate_fn=self._build_collator(),
             # uneven batches can cause distributed issues,
             # drop last batch to prevent those.
@@ -528,6 +562,102 @@ class VLDataModule(LightningDataModule):
         batch.update(
             {"mlm_labels": mlm_labels, "text": text, "text_masked": text_masked}
         )
+        return batch
+
+
+FINETUNING_IMAGE_MEAN = (0.485, 0.456, 0.406)
+FINETUNING_IMAGE_STD = (0.229, 0.224, 0.225)
+
+
+def default_torchvision_transforms():
+    transform = torchvision.transforms.Compose(
+        [
+            torchvision.transforms.Resize((224, 224)),
+            torchvision.transforms.ToTensor(),
+            torchvision.transforms.Normalize(
+                mean=FINETUNING_IMAGE_MEAN,
+                std=FINETUNING_IMAGE_STD,
+            ),
+        ]
+    )
+    return transform, transform
+
+
+class TorchVisionDataModule(LightningDataModule):
+    def __init__(
+        self,
+        dataset_info: TorchVisionDatasetInfo,
+        dataset_root: Optional[str] = None,
+        image_transforms: Optional[Tuple[Callable, Callable]] = None,
+        batch_size: int = 32,
+        num_workers: int = 4,
+        **kwargs,
+    ):
+        super().__init__()
+
+        if dataset_root is None:
+            dataset_root = os.path.join(TRANSFORMERS_CACHE, "datasets", "torchvision")
+            dataset_root = os.path.join(
+                dataset_root, dataset_info.class_ptr.__name__.lower()
+            )
+            os.makedirs(dataset_root, exist_ok=True)
+
+        self.dataset_info = dataset_info
+        self.dataset_root = dataset_root
+        if image_transforms is None:
+            image_transforms = default_torchvision_transforms()
+        self.train_transform, self.test_transform = image_transforms
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+
+    def setup(self, stage=None):
+        self.train_dataset = self.dataset_info.class_ptr(
+            self.dataset_root,
+            split=self.dataset_info.train_split,
+            transform=self.train_transform,
+            download=True,
+        )
+
+        if self.dataset_info.has_val:
+            self.val_dataset = self.dataset_info.class_ptr(
+                self.dataset_root,
+                split=self.dataset_info.val_split,
+                transform=self.test_transform,
+                download=True,
+            )
+
+        self.test_dataset = self.dataset_info.class_ptr(
+            self.dataset_root,
+            split=self.dataset_info.test_split,
+            transform=self.test_transform,
+            download=True,
+        )
+
+    def train_dataloader(self):
+        return self._build_dataloader(self.train_dataset)
+
+    def val_dataloader(self):
+        if self.dataset_info.has_val:
+            dataset = self.val_dataset
+        else:
+            dataset = self.test_dataset
+
+        return self._build_dataloader(dataset, shuffle=False)
+
+    def test_dataloader(self):
+        return self._build_dataloader(self.test_dataset, shuffle=False)
+
+    def _build_dataloader(self, dataset: torch.utils.data.Dataset, shuffle=True):
+        return torch.utils.data.DataLoader(
+            dataset,
+            shuffle=shuffle,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+        )
+
+    def on_before_batch_transfer(self, batch, *args):
+        images, targets = batch
+        batch = {"image": images, "labels": targets}
         return batch
 
 

--- a/examples/flava/finetune.py
+++ b/examples/flava/finetune.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torchvision
+from data import (
+    TorchVisionDataModule,
+    TorchVisionDatasetInfo,
+    HFDatasetInfo,
+    TextDataModule,
+)
+from model import FLAVAClassificationLightningModule
+from pytorch_lightning import Trainer, seed_everything
+from pytorch_lightning.callbacks import LearningRateMonitor
+
+AVAIL_GPUS = 1
+SEED = -1
+NUM_CLASSES = 2
+
+NUM_WORKERS = 4
+MAX_STEPS = 24000
+BATCH_SIZE = 32
+
+
+rendered_sst2_info = TorchVisionDatasetInfo(
+    key="rendered_sst2",
+    class_ptr=torchvision.datasets.RenderedSST2,
+)
+
+
+def main():
+    if SEED != -1:
+        seed_everything(SEED, workers=True)
+
+    datamodule = TorchVisionDataModule(
+        rendered_sst2_info,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+    )
+    datamodule.setup("fit")
+    model = FLAVAClassificationLightningModule(num_classes=NUM_CLASSES)
+
+    trainer = Trainer(
+        max_steps=MAX_STEPS,
+        gpus=AVAIL_GPUS,
+        progress_bar_refresh_rate=50,
+        callbacks=[
+            LearningRateMonitor(logging_interval="step"),
+        ],
+        strategy="ddp",
+    )
+    trainer.fit(model, datamodule=datamodule)
+    trainer.validate(model, datamodule=datamodule)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/flava/model.py
+++ b/examples/flava/model.py
@@ -3,10 +3,35 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
+import torch
 from pytorch_lightning import LightningModule
-from torchmultimodal.models.flava import flava_model_for_pretraining
-from transformers.optimization import AdamW, get_cosine_schedule_with_warmup
+from torchmultimodal.models.flava import (
+    flava_model_for_classification,
+    flava_model_for_pretraining,
+)
+from transformers.optimization import get_cosine_schedule_with_warmup
+
+
+def get_optimizers_for_lightning(
+    model: torch.nn.Module,
+    learning_rate: float,
+    adam_eps: float,
+    adam_weight_decay: float,
+    warmup_steps: int,
+    max_steps: int,
+):
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=learning_rate,
+        eps=adam_eps,
+        weight_decay=adam_weight_decay,
+    )
+    scheduler = get_cosine_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=warmup_steps,
+        num_training_steps=max_steps,
+    )
+    return [optimizer], [{"scheduler": scheduler, "interval": "step"}]
 
 
 class FLAVALightningModule(LightningModule):
@@ -26,7 +51,6 @@ class FLAVALightningModule(LightningModule):
         self.warmup_steps = warmup_steps
         self.max_steps = max_steps
 
-    # TODO: Setup validation loop
     def training_step(self, batch, batch_idx):
         output = self._step(batch, batch_idx)
         loss = sum(value for value in output.values())
@@ -67,15 +91,68 @@ class FLAVALightningModule(LightningModule):
         return output
 
     def configure_optimizers(self):
-        optimizer = AdamW(
-            self.parameters(),
-            lr=self.learning_rate,
-            eps=self.adam_eps,
-            weight_decay=self.adam_weight_decay,
+        return get_optimizers_for_lightning(
+            self.model,
+            self.learning_rate,
+            self.adam_eps,
+            self.adam_weight_decay,
+            self.warmup_steps,
+            self.max_steps,
         )
-        scheduler = get_cosine_schedule_with_warmup(
-            optimizer,
-            num_warmup_steps=self.warmup_steps,
-            num_training_steps=self.max_steps,
+
+
+class FLAVAClassificationLightningModule(FLAVALightningModule):
+    def __init__(
+        self,
+        num_classes: int,
+        learning_rate: float = 0.0002,
+        adam_eps: float = 1.0e-08,
+        adam_weight_decay: float = 0.01,
+        warmup_steps: int = 2000,
+        max_steps: int = 450000,
+    ):
+        super().__init__()
+        self.model = flava_model_for_classification(
+            num_classes=num_classes, pretrained_model_key="flava_full"
         )
-        return [optimizer], [{"lr_scheduler": scheduler, "interval": "step"}]
+        self.learning_rate = learning_rate
+        self.adam_eps = adam_eps
+        self.adam_weight_decay = adam_weight_decay
+        self.warmup_steps = warmup_steps
+        self.max_steps = max_steps
+
+    def training_step(self, batch, batch_idx):
+        output = self._step(batch, batch_idx)
+        loss = sum(value for value in output.values())
+        for key in output:
+            self.log(f"train/losses/{key}", output[key], prog_bar=True, logger=True)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        output = self._step(batch, batch_idx)
+        loss = sum(value for value in output.values())
+        for key in output:
+            self.log(
+                f"validation/losses/{key}", output[key], prog_bar=True, logger=True
+            )
+        return loss
+
+    def _step(self, batch, batch_idx):
+        if "image" in batch and ("text" in batch or "text_masked" in batch):
+            required_embedding = "mm"
+        elif "image" in batch:
+            required_embedding = "image"
+        elif "text" in batch or "text_masked" in batch:
+            required_embedding = "text"
+        else:
+            raise RuntimeError("Batch needs to have either or both 'image' and 'text'.")
+
+        output = self.model(
+            image=batch.get("image", None),
+            text=batch.get("text", None),
+            required_embedding=required_embedding,
+            labels=batch.get("labels", None),
+        )
+
+        # TODO: Add accuracy metric to this later.
+        return {"classification": output}

--- a/examples/flava/train.py
+++ b/examples/flava/train.py
@@ -7,19 +7,19 @@
 from data import (
     ImageDataModule,
     MLMDataModule,
-    HFDatasetsInfo,
+    HFDatasetInfo,
     VLDataModule,
     MultiDataModule,
 )
 from model import FLAVALightningModule
-from pytorch_lightning import Trainer  # , seed_everything
+from pytorch_lightning import Trainer, seed_everything
 from pytorch_lightning.callbacks import LearningRateMonitor
 
 from examples.flava.callbacks.multimodal_eval import MultimodalEvalCallback
 
 
 AVAIL_GPUS = 2
-SEED = 1234
+SEED = -1
 
 IMAGENET_TRAIN_ROOT = ""
 IMAGENET_VAL_ROOT = ""
@@ -30,8 +30,8 @@ ALLOW_UNEVEN_BATCHES = False
 
 
 def main():
-    # TODO: Check this later, since this is causing all workers to load same data.
-    # seed_everything(SEED, workers=True)
+    if SEED != -1:
+        seed_everything(SEED, workers=True)
     imagenet_datamodule = ImageDataModule(
         train_root=IMAGENET_TRAIN_ROOT,
         val_root=IMAGENET_VAL_ROOT,
@@ -40,7 +40,7 @@ def main():
         allow_unenven_batchs=ALLOW_UNEVEN_BATCHES,
     )
     mlm_datamodule = MLMDataModule(
-        [HFDatasetsInfo("wikitext", "wikitext-103-raw-v1")],
+        [HFDatasetInfo("wikitext", "wikitext-103-raw-v1")],
         batch_size=BATCH_SIZE,
         num_workers=NUM_WORKERS,
         allow_unenven_batchs=ALLOW_UNEVEN_BATCHES,
@@ -49,14 +49,14 @@ def main():
         [
             VLDataModule(
                 train_dataset_infos=[
-                    HFDatasetsInfo(
+                    HFDatasetInfo(
                         key="red_caps",
                         subset="mycology",
                         rename_columns=[("caption", "text")],
                     )
                 ],
                 val_dataset_infos=[
-                    HFDatasetsInfo(
+                    HFDatasetInfo(
                         key="red_caps",
                         subset="mycology",
                         rename_columns=[("caption", "text")],
@@ -82,6 +82,7 @@ def main():
             LearningRateMonitor(logging_interval="step"),
             MultimodalEvalCallback(imagenet_datamodule=imagenet_datamodule),
         ],
+        strategy="ddp",
     )
     trainer.fit(model, datamodule=datamodule)
     trainer.validate(model, datamodule=datamodule)

--- a/torchmultimodal/models/flava.py
+++ b/torchmultimodal/models/flava.py
@@ -26,6 +26,8 @@ from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 import torch
 from packaging import version
 from torch import nn, Tensor, device
+
+from torchmultimodal.modules.layers.mlp import MLP
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
 from torchmultimodal.modules.losses.flava import Pooler, FLAVAPretrainingLoss
 from torchmultimodal.utils.common import PretrainedMixin
@@ -155,7 +157,7 @@ def flava_model_for_pretraining(
     **flava_model_kwargs: Any,
     # TODO: Add parameters for loss here
 ):
-    model = flava_model()
+    model = flava_model(**flava_model_kwargs)
 
     codebook = DalleVAEEncoder(image_size=codebook_image_size)
     losses = FLAVAPretrainingLoss()
@@ -165,8 +167,37 @@ def flava_model_for_pretraining(
         image_codebook=codebook,
         loss=losses,
     )
-    flava.load_model(FLAVA_FOR_PRETRAINED_MAPPING[pretrained_model_key])
+
+    if pretrained_model_key is not None:
+        flava.load_model(FLAVA_FOR_PRETRAINED_MAPPING[pretrained_model_key])
+
     return flava
+
+
+def flava_model_for_classification(
+    num_classes: int,
+    classifier_in_dim: int = 768,
+    classifier_hidden_sizes: Union[int, List[int]] = 768,
+    classifier_dropout: float = 0.5,
+    classifier_activation: Callable[..., nn.Module] = nn.ReLU,
+    classifier_normalization: Optional[Callable[..., nn.Module]] = None,
+    loss_fn: Optional[Callable[..., Tensor]] = None,
+    **flava_model_kwargs: Any,
+):
+    model = flava_model(**flava_model_kwargs)
+    classifier = MLP(
+        in_dim=classifier_in_dim,
+        out_dim=num_classes,
+        hidden_dims=classifier_hidden_sizes,
+        dropout=classifier_dropout,
+        activation=classifier_activation,
+        normalization=classifier_normalization,
+    )
+
+    if loss_fn is None:
+        loss_fn = nn.CrossEntropyLoss()
+
+    return FLAVAForClassification(model=model, classifier=classifier, loss=loss_fn)
 
 
 class FLAVAModel(nn.Module, PretrainedMixin):
@@ -363,6 +394,45 @@ class FLAVAForPretraining(nn.Module, PretrainedMixin):
             mim_labels=image_labels,
             mlm_labels=mlm_labels,
         )
+
+
+class FLAVAForClassification(nn.Module, PretrainedMixin):
+    def __init__(
+        self,
+        model: FLAVAModel,
+        classifier: nn.Module,
+        loss: Union[nn.Module, Callable[[Tensor, Tensor], Tensor]],
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self.model = model
+        self.classifier = classifier
+        self.loss = loss
+
+    def forward(
+        self,
+        image: Optional[Tensor] = None,
+        text: Optional[Tensor] = None,
+        required_embedding: Optional[EMBEDDING_OPTIONS] = None,
+        labels: Optional[Tensor] = None,
+        cls_index: int = 0,
+    ):
+        flava_output: FLAVAOutput = self.model(
+            image=image,
+            text=text,
+            required_embedding=required_embedding,
+        )
+
+        hidden_state: Optional[Tensor] = None
+        if required_embedding == "image":
+            hidden_state = flava_output.image.last_hidden_state
+        elif required_embedding == "text":
+            hidden_state = flava_output.text.last_hidden_state
+        else:
+            hidden_state = flava_output.multimodal.last_hidden_state
+
+        scores = self.classifier(hidden_state[:, cls_index])
+        return self.loss(scores, labels)
 
 
 class TransformerSelfAttention(nn.Module):

--- a/torchmultimodal/modules/layers/mlp.py
+++ b/torchmultimodal/modules/layers/mlp.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 import torch
 from torch import nn
@@ -36,7 +36,7 @@ class MLP(nn.Module):
         self,
         in_dim: int,
         out_dim: int,
-        hidden_dims: Optional[List[int]] = None,
+        hidden_dims: Optional[Union[int, List[int]]] = None,
         dropout: float = 0.5,
         activation: Callable[..., nn.Module] = nn.ReLU,
         normalization: Optional[Callable[..., nn.Module]] = None,
@@ -48,6 +48,10 @@ class MLP(nn.Module):
 
         if hidden_dims is None:
             hidden_dims = []
+
+        if isinstance(hidden_dims, int):
+            hidden_dims = [hidden_dims]
+
         for hidden_dim in hidden_dims:
             layers.append(nn.Linear(in_dim, hidden_dim))
             if normalization:

--- a/torchmultimodal/modules/losses/flava.py
+++ b/torchmultimodal/modules/losses/flava.py
@@ -30,7 +30,7 @@ from torchmultimodal.modules.losses.contrastive_loss_with_temperature import (
 
 # TODO(asg): Replace later with MLP classifier if checkpoint permits
 class Pooler(nn.Module):
-    def __init__(self, hidden_size: int = 756, **kwargs: Any):
+    def __init__(self, hidden_size: int = 768, **kwargs: Any):
         super().__init__()
 
         self.dense = nn.Linear(hidden_size, hidden_size)
@@ -45,9 +45,8 @@ class Pooler(nn.Module):
         return pooled_output
 
 
-# TODO(asg): Simplify with existing checkpoints later
 class TwoWayHead(nn.Module):
-    def __init__(self, hidden_size: int = 756, **kwargs: Any):
+    def __init__(self, hidden_size: int = 768, **kwargs: Any):
         super().__init__()
 
         self.seq_relationship = nn.Linear(hidden_size, 2)
@@ -85,9 +84,9 @@ class ITMLoss(nn.Module):
 class MaskedPredictionHead(nn.Module):
     def __init__(
         self,
-        hidden_size: int = 756,
+        hidden_size: int = 768,
         vocab_size: int = 30522,
-        transform_act_fn: Callable[..., Tensor] = nn.functional.gelu,
+        transform_act_fn: Callable[[Tensor], Tensor] = nn.functional.gelu,
         layer_norm_eps: float = 1e-5,
         use_fp32_layer_norm: bool = True,
         **kwargs: Any,
@@ -123,9 +122,9 @@ class MaskedPredictionHead(nn.Module):
 class MaskedPredictionLoss(nn.Module):
     def __init__(
         self,
-        hidden_size: int = 756,
+        hidden_size: int = 768,
         vocab_size: int = 30522,
-        transform_act_fn: Callable[..., Tensor] = nn.functional.gelu,
+        transform_act_fn: Callable[[Tensor], Tensor] = nn.functional.gelu,
         layer_norm_eps: float = 1e-5,
         ignore_index: int = -1,
         **kwargs: Any,
@@ -220,7 +219,7 @@ class FLAVAPretrainingLoss(nn.Module):
         hidden_size: int = 768,
         text_vocab_size: int = 30522,
         image_vocab_size: int = 8192,
-        transform_act_fn: Callable[..., Tensor] = nn.functional.gelu,
+        transform_act_fn: Callable[[Tensor], Tensor] = nn.functional.gelu,
         layer_norm_eps: float = 1e-5,
         ignore_index: int = -1,
         mlm_weight: float = 1.0,
@@ -299,6 +298,7 @@ class FLAVAPretrainingLoss(nn.Module):
     ):
         # TODO(asg): Add proper checks and only calculate losses which can
         # be calculated
+        # TODO: Create a dataclass for loss outputs
         outputs = {}
         pos_mask = None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #10
* #9
* __->__ #8

- The PR aims at ending starter classification utils to flava examples.

As of now the PR adds following things:
- Finetuning trainer
- Classification FLAVA
- TorchVisionDataModule for easy composability of datasets from
torchvision
- Some changes to MLP module for more generalization
- Some improvements/bug fixes to original FLAVA code
- Splits the datamodules to better service their individual concerns.

TODOs:
- Add support for rest of the datasets. This involves levaraging the
existing datamodules that we created in this PR along with support for
seamlessly plugging different dataset
- Add command line overriding on top
- Add support for retrieval, zero-shot and other downstream tasks in an
easily accessible form
- Expose more things from the model other than just the loss

Test Plan:

The code is not in 100% working stage. I have tested only the changes in
my PR. I expect everything to be stable by the end of the stack.

Differential Revision: [D35361821](https://our.internmc.facebook.com/intern/diff/D35361821)