### PR TITLE
Upgrade pytorch lightning to address vulnerability

### DIFF
--- a/examples/flava/requirements.txt
+++ b/examples/flava/requirements.txt
@@ -1,5 +1,5 @@
 Pillow==9.0.1
-pytorch-lightning==1.5.10
+pytorch-lightning==1.6.0
 datasets==2.0.0
 requests==2.27.1
 DALL-E==0.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #14
* #10

Summary:
- One of FLAVA example module's dependencies -- pytorch_lightning version 1.5.10 --- is being identified for vulnerability issue by GitHub (see https://github.com/advisories/GHSA-r5qj-cvf9-p85h).

- This is fixed in v 1.6.0 -- https://github.com/pytorchlightning/pytorch-lightning/commit/8b7a12c52e52a06408e9231647839ddb4665e8ae

Test Plan:
- Merge the PR and rerun open source checker internally.

Differential Revision: [D35444649](https://our.internmc.facebook.com/intern/diff/D35444649)