### PR TITLE
[cleanup] Follow-ups from initial mypy PR

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,7 @@ allow_redefinition = True
 namespace_packages = True
 install_types = True
 
+# TODO (T116951827): Remove after fixing FLAVA type check errors
 exclude = models/flava.py|modules/losses/flava.py
 
 [mypy-PIL.*]

--- a/torchmultimodal/modules/encoders/clip_text_encoder.py
+++ b/torchmultimodal/modules/encoders/clip_text_encoder.py
@@ -61,7 +61,7 @@ class CLIPTextEncoder(nn.Module):
         if use_clip_init:
             self.initialize_parameters()
 
-    def initialize_parameters(self):
+    def initialize_parameters(self) -> None:
         # Initialize token and positional embeddings
         nn.init.normal_(
             self.encoder.token_embedding.weight, std=self.TOKEN_EMBEDDING_INIT_STD
@@ -85,7 +85,7 @@ class CLIPTextEncoder(nn.Module):
         # Initialize projection
         nn.init.normal_(self.projection.weight, std=self.width ** -0.5)
 
-    def build_attention_mask(self):
+    def build_attention_mask(self) -> torch.Tensor:
         mask = torch.full((self.context_length, self.context_length), True).triu(1)
         return mask.to(device=None, dtype=torch.bool)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #25

Summary:
A couple follow-ups from #22:
- Add TODO for type checking FLAVA code
- Add a couple other type hints missed by mypy in clip_text_encoder (due to https://mypy.readthedocs.io/en/stable/common_issues.html#no-errors-reported-for-obviously-wrong-code)
- Some changes to weighted_embedding_encoder to silence mypy errors

Test plan:
```
$ python -m pytest -v
...
====================================================================================== short test summary info =======================================================================================
FAILED test/transforms/test_clip_transform.py::TestCLIPTransform::test_clip_multi_transform - requests.exceptions.MissingSchema: Invalid URL '/data/home/ebs/torchmultimodal/torchmultimodal/test/a...
FAILED test/transforms/test_clip_transform.py::TestCLIPTransform::test_clip_single_transform - requests.exceptions.MissingSchema: Invalid URL '/data/home/ebs/torchmultimodal/torchmultimodal/test/...
================================================================== 2 failed, 48 passed, 3 skipped, 26 warnings in 76.48s (0:01:16) ===================================================================

```
(Failures are pre-existing and will be fixed with a separate commit)

```
$ mypy
Success: no issues found in 29 source files
```

Differential Revision: [D35617460](https://our.internmc.facebook.com/intern/diff/D35617460)