### PR TITLE
Introducing exponential moving average updates to embedding in Quantization layer

### DIFF
--- a/test/modules/layers/test_quantization.py
+++ b/test/modules/layers/test_quantization.py
@@ -40,9 +40,10 @@ class TestQuantization(unittest.TestCase):
         self.vq = Quantization(
             num_embeddings=self.num_embeddings, embedding_dim=self.embedding_dim
         )
-        self.vq.embedding = nn.Embedding.from_pretrained(self.embedding_weights)
 
     def test_quantized_output(self):
+        self.vq.embedding = nn.Embedding.from_pretrained(self.embedding_weights)
+        self.vq._is_embedding_init = True
         output = self.vq(self.encoded)
         _, actual_quantized_flat, actual_codebook_indices, actual_quantized = output
         # This is shape (2,5,3)

--- a/test/modules/layers/test_quantization.py
+++ b/test/modules/layers/test_quantization.py
@@ -40,7 +40,7 @@ class TestQuantization(unittest.TestCase):
         self.vq = Quantization(
             num_embeddings=self.num_embeddings,
             embedding_dim=self.embedding_dim,
-            decay=0.5,
+            decay=0.3,
         )
 
     def test_quantized_output(self):
@@ -128,15 +128,15 @@ class TestQuantization(unittest.TestCase):
         expected_code_usage = torch.ones(self.num_embeddings)
         assert_expected(actual_code_usage, expected_code_usage)
 
-    def test_ema_update(self):
+    def test_ema_update_embedding(self):
         _ = self.vq(self.encoded)
 
         actual_weight = self.vq.embedding
         expected_weight = torch.Tensor(
             [
-                [1.0000, -1.3333, 0.0000, 1.6667, 0.0000],
+                [0.7647, -1.4118, 0.0000, 1.5882, 0.0000],
                 [2.0000, 1.0000, 0.0000, 1.0000, 1.0000],
-                [-0.3333, 1.3333, -0.6667, 1.3333, -1.3333],
+                [-0.4118, 1.4118, -0.5882, 1.1765, -1.4118],
                 [1.0000, 0.0000, -1.0000, -1.0000, 1.0000],
             ]
         )
@@ -145,14 +145,14 @@ class TestQuantization(unittest.TestCase):
         actual_code_avg = self.vq.code_avg
         expected_code_avg = torch.Tensor(
             [
-                [1.5000, -2.0000, 0.0000, 2.5000, 0.0000],
+                [1.3000, -2.4000, 0.0000, 2.7000, 0.0000],
                 [2.0000, 1.0000, 0.0000, 1.0000, 1.0000],
-                [-0.5000, 2.0000, -1.0000, 2.0000, -2.0000],
+                [-0.7000, 2.4000, -1.0000, 2.0000, -2.4000],
                 [1.0000, 0.0000, -1.0000, -1.0000, 1.0000],
             ]
         )
         assert_expected(actual_code_avg, expected_code_avg, rtol=0.0, atol=1e-4)
 
         actual_code_usage = self.vq.code_usage
-        expected_code_usage = torch.Tensor([1.5000, 1.0000, 1.5000, 1.0000])
+        expected_code_usage = torch.Tensor([1.7000, 1.0000, 1.7000, 1.0000])
         assert_expected(actual_code_usage, expected_code_usage, rtol=0.0, atol=1e-4)

--- a/test/modules/layers/test_quantization.py
+++ b/test/modules/layers/test_quantization.py
@@ -171,7 +171,7 @@ class TestQuantization(unittest.TestCase):
             self.vq.parameters()
         ), "buffer variables incorrectly assigned as params"
 
-    def test_tile(self):
+    def test_init_embedding_smaller_encoded(self):
         encoded_small = self.encoded[:1, :, :2]
         out = self.vq(encoded_small)
         encoded_small_flat = out.encoded_flat

--- a/torchmultimodal/modules/layers/quantization.py
+++ b/torchmultimodal/modules/layers/quantization.py
@@ -52,9 +52,10 @@ class Quantization(nn.Module):
         # Embedding weights and parameters for EMA update will be registered to buffer, as they
         # will not be updated by the optimizer but are still model parameters.
         # code_usage and code_avg correspond with N and m, respectively, from Oord et al.
-        self.register_buffer("embedding", torch.randn(num_embeddings, embedding_dim))
+        randn_init_embedding = torch.randn(num_embeddings, embedding_dim)
+        self.register_buffer("embedding", randn_init_embedding.clone())
         self.register_buffer("code_usage", torch.zeros(num_embeddings))
-        self.register_buffer("code_avg", self.embedding.clone())
+        self.register_buffer("code_avg", randn_init_embedding.clone())
 
         self.embedding_dim = embedding_dim
         self.num_embeddings = num_embeddings

--- a/torchmultimodal/modules/layers/quantization.py
+++ b/torchmultimodal/modules/layers/quantization.py
@@ -8,7 +8,6 @@ from typing import NamedTuple, Tuple
 
 import torch
 from torch import nn, Size, Tensor
-from torch.nn import functional as F
 
 
 class QuantizationOutput(NamedTuple):
@@ -76,7 +75,7 @@ class Quantization(nn.Module):
                 self.num_embeddings + num_encoder_vectors - 1
             ) // num_encoder_vectors
             # Add a small amount of noise to repeated vectors
-            std = 0.01 / torch.sqrt(num_channels)
+            std = 0.01 / torch.sqrt(torch.tensor(num_channels))
             x = x.repeat(num_repeats, 1)
             x = x + torch.randn_like(x) * std
         return x
@@ -167,7 +166,7 @@ class Quantization(nn.Module):
         codebook_indices = torch.argmin(distances, dim=1)
 
         # Quantize
-        quantized_flat = F.embedding(codebook_indices, self.embedding)
+        quantized_flat = self.embedding[codebook_indices]
 
         # Use exponential moving average to update the embedding instead of a codebook loss,
         # as suggested by Oord et al. 2017 and Razavi et al. 2019.

--- a/torchmultimodal/modules/layers/quantization.py
+++ b/torchmultimodal/modules/layers/quantization.py
@@ -113,7 +113,7 @@ class Quantization(nn.Module):
         # Convert indices to one hot encoding
         codebook_onehot = nn.functional.one_hot(
             codebook_indices, num_classes=self.num_embeddings
-        )
+        ).type(torch.float)
         # Count how often each embedding vector was looked up
         codebook_selection_count = torch.sum(codebook_onehot, 0)
         # Update usage value for each embedding vector
@@ -134,7 +134,9 @@ class Quantization(nn.Module):
         self._code_avg = (
             self._code_avg * self._decay + (1 - self._decay) * encoded_per_codebook
         )
-        self.embedding.weight = self._code_avg / self._code_usage.unsqueeze(1)
+        self.embedding.weight = nn.Parameter(
+            self._code_avg / self._code_usage.unsqueeze(1)
+        )
 
     def _quantize(self, encoded_flat: Tensor) -> Tuple[Tensor, Tensor]:
         # Calculate distances from each encoder, E(x), output vector to each embedding vector, e, ||E(x) - e||^2


### PR DESCRIPTION
### Summary
VQVAE implements a codebook of embedding vectors to tokenize an input. It does this by encouraging the encoder output to be close to the embedding vectors during training. The embedding vectors learn this via exponential moving average (EMA) updates that coerce them to become an average of the encoder output. This method of optimization is found to converge faster than MSE codebook loss, as described in the original paper.

This PR introduces EMA updates to the Quantization layer with some refactoring of old unit tests. Additionally, it initializes the embedding weights with random latents from the encoder similar to VideoGPT and Jukebox. In a future PR, codebook restarts will be implemented to alleviate codebook collapse.

### Test plan
Added unit tests for embedding initialization and EMA updates in `test_quantization.py`
