### PR TITLE
Re-enable flava tests for open source

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 mypy
 pre-commit
+DALL-E==0.1

--- a/test/models/test_flava.py
+++ b/test/models/test_flava.py
@@ -20,7 +20,6 @@ class TestFLAVA(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(1234)
 
-    @unittest.skip("Pending fix network connection, see (T116682215)")
     @torch.no_grad()
     def test_forward_classification(self):
         flava = flava_model_for_classification(NUM_CLASSES)
@@ -41,7 +40,6 @@ class TestFLAVA(unittest.TestCase):
         output = flava(image, text, "text", labels)
         self.assertAlmostEqual(output.loss.item(), 0.7074, places=4)
 
-    @unittest.skip("Pending fix network connection, see (T116682215)")
     @torch.no_grad()
     def test_forward_pretraining(self):
         flava = flava_model_for_pretraining()


### PR DESCRIPTION
As title. Added DallE to the dev requirements since FLAVA model depends on it but feels odd to force everyone to install it.
Differential Revision: D36495395

