### PR TITLE
Run lint gha only on prs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,8 +1,5 @@
 name: lint
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Summary:
The action fails on push due to the "no-commit-to-main" hook https://github.com/facebookresearch/multimodal/actions/runs/2117843598. So enabling it only for pull requests which should be sufficient for now

Test plan:
will check the run on merge

