### PR TITLE
Dedup instructions of ISSUE TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,6 @@ Error messages and stack traces are also helpful.
 ## System Info
 Please copy and paste the output from
 [environment collection script](https://raw.githubusercontent.com/pytorch/pytorch/master/torch/utils/collect_env.py)
-and fill out the checklist below.
 
 You can get the script and run it with:
 ```
@@ -25,6 +24,8 @@ wget https://raw.githubusercontent.com/pytorch/pytorch/master/torch/utils/collec
 # For security purposes, please check the contents of collect_env.py before running it.
 python collect_env.py
 ```
+
+OR manually fill out the checklist below.
 
 - How you installed TorchMultimodal (conda, pip, source):
 - Build command you used (if compiling from source):


### PR DESCRIPTION
Summary:
Deduplicate instructions in [ISSUE TEMPALTE](`.github/ISSUE_TEMPLATE.md`)

Test plan:
This option alone will output everything to be filled manually (as the alternative "OR" option)

```
wget https://raw.githubusercontent.com/pytorch/pytorch/master/torch/utils/collect_env.py
# For security purposes, please check the contents of collect_env.py before running it.
python collect_env.py
```
