### PR TITLE
[TorchMultimodal][refactor] Support type checking with mypy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,24 @@ flake8 `git diff main --name-only`
 ufmt format `git diff main --name-only`
 ```
 
+### Type checking
+
+TorchMultimodal uses mypy for type checking. You can install mypy with the command
+
+```
+python3 -m pip install mypy
+```
+
+To perform type checking:
+
+```
+# on the whole repo
+mypy
+
+## only on modified files
+mypy `git diff main --name-only`
+```
+
 
 ### Unit Tests
 Please add unit tests for adding a new feature or a bug-fix. To run a specific test:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,25 @@
+[mypy]
+
+files = torchmultimodal
+
+warn_unused_configs = True
+warn_redundant_casts = True
+show_error_codes = True
+show_column_numbers = True
+check_untyped_defs = True
+pretty = True
+strict_optional = False
+allow_redefinition = True
+namespace_packages = True
+install_types = True
+
+exclude = models/flava.py|modules/losses/flava.py
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-torchtext.*]
+ignore_missing_imports = True
+
+[mypy-torchvision.*]
+ignore_missing_imports = True

--- a/torchmultimodal/architectures/clip.py
+++ b/torchmultimodal/architectures/clip.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Dict
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -40,7 +42,7 @@ class CLIPArchitecture(nn.Module):
         self,
         image: torch.Tensor,
         text: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> Dict[str, torch.Tensor]:
 
         img_embeddings = self.vision_encoder(image)
         text_embeddings = self.text_encoder(text)

--- a/torchmultimodal/models/cnn_lstm.py
+++ b/torchmultimodal/models/cnn_lstm.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional
+from typing import List
 
 from torch import nn
 from torchmultimodal.architectures.late_fusion import LateFusionArchitecture
@@ -12,6 +12,11 @@ from torchmultimodal.modules.encoders.cnn_encoder import CNNEncoder
 from torchmultimodal.modules.encoders.lstm_encoder import LSTMEncoder
 from torchmultimodal.modules.fusions.concat_fusion import ConcatFusionModule
 from torchmultimodal.modules.layers.mlp import MLP
+
+
+DEFAULT_CNN_INPUT_DIMS = [3, 64, 128, 128, 64, 64]
+DEFAULT_CNN_OUTPUT_DIMS = DEFAULT_CNN_INPUT_DIMS[1:] + [10]
+DEFAULT_CNN_KERNEL_SIZES = [7, 5, 5, 5, 5, 1]
 
 
 def cnn_lstm_classifier(
@@ -23,12 +28,12 @@ def cnn_lstm_classifier(
     lstm_bidirectional: bool = True,
     lstm_batch_first: bool = True,
     # parameters for encoding the image
-    cnn_input_dims: Optional[List[int]] = None,
-    cnn_output_dims: Optional[List[int]] = None,
-    cnn_kernel_sizes: Optional[List[int]] = None,
+    cnn_input_dims: List[int] = DEFAULT_CNN_INPUT_DIMS,
+    cnn_output_dims: List[int] = DEFAULT_CNN_OUTPUT_DIMS,
+    cnn_kernel_sizes: List[int] = DEFAULT_CNN_KERNEL_SIZES,
     # parameters for the classifier
-    classifier_in_dim: Optional[int] = 450,
-    num_classes: Optional[int] = 2,
+    classifier_in_dim: int = 450,
+    num_classes: int = 2,
 ) -> LateFusionArchitecture:
     """
     A simple example to show the composability in TorchMultimodal, and how to
@@ -64,19 +69,6 @@ def cnn_lstm_classifier(
             Should equal output_dim for CNN + output_dim for LSTM (flattened).
         num_classes (int): Number of classes predicted by classifier.
     """
-
-    # Do some basic sanity checking on the input parameters
-    check_all = [cnn_input_dims, cnn_output_dims, cnn_kernel_sizes]
-    none_count = check_all.count(None)
-    if none_count > 0:
-        assert none_count == 3, (
-            "Please either pass all CNN parameters or "
-            + "none of them. If you don't pass any, expected image input "
-            + "is of size 224 x 224."
-        )
-        cnn_input_dims = (3, 64, 128, 128, 64, 64)
-        cnn_output_dims = cnn_input_dims[1:] + (10,)
-        cnn_kernel_sizes = [7, 5, 5, 5, 5, 1]
 
     image_encoder = CNNEncoder(
         input_dims=cnn_input_dims,

--- a/torchmultimodal/modules/encoders/clip_resnet_encoder.py
+++ b/torchmultimodal/modules/encoders/clip_resnet_encoder.py
@@ -145,7 +145,7 @@ class ResNetForCLIP(nn.Module):
 
     def __init__(
         self,
-        layers: Tuple[int] = (3, 4, 6, 3),
+        layers: Tuple[int, int, int, int] = (3, 4, 6, 3),
         output_dim: int = 512,
         heads: int = 1024,
         input_resolution: int = 224,

--- a/torchmultimodal/modules/encoders/clip_text_encoder.py
+++ b/torchmultimodal/modules/encoders/clip_text_encoder.py
@@ -87,7 +87,7 @@ class CLIPTextEncoder(nn.Module):
 
     def build_attention_mask(self):
         mask = torch.full((self.context_length, self.context_length), True).triu(1)
-        return mask.to(dtype=bool)
+        return mask.to(device=None, dtype=torch.bool)
 
     def forward(self, text: torch.Tensor) -> torch.Tensor:
         embeddings = self.encoder(text, attn_mask=self.build_attention_mask())

--- a/torchmultimodal/modules/encoders/cnn_encoder.py
+++ b/torchmultimodal/modules/encoders/cnn_encoder.py
@@ -32,7 +32,7 @@ class CNNEncoder(nn.Module):
         self, input_dims: List[int], output_dims: List[int], kernel_sizes: List[int]
     ):
         super().__init__()
-        conv_layers = []
+        conv_layers: List[nn.Module] = []
         assert len(input_dims) == len(output_dims) and len(output_dims) == len(
             kernel_sizes
         ), "input_dims, output_dims, and kernel_sizes should all have the same length"

--- a/torchmultimodal/modules/encoders/mil_encoder.py
+++ b/torchmultimodal/modules/encoders/mil_encoder.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 import torch
 from torch import nn, Tensor
@@ -59,13 +59,15 @@ class MILEncoder(nn.Module):
         channel_to_encoder_dim = {}
         for i in range(len(partition_sizes)):
             channel_to_encoder_dim[self.get_channel_name(i)] = shared_encoder_dim
+        deepset_fusion_cls = (
+            DeepsetFusionWithTransformer
+            if isinstance(pooling_function, nn.TransformerEncoder)
+            else DeepsetFusionModule
+        )
 
-        if isinstance(pooling_function, nn.TransformerEncoder):
-            deepset_fusion_cls = DeepsetFusionWithTransformer
-        else:
-            deepset_fusion_cls = DeepsetFusionModule
-
-        self.deepset_fusion = deepset_fusion_cls(
+        self.deepset_fusion: Union[
+            DeepsetFusionWithTransformer, DeepsetFusionModule
+        ] = deepset_fusion_cls(
             channel_to_encoder_dim=channel_to_encoder_dim,
             mlp=mlp,
             pooling_function=pooling_function,

--- a/torchmultimodal/modules/fusions/deepset_fusion.py
+++ b/torchmultimodal/modules/fusions/deepset_fusion.py
@@ -66,6 +66,7 @@ class DeepsetFusionModule(nn.Module):
                 {channel: nn.Identity() for channel in channel_to_encoder_dim}
             )
         if self.apply_attention:
+            self.attention: nn.Module
             if attention_dim is None:
                 # default value as per older implementation
                 attention_dim = projection_dim // 2

--- a/torchmultimodal/modules/losses/contrastive_loss_with_temperature.py
+++ b/torchmultimodal/modules/losses/contrastive_loss_with_temperature.py
@@ -6,7 +6,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -134,6 +134,9 @@ def contrastive_loss_with_temperature(
     )
 
 
+DEFAULT_LOGIT_SCALE = nn.Parameter(math.log(1 / 0.07) * torch.ones([]))
+
+
 class ContrastiveLossWithTemperature(nn.Module):
     """Contrastive loss with a temperature parameter, as used in CLIP and FLAVA.
     CLIP: https://arxiv.org/pdf/2103.00020.pdf
@@ -164,10 +167,8 @@ class ContrastiveLossWithTemperature(nn.Module):
                 all_gather to all workers (versus just the local worker).
     """
 
-    def __init__(self, logit_scale: float = None):
+    def __init__(self, logit_scale: Union[float, nn.Parameter] = DEFAULT_LOGIT_SCALE):
         super().__init__()
-        if logit_scale is None:
-            logit_scale = math.log(1 / 0.07)
 
         # If already initialized, set to what was passed
         if isinstance(logit_scale, nn.Parameter):

--- a/torchmultimodal/transforms/text_transforms.py
+++ b/torchmultimodal/transforms/text_transforms.py
@@ -30,7 +30,7 @@ class StrToIntTransform:
         self, l: Union[List[str], List[List[str]]]
     ) -> Union[List[int], List[List[int]]]:
         if isinstance(l[0], str):
-            return [int(x) for x in l]
+            return [int(x) for x in l]  # type: ignore
         if isinstance(l[0], List) and isinstance(l[0][0], str):
             return [[int(x) for x in ll] for ll in l]
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Summary:
Adding support for type checking using mypy.
Cleaning up a bunch of files to fix existing type check errors.
Note that for now we are only type checking non-FLAVA code inside torchmultimodal.
Also adding some instructions to CONTRIBUTING.md

Test plan:
```
mypy
Success: no issues found in 28 source files
```

```
python3 -m pytest -vv
...
42 passed, 2 skipped, 26 warnings in 22.87s
```