### PR TITLE
Fix mypy type checker error

### DIFF
--- a/torchmultimodal/modules/encoders/mil_encoder.py
+++ b/torchmultimodal/modules/encoders/mil_encoder.py
@@ -83,7 +83,6 @@ class MILEncoder(nn.Module):
         return f"mil_{id}"
 
     def forward(self, x: Tensor) -> Tensor:
-        partitioned_input = {}
         idx = 0
         input_size = x.size(dim=1)
         if input_size != sum(self.partition_sizes):


### PR DESCRIPTION
Summary:
`mil_encoder.py` was breaking mypy type checking in OSS

https://github.com/facebookresearch/multimodal/runs/6311395953?check_suite_focus=true

```
Found 2 errors in 1 file (checked 31 source files)
annotation for "partitioned_input" (hint:
"partitioned_input: Dict[<type>, <type>] = ...")  [var-annotated]
            partitioned_input = {}
            ^
torchmultimodal/modules/encoders/mil_encoder.py:93:29: error: Incompatible
types in assignment (expression has type "List[Tensor]", variable has type
"Dict[Any, Any]")  [assignment]
            partitioned_input = torch.split(x, self.partition_sizes, dim=1...
```

Differential Revision: D36185850

