### PR TITLE
Refactored tensor equal assertion test into common utility

### DIFF
--- a/test/architectures/test_late_fusion.py
+++ b/test/architectures/test_late_fusion.py
@@ -7,7 +7,7 @@
 import unittest
 
 import torch
-from test.test_utils import assert_tensors_equal
+from test.test_utils import assert_expected
 from torchmultimodal.architectures.late_fusion import LateFusionArchitecture
 from torchmultimodal.modules.fusions.concat_fusion import ConcatFusionModule
 
@@ -45,7 +45,7 @@ class TestLateFusion(unittest.TestCase):
             [[1, 0, 0.25, 0.75, 3, 1, 0.8, 0.9], [0, 1, 0.6, 0.4, 0.7, 2, 0.6, 0]]
         )
 
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_script(self):
         modalities = {
@@ -65,7 +65,7 @@ class TestLateFusion(unittest.TestCase):
         scripted_late_fusion = torch.jit.script(self.late_fusion)
         actual = scripted_late_fusion(modalities)
         expected = torch.Tensor([[7, 0, 0.65, 8, 9, 0.8], [88, 5, 0.3, 0.74, 2, 0]])
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_missing_key_in_modalities(self):
         modalities = {

--- a/test/architectures/test_late_fusion.py
+++ b/test/architectures/test_late_fusion.py
@@ -7,6 +7,7 @@
 import unittest
 
 import torch
+from test.test_utils import assert_tensors_equal
 from torchmultimodal.architectures.late_fusion import LateFusionArchitecture
 from torchmultimodal.modules.fusions.concat_fusion import ConcatFusionModule
 
@@ -44,11 +45,7 @@ class TestLateFusion(unittest.TestCase):
             [[1, 0, 0.25, 0.75, 3, 1, 0.8, 0.9], [0, 1, 0.6, 0.4, 0.7, 2, 0.6, 0]]
         )
 
-        torch.testing.assert_close(
-            actual,
-            expected,
-            msg=f"actual: {actual}, expected: {expected}",
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_script(self):
         modalities = {
@@ -68,11 +65,7 @@ class TestLateFusion(unittest.TestCase):
         scripted_late_fusion = torch.jit.script(self.late_fusion)
         actual = scripted_late_fusion(modalities)
         expected = torch.Tensor([[7, 0, 0.65, 8, 9, 0.8], [88, 5, 0.3, 0.74, 2, 0]])
-        torch.testing.assert_close(
-            actual,
-            expected,
-            msg=f"actual: {actual}, expected: {expected}",
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_missing_key_in_modalities(self):
         modalities = {

--- a/test/modules/encoders/test_weighted_embedding_encoder.py
+++ b/test/modules/encoders/test_weighted_embedding_encoder.py
@@ -8,6 +8,7 @@ import unittest
 from copy import deepcopy
 
 import torch
+from test.test_utils import assert_tensors_equal
 from torch import nn
 from torchmultimodal.modules.encoders.weighted_embedding_encoder import (
     WeightedEmbeddingEncoder,
@@ -45,9 +46,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [1.4, 1.4],
             ]
         )
-        torch.testing.assert_close(
-            actual, expected, msg=f"Actual: {actual}, expected: {expected}"
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_forward_mean_pooling(self):
         input = torch.Tensor(
@@ -66,9 +65,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [0.7, 0.7],
             ]
         )
-        torch.testing.assert_close(
-            actual, expected, msg=f"Actual: {actual}, expected: {expected}"
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_forward_max_pooling(self):
         input = torch.Tensor(
@@ -87,9 +84,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [0.8, 0.8],
             ]
         )
-        torch.testing.assert_close(
-            actual, expected, msg=f"Actual: {actual}, expected: {expected}"
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_forward_hash_no_padding(self):
         input = torch.Tensor(
@@ -108,9 +103,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [0.8, 0.8],
             ]
         )
-        torch.testing.assert_close(
-            actual, expected, msg=f"Actual: {actual}, expected: {expected}"
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_forward_hash_zero_padding(self):
         input = torch.Tensor(
@@ -131,9 +124,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [1.4, 0.8],
             ]
         )
-        torch.testing.assert_close(
-            actual, expected, msg=f"Actual: {actual}, expected: {expected}"
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_forward_hash_invalid_padding(self):
         embedding = deepcopy(self.embedding)
@@ -160,6 +151,4 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [0.7, 0.7],
             ]
         )
-        torch.testing.assert_close(
-            actual, expected, msg=f"Actual: {actual}, expected: {expected}"
-        )
+        assert_tensors_equal(actual, expected)

--- a/test/modules/encoders/test_weighted_embedding_encoder.py
+++ b/test/modules/encoders/test_weighted_embedding_encoder.py
@@ -8,7 +8,7 @@ import unittest
 from copy import deepcopy
 
 import torch
-from test.test_utils import assert_tensors_equal
+from test.test_utils import assert_expected
 from torch import nn
 from torchmultimodal.modules.encoders.weighted_embedding_encoder import (
     WeightedEmbeddingEncoder,
@@ -46,7 +46,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [1.4, 1.4],
             ]
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_forward_mean_pooling(self):
         input = torch.Tensor(
@@ -65,7 +65,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [0.7, 0.7],
             ]
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_forward_max_pooling(self):
         input = torch.Tensor(
@@ -84,7 +84,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [0.8, 0.8],
             ]
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_forward_hash_no_padding(self):
         input = torch.Tensor(
@@ -103,7 +103,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [0.8, 0.8],
             ]
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_forward_hash_zero_padding(self):
         input = torch.Tensor(
@@ -124,7 +124,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [1.4, 0.8],
             ]
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_forward_hash_invalid_padding(self):
         embedding = deepcopy(self.embedding)
@@ -151,4 +151,4 @@ class TestEmbeddingEncoder(unittest.TestCase):
                 [0.7, 0.7],
             ]
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)

--- a/test/modules/layers/test_mlp.py
+++ b/test/modules/layers/test_mlp.py
@@ -8,7 +8,7 @@ import unittest
 from functools import partial
 
 import torch
-from test.test_utils import set_rng_seed
+from test.test_utils import set_rng_seed, assert_tensors_equal
 from torchmultimodal.modules.layers.mlp import MLP
 
 
@@ -36,11 +36,7 @@ class TestMLP(unittest.TestCase):
                 [1.710142, -0.744562, -0.199996],
             ],
         )
-        torch.testing.assert_close(
-            actual,
-            expected,
-            msg=f"actual: {actual}, expected: {expected}",
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_pass_hidden_dims(self):
         mlp = MLP(
@@ -55,11 +51,7 @@ class TestMLP(unittest.TestCase):
                 [0.395047, 1.070629, -0.927500],
             ],
         )
-        torch.testing.assert_close(
-            actual,
-            expected,
-            msg=f"actual: {actual}, expected: {expected}",
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_activation_and_normalization(self):
         activation = torch.nn.LeakyReLU
@@ -80,11 +72,7 @@ class TestMLP(unittest.TestCase):
                 [0.348458, 0.898804, -0.778149],
             ]
         )
-        torch.testing.assert_close(
-            actual,
-            expected,
-            msg=f"actual: {actual}, expected: {expected}",
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_torchscript(self):
         mlp = MLP(in_dim=self.in_dim, out_dim=self.out_dim)

--- a/test/modules/layers/test_mlp.py
+++ b/test/modules/layers/test_mlp.py
@@ -8,7 +8,7 @@ import unittest
 from functools import partial
 
 import torch
-from test.test_utils import set_rng_seed, assert_tensors_equal
+from test.test_utils import set_rng_seed, assert_expected
 from torchmultimodal.modules.layers.mlp import MLP
 
 
@@ -36,7 +36,7 @@ class TestMLP(unittest.TestCase):
                 [1.710142, -0.744562, -0.199996],
             ],
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_pass_hidden_dims(self):
         mlp = MLP(
@@ -51,7 +51,7 @@ class TestMLP(unittest.TestCase):
                 [0.395047, 1.070629, -0.927500],
             ],
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_activation_and_normalization(self):
         activation = torch.nn.LeakyReLU
@@ -72,7 +72,7 @@ class TestMLP(unittest.TestCase):
                 [0.348458, 0.898804, -0.778149],
             ]
         )
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_torchscript(self):
         mlp = MLP(in_dim=self.in_dim, out_dim=self.out_dim)

--- a/test/modules/layers/test_quantisation.py
+++ b/test/modules/layers/test_quantisation.py
@@ -7,6 +7,7 @@
 import unittest
 
 import torch
+from test.test_utils import assert_tensors_equal
 from torch import nn
 from torchmultimodal.modules.layers.quantisation import Quantisation
 
@@ -63,11 +64,7 @@ class TestQuantisation(unittest.TestCase):
             ]
         )
 
-        torch.testing.assert_close(
-            actual,
-            expected,
-            msg=f"actual: {actual}, expected: {expected}",
-        )
+        assert_tensors_equal(actual, expected)
 
     def test_preprocess(self):
         encoded_flat, permuted_shape = self.vq._preprocess(self.encoded)

--- a/test/modules/layers/test_quantisation.py
+++ b/test/modules/layers/test_quantisation.py
@@ -7,7 +7,7 @@
 import unittest
 
 import torch
-from test.test_utils import assert_tensors_equal
+from test.test_utils import assert_expected
 from torch import nn
 from torchmultimodal.modules.layers.quantisation import Quantisation
 
@@ -64,7 +64,7 @@ class TestQuantisation(unittest.TestCase):
             ]
         )
 
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)
 
     def test_preprocess(self):
         encoded_flat, permuted_shape = self.vq._preprocess(self.encoded)

--- a/test/modules/losses/test_commitment.py
+++ b/test/modules/losses/test_commitment.py
@@ -7,7 +7,7 @@
 import unittest
 
 import torch
-from test.test_utils import assert_tensors_equal
+from test.test_utils import assert_expected
 from torchmultimodal.modules.losses.vqvae import CommitmentLoss
 
 
@@ -27,4 +27,4 @@ class TestCommitment(unittest.TestCase):
         actual = loss.item()
         expected = 2.0
 
-        assert_tensors_equal(actual, expected)
+        assert_expected(actual, expected)

--- a/test/modules/losses/test_commitment.py
+++ b/test/modules/losses/test_commitment.py
@@ -7,6 +7,7 @@
 import unittest
 
 import torch
+from test.test_utils import assert_tensors_equal
 from torchmultimodal.modules.losses.vqvae import CommitmentLoss
 
 
@@ -26,8 +27,4 @@ class TestCommitment(unittest.TestCase):
         actual = loss.item()
         expected = 2.0
 
-        torch.testing.assert_close(
-            actual,
-            expected,
-            msg=f"actual: {actual}, expected: {expected}",
-        )
+        assert_tensors_equal(actual, expected)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -71,9 +71,13 @@ def get_asset_path(file_name: str) -> str:
     return str(_ASSET_DIR.joinpath(file_name))
 
 
-def assert_tensors_equal(actual: Tensor, expected: Tensor):
+def assert_expected(
+    actual: Tensor, expected: Tensor, rtol: float = None, atol: float = None
+):
     torch.testing.assert_close(
         actual,
         expected,
+        rtol=rtol,
+        atol=atol,
         msg=f"actual: {actual}, expected: {expected}",
     )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import torch
 import torch.distributed as dist
+from torch import Tensor
 
 
 def gpu_test(gpu_count: int = 1):
@@ -68,3 +69,11 @@ _ASSET_DIR = (Path(__file__).parent / "assets").resolve()
 def get_asset_path(file_name: str) -> str:
     """Get the path to the file under assets directory."""
     return str(_ASSET_DIR.joinpath(file_name))
+
+
+def assert_tensors_equal(actual: Tensor, expected: Tensor):
+    torch.testing.assert_close(
+        actual,
+        expected,
+        msg=f"actual: {actual}, expected: {expected}",
+    )

--- a/test/transforms/test_clip_transform.py
+++ b/test/transforms/test_clip_transform.py
@@ -7,7 +7,7 @@
 import unittest
 
 import torch
-from test.test_utils import get_asset_path, set_rng_seed, assert_tensors_equal
+from test.test_utils import get_asset_path, set_rng_seed, assert_expected
 from torchmultimodal.transforms.clip_transform import CLIPTransform
 from torchvision.transforms import ToPILImage
 
@@ -54,14 +54,14 @@ class TestCLIPTransform(unittest.TestCase):
 
         actual_image_size = transformed_image.size()
         expected_image_size = torch.Size([1, 3, 224, 224])
-        assert_tensors_equal(actual_image_size, expected_image_size)
+        assert_expected(actual_image_size, expected_image_size)
 
         actual_text = transformed_text[0]
         expected_text = torch.tensor(
             self.text1_tokens + [0] * (self.context_length - self.text1_token_len),
             dtype=torch.long,
         )
-        assert_tensors_equal(actual_text, expected_text)
+        assert_expected(actual_text, expected_text)
 
     def test_clip_multi_transform(self):
         images = [self.image1] * 5 + [self.image2] * 2
@@ -72,11 +72,11 @@ class TestCLIPTransform(unittest.TestCase):
 
         actual_images_size = transformed_images.size()
         expected_images_size = torch.Size([7, 3, 224, 224])
-        assert_tensors_equal(actual_images_size, expected_images_size)
+        assert_expected(actual_images_size, expected_images_size)
 
         actual_texts_size = transformed_texts.size()
         expected_texts_size = torch.Size([7, self.context_length])
-        assert_tensors_equal(actual_texts_size, expected_texts_size)
+        assert_expected(actual_texts_size, expected_texts_size)
 
         # Check encoding of long text
         actual_long_text = transformed_texts[-1]
@@ -84,9 +84,9 @@ class TestCLIPTransform(unittest.TestCase):
             [self.bos_token] + self.text1_tokens[1:-1] * 20 + [self.eos_token],
             dtype=torch.long,
         )[: self.context_length]
-        assert_tensors_equal(actual_long_text, expected_long_text)
+        assert_expected(actual_long_text, expected_long_text)
 
         # Check zero padding for short texts
         actual_zero_pad_val = transformed_texts[:-1, self.text1_token_len :].max()
         expected_zero_pad_val = torch.tensor(0)
-        assert_tensors_equal(actual_zero_pad_val, expected_zero_pad_val)
+        assert_expected(actual_zero_pad_val, expected_zero_pad_val)

--- a/test/transforms/test_clip_transform.py
+++ b/test/transforms/test_clip_transform.py
@@ -7,7 +7,7 @@
 import unittest
 
 import torch
-from test.test_utils import get_asset_path, set_rng_seed
+from test.test_utils import get_asset_path, set_rng_seed, assert_tensors_equal
 from torchmultimodal.transforms.clip_transform import CLIPTransform
 from torchvision.transforms import ToPILImage
 
@@ -54,22 +54,14 @@ class TestCLIPTransform(unittest.TestCase):
 
         actual_image_size = transformed_image.size()
         expected_image_size = torch.Size([1, 3, 224, 224])
-        torch.testing.assert_close(
-            actual_image_size,
-            expected_image_size,
-            msg=f"actual: {actual_image_size}, expected: {expected_image_size}",
-        )
+        assert_tensors_equal(actual_image_size, expected_image_size)
 
         actual_text = transformed_text[0]
         expected_text = torch.tensor(
             self.text1_tokens + [0] * (self.context_length - self.text1_token_len),
             dtype=torch.long,
         )
-        torch.testing.assert_close(
-            actual_text,
-            expected_text,
-            msg=f"actual: {actual_text}, expected: {expected_text}",
-        )
+        assert_tensors_equal(actual_text, expected_text)
 
     def test_clip_multi_transform(self):
         images = [self.image1] * 5 + [self.image2] * 2
@@ -80,19 +72,11 @@ class TestCLIPTransform(unittest.TestCase):
 
         actual_images_size = transformed_images.size()
         expected_images_size = torch.Size([7, 3, 224, 224])
-        torch.testing.assert_close(
-            actual_images_size,
-            expected_images_size,
-            msg=f"actual: {actual_images_size}, expected: {expected_images_size}",
-        )
+        assert_tensors_equal(actual_images_size, expected_images_size)
 
         actual_texts_size = transformed_texts.size()
         expected_texts_size = torch.Size([7, self.context_length])
-        torch.testing.assert_close(
-            actual_texts_size,
-            expected_texts_size,
-            msg=f"actual: {actual_texts_size}, expected: {expected_texts_size}",
-        )
+        assert_tensors_equal(actual_texts_size, expected_texts_size)
 
         # Check encoding of long text
         actual_long_text = transformed_texts[-1]
@@ -100,17 +84,9 @@ class TestCLIPTransform(unittest.TestCase):
             [self.bos_token] + self.text1_tokens[1:-1] * 20 + [self.eos_token],
             dtype=torch.long,
         )[: self.context_length]
-        torch.testing.assert_close(
-            actual_long_text,
-            expected_long_text,
-            msg=f"actual: {actual_long_text}, expected: {expected_long_text}",
-        )
+        assert_tensors_equal(actual_long_text, expected_long_text)
 
         # Check zero padding for short texts
         actual_zero_pad_val = transformed_texts[:-1, self.text1_token_len :].max()
         expected_zero_pad_val = torch.tensor(0)
-        torch.testing.assert_close(
-            actual_zero_pad_val,
-            expected_zero_pad_val,
-            msg=f"actual: {actual_zero_pad_val}, expected: {expected_zero_pad_val}",
-        )
+        assert_tensors_equal(actual_zero_pad_val, expected_zero_pad_val)

--- a/test/transforms/test_text_transforms.py
+++ b/test/transforms/test_text_transforms.py
@@ -7,6 +7,7 @@
 import unittest
 
 import torch
+from test.test_utils import assert_expected
 from torchmultimodal.transforms.text_transforms import PadTransform, StrToIntTransform
 
 
@@ -22,40 +23,24 @@ class TestTextTransforms(unittest.TestCase):
 
         padded_1d_tensor_actual = pad_long(self.input_1d_tensor)
         padded_1d_tensor_expected = torch.cat([torch.ones(5), torch.zeros(2)])
-        torch.testing.assert_close(
-            padded_1d_tensor_actual,
-            padded_1d_tensor_expected,
-            msg=f"actual: {padded_1d_tensor_actual}, expected: {padded_1d_tensor_expected}",
-        )
+        assert_expected(padded_1d_tensor_actual, padded_1d_tensor_expected)
 
         padded_2d_tensor_actual = pad_long(self.input_2d_tensor)
         padded_2d_tensor_expected = torch.cat(
             [torch.ones(8, 5), torch.zeros(8, 2)], axis=-1
         )
-        torch.testing.assert_close(
-            padded_2d_tensor_actual,
-            padded_2d_tensor_expected,
-            msg=f"actual: {padded_2d_tensor_actual}, expected: {padded_2d_tensor_expected}",
-        )
+        assert_expected(padded_2d_tensor_actual, padded_2d_tensor_expected)
 
     def test_pad_transform_short(self):
         pad_short = PadTransform(max_length=3)
 
         padded_1d_tensor_actual = pad_short(self.input_1d_tensor)
         padded_1d_tensor_expected = self.input_1d_tensor
-        torch.testing.assert_close(
-            padded_1d_tensor_actual,
-            padded_1d_tensor_expected,
-            msg=f"actual: {padded_1d_tensor_actual}, expected: {padded_1d_tensor_expected}",
-        )
+        assert_expected(padded_1d_tensor_actual, padded_1d_tensor_expected)
 
         padded_2d_tensor_actual = pad_short(self.input_2d_tensor)
         padded_2d_tensor_expected = self.input_2d_tensor
-        torch.testing.assert_close(
-            padded_2d_tensor_actual,
-            padded_2d_tensor_expected,
-            msg=f"actual: {padded_2d_tensor_actual}, expected: {padded_2d_tensor_expected}",
-        )
+        assert_expected(padded_2d_tensor_actual, padded_2d_tensor_expected)
 
     def test_clip_multi_transform(self):
         str_to_int = StrToIntTransform()

--- a/torchmultimodal/utils/test_utils.py
+++ b/torchmultimodal/utils/test_utils.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/utils/test_utils.py
+++ b/torchmultimodal/utils/test_utils.py
@@ -1,5 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
The use of `torch.testing.assert_close(actual, expected)` was a prevalent pattern throughout the codebase, each having to create its own assertion failure message. This was consolidated into a common utility function in `test/test_utils.py` such that this assertion is only defined in a single location and all current/future unit tests simply have to import this to test if two tensors are equal without having to write the same assertion failure message.

Test plan:
Since this impacts potentially all unit tests, I ran the entire test suite with `pytest -vv`.
