### PR TITLE
Fixes to make FLAVA pretraining / finetuning run

### DIFF
--- a/examples/flava/README.md
+++ b/examples/flava/README.md
@@ -52,7 +52,7 @@ python train.py config=configs/pretraining/debug.yaml training.lightning.max_ste
 Similarly, let's say you want to use a pretrained model for your pretraining/finetuning.
 
 ```
-python train.py configs=configs/pretraining/debug.yaml model.pretrained_model_key=flava_full
+python train.py config=configs/pretraining/debug.yaml model.pretrained_model_key=flava_full
 ```
 
 ### Full Pretraining
@@ -64,7 +64,7 @@ python train.py configs=configs/pretraining/debug.yaml model.pretrained_model_ke
 Similarly to pretraining, finetuning can be launched by following command:
 
 ```
-python finetune.py configs=configs/finetuning/qnli.yaml model.pretrained_model_key=flava_full
+python finetune.py config=configs/finetuning/qnli.yaml model.pretrained_model_key=flava_full
 ```
 
 ### Linear Probe

--- a/examples/flava/configs/finetuning/qnli.yaml
+++ b/examples/flava/configs/finetuning/qnli.yaml
@@ -34,3 +34,5 @@ datasets:
         rename_columns:
           - ["question", "sentence1"]
           - ["sentence", "sentence2"]
+    datamodule_extra_kwargs:
+      text_columns: ["sentence1", "sentence2"]

--- a/examples/flava/configs/pretraining/debug.yaml
+++ b/examples/flava/configs/pretraining/debug.yaml
@@ -25,7 +25,7 @@ datasets:
     _target_: definitions.TrainingSingleDatasetInfo
     train:
       - _target_: definitions.HFDatasetInfo
-        key: aps/imagenet2012
+        key: imagenet-1k
         subset: default
         extra_kwargs:
           data_dir: ${oc.env:IMAGENET_TAR}
@@ -35,6 +35,8 @@ datasets:
       - _target_: definitions.HFDatasetInfo
         key: wikitext
         subset: wikitext-103-raw-v1
+    datamodule_extra_kwargs:
+      text_columns: ["text"]
   vl:
     _target_: definitions.TrainingSingleDatasetInfo
     train:

--- a/examples/flava/data/transforms.py
+++ b/examples/flava/data/transforms.py
@@ -41,12 +41,15 @@ def encode_text(text, tokenizer, *args, **kwargs):
     return tokenizer(text, *args, **kwargs)
 
 
-def encode_text_batch(batch, tokenizer, text_columns=None, *args, **kwargs):
-    if text_columns is None:
-        text_columns = ["sentence1", "sentence2"]
+def encode_text_batch(
+    batch, tokenizer, text_columns, return_batch=False, *args, **kwargs
+):
     texts = [batch[column] for column in text_columns]
-    batch.update(tokenizer(*texts, *args, **kwargs))
-    return batch
+    tokens = tokenizer(*texts, *args, **kwargs)
+    if return_batch:
+        batch.update(tokens)
+        return batch
+    return tokens
 
 
 def transform_image_dict(transform, image_dict, *args, **kwargs):

--- a/examples/flava/definitions.py
+++ b/examples/flava/definitions.py
@@ -50,6 +50,7 @@ class TrainingSingleDatasetInfo:
     batch_size: Optional[int] = None
     num_workers: Optional[int] = None
     allow_uneven_batches: bool = False
+    datamodule_extra_kwargs: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -71,7 +72,7 @@ class TrainingArguments:
     learning_rate: float = 0.0002
     adam_eps: float = 1e-08
     adam_weight_decay: float = 0.01
-    adam_betas: Tuple[int, int] = field(default_factory=lambda: (0.9, 0.999))
+    adam_betas: Tuple[float, float] = field(default_factory=lambda: (0.9, 0.999))
     warmup_steps: int = 2000
 
 

--- a/examples/flava/train.py
+++ b/examples/flava/train.py
@@ -20,6 +20,8 @@ def main():
         seed_everything(config.training.seed, workers=True)
 
     datamodules = []
+
+    # also needed for the imagenet eval callback
     imagenet_datamodule = ImageDataModule(
         **build_datamodule_kwargs(config.datasets.image, config.training)
     )

--- a/examples/flava/utils.py
+++ b/examples/flava/utils.py
@@ -4,19 +4,23 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from definitions import DatasetInfo, FLAVAArguments, TrainingArguments
+from definitions import FLAVAArguments, TrainingArguments, TrainingSingleDatasetInfo
 from hydra.utils import instantiate
 from omegaconf import OmegaConf
 
 
-def build_datamodule_kwargs(dm_config: DatasetInfo, training_config: TrainingArguments):
-    return {
+def build_datamodule_kwargs(
+    dm_config: TrainingSingleDatasetInfo, training_config: TrainingArguments
+):
+    kwargs = {
         "train_infos": dm_config.train,
         "val_infos": dm_config.val,
         "batch_size": dm_config.batch_size or training_config.batch_size,
         "num_workers": dm_config.num_workers or training_config.num_workers,
         "allow_uneven_batches": dm_config.allow_uneven_batches,
     }
+    kwargs.update(dm_config.datamodule_extra_kwargs)
+    return kwargs
 
 
 def build_config():


### PR DESCRIPTION
Summary:
Some fixes to make both pretraining and finetuning work:
- change adam beta type to float
- Pass in text column names from configs to the encode_batch_text since its different for different datasets
- Allow encode_batch_text to return batch or just tokenized text

Test plan:
Manual sanity checks:
python train.py config=configs/pretraining/debug.yaml training.lightning.gpus=0 training.lightning.accelerator=cpu

  | Name  | Type                | Params
----------------------------------------------
0 | model | FLAVAForPreTraining | 357 M 
----------------------------------------------
357 M     Trainable params
0         Non-trainable params
357 M     Total params
1,430.581 Total estimated model params size (MB)
Epoch 0: : 50it [03:43,  4.47s/it, loss=15.2, v_num=17, train/losses/mmm_text_loss=10.40, train/losses/mmm_image_loss=9.120, train/losses/itm_loss=0.140, train/losses/global_Epoch 0: : 100it [06:57,  4.17s/it, loss=15.2, v_num=17, train/losses/mmm_text_loss=10.40, train/losses/mmm_image_loss=9.120, train/losses/itm_loss=0.140, train/losses/globalEpoch 0: : 100it [06:57,  4.17s/it, loss=14.2, v_num=17, train/losses/mmm_text_loss=9.950, train/losses/mmm_image_loss=9.140, train/losses/itm_loss=0.465, train/losses/global_contrastive_loss=2.090, train/losses/mim_loss=9.150, train/losses/mlm_loss=9.880]

python finetune.py config=configs/finetuning/qnli.yaml model.pretrained_model_key=flava_full training.lightning.gpus=0 training.lightning.accelerator=cpu


  | Name  | Type                   | Params
-------------------------------------------------
0 | model | FLAVAForClassification | 240 M 
-------------------------------------------------
240 M     Trainable params
0         Non-trainable params
240 M     Total params
963.069   Total estimated model params size (MB)
Epoch 0:   1%|▊                                                                 | 50/3787 [10:08<12:37:52, 12.17s/it, loss=0.715, v_num=18, train/losses/classification=0.721

--------------------------
pytest test/models/test_flava.py -vv

test/models/test_flava.py::TestFLAVA::test_forward_classification PASSED                                                                                               [ 50%]
test/models/test_flava.py::TestFLAVA::test_forward_pretraining PASSED