### PR TITLE
Read dependencies from requirement files for setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ outlined on that page and do not file a public issue.
 
 Same as in [README](README.md) with the exception of:
 ```
-python setup.py develop
+pip install -e ".[dev]"
 ```
 
 ## Development Process
@@ -54,7 +54,7 @@ We actively welcome your pull requests.
 TorchMultimodal uses pre-commit hooks to ensure style consistency and prevent common mistakes. Enable it by:
 
 ```
-pip install pre-commit && pre-commit install
+pre-commit install
 ```
 
 After this pre-commit hooks will be run before every commit.
@@ -63,7 +63,6 @@ Ideally, flake and ufmt should be run via pre-commit hooks.
 But if for some reason you want to run them separately follow this:
 
 ```
-pip install flake8==4.0.1 ufmt==1.3.0 black==21.4b2 usort==0.6.4
 flake8 (examples|test|torchmultimodal)
 ufmt format (examples|test|torchmultimodal)
 ```
@@ -71,19 +70,14 @@ ufmt format (examples|test|torchmultimodal)
 Alternatively, you can run on only those files you have modified, e.g.
 
 ```
+pip install flake8==4.0.1 ufmt==1.3.0 black==21.4b2 usort==0.6.4
 flake8 `git diff main --name-only`
 ufmt format `git diff main --name-only`
 ```
 
 ### Type checking
 
-TorchMultimodal uses mypy for type checking. You can install mypy with the command
-
-```
-python3 -m pip install mypy
-```
-
-To perform type checking:
+TorchMultimodal uses mypy for type checking. To perform type checking:
 
 ```
 # on the whole repo

--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ TorchMultimodal requires Python >= 3.8. The library can be installed with or wit
     ```
     git clone --recursive https://github.com/facebookresearch/multimodal.git torchmultimodal
     cd torchmultimodal
-    pip install -r requirements.txt
 
-    python setup.py install
+    pip install -e .
     ```
     For developers please follow the [development installation](https://github.com/facebookresearch/multimodal/blob/main/CONTRIBUTING.md#development-installation).
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+mypy
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 packaging
-pytest

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,13 @@ def fetch_long_description():
     return readme
 
 
+def read_requirements(file):
+    with open(file) as f:
+        reqs = f.read()
+
+    return reqs.strip().split("\n")
+
+
 DISTNAME = "torchmultimodal"
 DESCRIPTION = "Multimodal modeling in PyTorch"
 LONG_DESCRIPTION = fetch_long_description()
@@ -43,12 +50,15 @@ AUTHOR_EMAIL = "kartikayk@fb.com"
 # Need to exclude folders in test as well so as they don't create an extra package
 EXCLUDES = ("examples", "test")
 
+
 if __name__ == "__main__":
+
     setup(
         name=DISTNAME,
         include_package_data=True,
         packages=find_packages(exclude=EXCLUDES),
         python_requires=">=3.8",
+        install_requires=read_requirements("requirements.txt"),
         version=_get_version(),
         description=DESCRIPTION,
         long_description=LONG_DESCRIPTION,
@@ -62,4 +72,5 @@ if __name__ == "__main__":
             "License :: OSI Approved :: BSD License",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
         ],
+        extras_require={"dev": read_requirements("dev-requirements.txt")},
     )


### PR DESCRIPTION
Summary:
- setup.py now has install_requires which reads from requirements.txt
- extra requires for dev specific dependencies coming from dev-requirements.txt (moved pytest to it)
- pytorch and torch* dependencies still need to be installed manually since we depend on nightly builds and there seems to be no principled way of getting them in setup.py

Test plan:
 - In a fresh conda env, followed Readme and tried to import flava. Checked no dev dependencies were installed in the env
 - In another env, followed updated contribution guide and ran pytest. Verified mypy, pytest and precommit were installed

