### PR TITLE
[feat,tests] Expose more information from FLAVA along with tests

### DIFF
--- a/test/models/test_flava.py
+++ b/test/models/test_flava.py
@@ -1,0 +1,178 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from dataclasses import asdict
+
+import torch
+from torchmultimodal.models.flava import (
+    flava_model_for_pretraining,
+    flava_model_for_classification,
+    EMBEDDING_OPTIONS,
+)
+
+
+NUM_CLASSES = 2
+
+
+class TestFLAVA(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(1234)
+
+    @torch.no_grad()
+    def test_forward_classification(self):
+        flava = flava_model_for_classification(NUM_CLASSES)
+        text = torch.randint(0, 30500, (2, 77), dtype=torch.long)
+        image = torch.rand((2, 3, 224, 224))
+
+        labels = torch.randint(0, 2, (2,), dtype=torch.long)
+
+        # Test multimodal scenario
+        output = flava(image, text, "mm", labels)
+        print(output)
+        print(output.logits.sum())
+        self.assertTrue(
+            torch.allclose(
+                output.loss, torch.tensor(0.9303, dtype=torch.float), atol=1e-4
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                output.logits.sum(), torch.tensor(0.7676, dtype=torch.float), atol=1e-4
+            )
+        )
+
+        # Test unimodal image scenario
+        output = flava(image, text, "image", labels)
+        print(output)
+        print(output.logits.sum())
+        self.assertTrue(
+            torch.allclose(
+                output.loss, torch.tensor(0.5453, dtype=torch.float), atol=1e-4
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                output.logits.sum(), torch.tensor(-0.2235, dtype=torch.float), atol=1e-4
+            )
+        )
+
+        # Test unimodal text scenario
+        output = flava(image, text, "text", labels)
+        print(output)
+        print(output.logits.sum())
+        self.assertTrue(
+            torch.allclose(
+                output.loss, torch.tensor(0.7074, dtype=torch.float), atol=1e-4
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                output.logits.sum(), torch.tensor(-1.0528, dtype=torch.float), atol=1e-4
+            )
+        )
+
+    @torch.no_grad()
+    def test_forward_pretraining(self):
+        flava = flava_model_for_pretraining()
+        text = torch.randint(0, 30500, (2, 77), dtype=torch.long)
+        image = torch.rand((2, 3, 224, 224))
+        image_for_codebook = torch.rand(2, 3, 112, 112)
+        image_patches_mask = torch.randint(0, 2, (2, 196), dtype=torch.long)
+        text_masked = text.detach().clone()
+        text_masked[:, 1:3] = 100
+        mlm_labels = text.detach().clone()
+        mlm_labels[:, :] = -1
+        mlm_labels[:, 1:3] = text[:, 1:3]
+        itm_labels = torch.tensor((0, 1), dtype=torch.long)
+
+        output = flava(
+            image=image,
+            text=text,
+            image_for_codebook=image_for_codebook,
+            image_patches_mask=image_patches_mask,
+            text_masked=text_masked,
+            required_embedding="mm",
+            itm_labels=itm_labels,
+            mlm_labels=mlm_labels,
+        )
+        print(output)
+        self.assertIsNone(output.mlm_output)
+        self.assertIsNone(output.mim_output)
+        self.assertIsNotNone(output.global_contrastive_output)
+        self.assertIsNotNone(output.mmm_text_output)
+        self.assertIsNotNone(output.mmm_image_output)
+        self.assertIsNotNone(output.itm_output)
+        self.assertTrue(
+            torch.allclose(
+                sum(
+                    value if value is not None else 0
+                    for _, value in asdict(output.losses).items()
+                ),
+                torch.tensor(20.6433, dtype=torch.float),
+                atol=1e-4,
+            )
+        )
+
+        output = flava(
+            image=image,
+            text=text,
+            image_for_codebook=image_for_codebook,
+            image_patches_mask=image_patches_mask,
+            text_masked=text_masked,
+            required_embedding="image",
+            itm_labels=itm_labels,
+            mlm_labels=mlm_labels,
+        )
+        self.assertIsNone(output.mlm_output)
+        self.assertIsNotNone(output.mim_output)
+        self.assertIsNone(output.global_contrastive_output)
+        self.assertIsNone(output.mmm_text_output)
+        self.assertIsNone(output.mmm_image_output)
+        self.assertIsNone(output.itm_output)
+        self.assertTrue(
+            torch.allclose(
+                sum(
+                    value if value is not None else 0
+                    for _, value in asdict(output.losses).items()
+                ),
+                torch.tensor(9.3403, dtype=torch.float),
+                atol=1e-4,
+            )
+        )
+
+        output = flava(
+            image=image,
+            text=text,
+            image_for_codebook=image_for_codebook,
+            image_patches_mask=image_patches_mask,
+            text_masked=text_masked,
+            required_embedding="text",
+            itm_labels=itm_labels,
+            mlm_labels=mlm_labels,
+        )
+        self.assertIsNotNone(output.mlm_output)
+        self.assertIsNone(output.mim_output)
+        self.assertIsNone(output.global_contrastive_output)
+        self.assertIsNone(output.mmm_text_output)
+        self.assertIsNone(output.mmm_image_output)
+        self.assertIsNone(output.itm_output)
+        print(
+            sum(
+                value if value is not None else 0
+                for key, value in asdict(output.losses).items()
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                sum(
+                    value if value is not None else 0
+                    for _, value in asdict(output.losses).items()
+                ),
+                torch.tensor(10.8777, dtype=torch.float),
+                atol=1e-4,
+            )
+        )

--- a/torchmultimodal/models/flava.py
+++ b/torchmultimodal/models/flava.py
@@ -8,6 +8,7 @@ import collections
 import math
 import warnings
 from collections import namedtuple, OrderedDict
+from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 
@@ -17,7 +18,11 @@ from torch import nn, Tensor, device
 
 from torchmultimodal.modules.layers.mlp import MLP
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
-from torchmultimodal.modules.losses.flava import Pooler, FLAVAPretrainingLoss
+from torchmultimodal.modules.losses.flava import (
+    FLAVAPretrainingLossOutput,
+    Pooler,
+    FLAVAPretrainingLoss,
+)
 from torchmultimodal.utils.common import PretrainedMixin
 
 
@@ -188,6 +193,12 @@ def flava_model_for_classification(
     return FLAVAForClassification(model=model, classifier=classifier, loss=loss_fn)
 
 
+@dataclass
+class FLAVAForClassificationOutput:
+    logits: Tensor
+    loss: Tensor
+
+
 class FLAVAModel(nn.Module, PretrainedMixin):
     def __init__(
         self,
@@ -305,6 +316,10 @@ class FLAVAModel(nn.Module, PretrainedMixin):
         image_embedding: Tensor,
         text_embedding: Tensor,
     ):
+        if image_embedding is None or text_embedding is None:
+            # Since nothing is passed, it might be case without
+            # masked data let's say.
+            return TransformerOutput()
         image_embedding = self.image_to_mm_projection(image_embedding)
         text_embedding = self.text_to_mm_projection(text_embedding)
         fused_state = torch.cat([image_embedding, text_embedding], dim=1)
@@ -315,10 +330,7 @@ class FLAVAModel(nn.Module, PretrainedMixin):
 class FLAVAForPretraining(nn.Module, PretrainedMixin):
     # TODOs:
     # 1. Expose logit scale
-    # 2. Test out encode methods
-    # 3. Add pretrained model loading capabilities.
-    # 4. For FLAVA model, allow interpolating the embeddings to
-
+    # 2. For FLAVA model, allow interpolating the embeddings to
     # for patch embeddings
     def __init__(self, model: FLAVAModel, image_codebook: nn.Module, loss: nn.Module):
         super().__init__()
@@ -356,7 +368,7 @@ class FLAVAForPretraining(nn.Module, PretrainedMixin):
         required_embedding: Optional[EMBEDDING_OPTIONS] = None,
         itm_labels: Optional[Tensor] = None,
         mlm_labels: Optional[Tensor] = None,
-    ):
+    ) -> FLAVAPretrainingLossOutput:
         image_labels = None
         if image_for_codebook is not None:
             image_labels = self.image_codebook(image_for_codebook).flatten(1)
@@ -420,7 +432,11 @@ class FLAVAForClassification(nn.Module, PretrainedMixin):
             hidden_state = flava_output.multimodal.last_hidden_state
 
         scores = self.classifier(hidden_state[:, cls_index])
-        return self.loss(scores, labels)
+        loss = self.loss(scores, labels)
+        return FLAVAForClassificationOutput(
+            logits=scores,
+            loss=loss,
+        )
 
 
 class TransformerSelfAttention(nn.Module):

--- a/torchmultimodal/modules/losses/flava.py
+++ b/torchmultimodal/modules/losses/flava.py
@@ -7,14 +7,64 @@
 
 import math
 import warnings
+from dataclasses import dataclass, asdict, field
 from typing import Any, Callable, Optional, Union
 
 import torch
 from torch import nn, Tensor
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
 from torchmultimodal.modules.losses.contrastive_loss_with_temperature import (
+    ContrastiveLossOutput,
     contrastive_loss_with_temperature,
 )
+
+
+@dataclass
+class ITMLossOutput:
+    logits: Tensor
+    loss: Tensor
+
+
+@dataclass
+class MaskedPredictionLossOutput:
+    logits: Tensor
+    loss: Tensor
+
+
+@dataclass
+class FLAVAGlobalContrastiveLossOutput(ContrastiveLossOutput):
+    text_embedding: Tensor
+    image_embedding: Tensor
+    logit_scale: Tensor
+
+
+@dataclass
+class FLAVAPretrainingLossesCollection:
+    mmm_text_loss: Optional[Tensor] = None
+    mmm_image_loss: Optional[Tensor] = None
+    mim_loss: Optional[Tensor] = None
+    mlm_loss: Optional[Tensor] = None
+    itm_loss: Optional[Tensor] = None
+    global_contrastive_loss: Optional[Tensor] = None
+
+
+@dataclass
+class FLAVAPretrainingLossOutput:
+    losses: FLAVAPretrainingLossesCollection = field(
+        default_factory=FLAVAPretrainingLossesCollection
+    )
+    mlm_output: Optional[MaskedPredictionLossOutput] = None
+    mim_output: Optional[MaskedPredictionLossOutput] = None
+    mmm_text_output: Optional[MaskedPredictionLossOutput] = None
+    mmm_image_output: Optional[MaskedPredictionLossOutput] = None
+    itm_output: Optional[ITMLossOutput] = None
+    global_contrastive_output: Optional[FLAVAGlobalContrastiveLossOutput] = None
+    image_sequence: Optional[Tensor] = None
+    text_sequence: Optional[Tensor] = None
+    image_masked_sequence: Optional[Tensor] = None
+    text_masked_sequence: Optional[Tensor] = None
+    multimodal_sequence: Optional[Tensor] = None
+    multimodal_masked_sequence: Optional[Tensor] = None
 
 
 # TODO(asg): Replace later with MLP classifier if checkpoint permits
@@ -64,10 +114,11 @@ class ITMLoss(nn.Module):
         pooled_output = self.pooler(hidden_states)
         scores = self.cls(pooled_output)
 
-        return self.ce_loss(
+        loss = self.ce_loss(
             scores.view(-1, 2),
             labels.view(-1),
         )
+        return ITMLossOutput(logits=scores, loss=loss)
 
 
 class MaskedPredictionHead(nn.Module):
@@ -146,7 +197,10 @@ class MaskedPredictionLoss(nn.Module):
         if torch.isnan(masked_loss):
             warnings.warn("NaN detected in masked_loss. Replacing it with 0.")
             masked_loss = torch.nan_to_num(masked_loss, nan=0.0)
-        return masked_loss
+        return MaskedPredictionLossOutput(
+            logits=prediction,
+            loss=masked_loss,
+        )
 
 
 class FLAVAGlobalContrastiveLoss(nn.Module):
@@ -191,13 +245,24 @@ class FLAVAGlobalContrastiveLoss(nn.Module):
 
         self.logit_scale.data.clamp_(0, 4.6052)
 
-        return contrastive_loss_with_temperature(
+        output = contrastive_loss_with_temperature(
             image_embeddings=image_embedding,
             text_embeddings=text_embedding,
             logit_scale=self.logit_scale,
             mask=mask,
             # Always true for FLAVA global contrastive loss
             backprop_in_gather=True,
+        )
+
+        return FLAVAGlobalContrastiveLossOutput(
+            loss=output.loss,
+            image_logits=output.image_logits,
+            text_logits=output.text_logits,
+            image_loss=output.image_loss,
+            text_loss=output.text_loss,
+            text_embedding=text_embedding,
+            image_embedding=image_embedding,
+            logit_scale=self.logit_scale.data,
         )
 
 
@@ -273,6 +338,8 @@ class FLAVAPretrainingLoss(nn.Module):
         self.itm_loss_weight = itm_loss_weight
 
     # TODO: Some refactoring is needed in this function to make it look better
+    # TODO: Possibly refactor this into functional and class component
+    # for better usability
     def forward(
         self,
         image_sequence: Optional[Tensor] = None,
@@ -284,11 +351,11 @@ class FLAVAPretrainingLoss(nn.Module):
         itm_labels: Optional[Tensor] = None,
         mim_labels: Optional[Tensor] = None,
         mlm_labels: Optional[Tensor] = None,
-    ):
+    ) -> FLAVAPretrainingLossOutput:
         # TODO(asg): Add proper checks and only calculate losses which can
         # be calculated
         # TODO: Create a dataclass for loss outputs
-        outputs = {}
+        outputs = FLAVAPretrainingLossOutput()
         pos_mask = None
 
         # Check multimodal_masked_sequence to make sure this is unimodal case
@@ -296,33 +363,29 @@ class FLAVAPretrainingLoss(nn.Module):
         # text, but that is a research question :)
         if (
             mim_labels is not None
+            and image_masked_sequence is not None
             and self.mim_weight > 0
             and multimodal_masked_sequence is None
         ):
-            assert image_masked_sequence is not None, (
-                "image_masked_sequence must be passed with "
-                + "mim_labels when it is not a multimodal case"
-            )
             # Remove CLS token from image_masked_sequence
-            outputs["mim_loss"] = self.mim_loss(
+            outputs.mim_output = self.mim_loss(
                 image_masked_sequence[:, -mim_labels.size(1) :, :], mim_labels
             )
-            outputs["mim_loss"] *= self.mim_weight
+            outputs.mim_output.loss *= self.mim_weight
+            outputs.losses.mim_loss = outputs.mim_output.loss
 
         # Check multimodal_masked_sequence to make sure this is unimodal case
         if (
             mlm_labels is not None
+            and text_masked_sequence is not None
             and self.mlm_weight > 0
             and multimodal_masked_sequence is None
         ):
-            assert text_masked_sequence is not None, (
-                "text_masked_sequence must be passed with "
-                + "mlm_labels when it is not a multimodal case"
-            )
-            outputs["mlm_loss"] = self.mlm_loss(
+            outputs.mlm_output = self.mlm_loss(
                 text_masked_sequence[:, -mlm_labels.size(1) :, :], mlm_labels
             )
-            outputs["mlm_loss"] *= self.mlm_weight
+            outputs.mlm_output.loss *= self.mlm_weight
+            outputs.losses.mlm_loss = outputs.mlm_output.loss
 
         if (
             multimodal_sequence is not None
@@ -332,7 +395,10 @@ class FLAVAPretrainingLoss(nn.Module):
             pos_pairs = itm_labels.ne(0)
             pos_mask = torch.where(pos_pairs.any(), pos_pairs, pos_pairs.new([True]))
             itm_loss = self.itm_loss(multimodal_sequence, itm_labels)
-            outputs["itm_loss"] = self.itm_loss_weight * itm_loss
+            outputs.itm_output = itm_loss
+            outputs.itm_output.loss *= self.itm_loss_weight
+            outputs.losses.itm_loss = outputs.itm_output.loss
+
             multimodal_sequence = multimodal_sequence[pos_mask]
             if multimodal_masked_sequence is not None:
                 multimodal_masked_sequence = multimodal_masked_sequence[pos_mask]
@@ -344,11 +410,12 @@ class FLAVAPretrainingLoss(nn.Module):
         if multimodal_masked_sequence is not None and self.mmm_text_loss_weight > 0:
             assert mlm_labels is not None, "mlm_labels must be passed for mmm_text_loss"
             sequence_for_text = multimodal_masked_sequence[:, -mlm_labels.size(1) :, :]
-            outputs["mmm/text_loss"] = self.mmm_loss.mlm(
+            outputs.mmm_text_output = self.mmm_loss.mlm(
                 sequence_for_text,
                 mlm_labels,
             )
-            outputs["mmm/text_loss"] *= self.mmm_text_loss_weight
+            outputs.mmm_text_output.loss *= self.mmm_text_loss_weight
+            outputs.losses.mmm_text_loss = outputs.mmm_text_output.loss
 
         if multimodal_masked_sequence is not None and self.mmm_image_loss_weight > 0:
             assert (
@@ -359,22 +426,26 @@ class FLAVAPretrainingLoss(nn.Module):
             sequence_for_image = multimodal_masked_sequence[
                 :, 2 : 2 + mim_labels.size(1), :
             ]
-            outputs["mmm/image_loss"] = self.mmm_loss.mim(
+            outputs.mmm_image_output = self.mmm_loss.mim(
                 sequence_for_image,
                 mim_labels,
             )
-            outputs["mmm/image_loss"] *= self.mmm_image_loss_weight
+            outputs.mmm_image_output.loss *= self.mmm_image_loss_weight
+            outputs.losses.mmm_image_loss = outputs.mmm_image_output.loss
 
         if (
             image_sequence is not None
             and text_sequence is not None
             and self.contrastive_loss_weight > 0
         ):
-            outputs["global_contrastive_loss"] = self.contrastive_loss(
+            outputs.global_contrastive_output = self.contrastive_loss(
                 image_sequence,
                 text_sequence,
                 pos_mask,
             )
-            outputs["global_contrastive_loss"] *= self.contrastive_loss_weight
+            outputs.global_contrastive_output.loss *= self.contrastive_loss_weight
+            outputs.losses.global_contrastive_loss = (
+                outputs.global_contrastive_output.loss
+            )
 
         return outputs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #10

This PR does multiple things:
1. Adds tests for FLAVA pretraining and classification forward models
2. Exposes some of the important information from the model other than
losses. This will allow people to build stuff on top of flava
3. Fix image transform for pretraining and defaults for case of testing
4. Fix some issues with the complete end-to-end repo

Test Plan:
Tests have been added for the model

Differential Revision: [D35363010](https://our.internmc.facebook.com/intern/diff/D35363010)