### PR TITLE
Use nvidia channel for linux cuda build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,19 +31,8 @@ outlined on that page and do not file a public issue.
 
 ### Install Dependencies
 
+Same as in [README](README.md) with the exception of:
 ```
-conda install pytorch torchvision torchtext cudatoolkit=11.3 -c pytorch-nightly
-
-# For CPU-only install
-conda install pytorch torchvision torchtext cpuonly -c pytorch-nightly
-```
-
-### Install TorchMultimodal
-
-```
-git clone --recursive https://github.com/facebookresearch/multimodal.git torchmultimodal
-cd torchmultimodal
-pip install -r requirements.txt
 python setup.py develop
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ TorchMultimodal requires Python >= 3.8. The library can be installed with or wit
 
 1. Create conda environment
     ```
-    conda create -n torch-multimodal
+    conda create -n torch-multimodal python=<python_version>
     conda activate torch-multimodal
     ```
 2. Install pytorch, torchvision, and torchtext. See [PyTorch documentation](https://pytorch.org/get-started/locally/).
-   ```
-   conda install pytorch torchvision torchtext cudatoolkit=11.3 -c pytorch-nightly
+   For now we only support Linux platform.
+    ```
+    conda install pytorch torchvision torchtext cudatoolkit=11.3 -c pytorch-nightly -c nvidia
 
-   # For CPU-only install
-   conda install pytorch torchvision torchtext cpuonly -c pytorch-nightly
-   ```
+    # For CPU-only install
+    conda install pytorch torchvision torchtext cpuonly -c pytorch-nightly
+    ```
 3. Download and install TorchMultimodal and remaining requirements.
     ```
     git clone --recursive https://github.com/facebookresearch/multimodal.git torchmultimodal


### PR DESCRIPTION
Summary:
Fix build instruction in `README.md` to specify `nvidia` as the channel for Linux cudatoolkit.
Ref. this issue for context: 
- https://github.com/pytorch/pytorch/issues/59517#issuecomment-864178104
- (meta internal only): [comment](https://fb.workplace.com/groups/1405155842844877/posts/5763447240349027/?comment_id=5765281670165584&reply_comment_id=5765321913494893)

Test plan:
```
$ conda create -n torchmmcuda39 python=3.9
$ conda activate torchmmcuda39
$ conda install pytorch torchvision torchtext cudatoolkit=11.3 -c pytorch-nightly -c nvidia

Preparing transaction: done
Verifying transaction: done
Executing transaction: \ By downloading and using the CUDA Toolkit conda packages, you accept the terms and conditions of the CUDA End User License Agreement (EULA): https://docs.nvidia.com/cuda/eula/index.html
```
