### PR TITLE
[Test] Add code coverage CI and integration into pull requests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit =
+    *test/*
+    *examples/*
+
+[report]
+omit =
+    *test/*
+    *examples/*

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 # Suggested config from pytorch that we can adapat
-select = B,C,E,F,P,T4,W,B9
+select = B,C,E,F,N,P,T4,W,B9
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
@@ -17,3 +17,6 @@ exclude =
     ./scripts,
     ./venv,
     *.pyi
+    .pre-commit-config.yaml
+    *.md
+    .flake8

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -27,9 +27,11 @@ jobs:
           conda activate test
           conda install pytorch torchvision torchtext cpuonly -c pytorch-nightly
           pip install -e ".[dev]"
-      - name: Run unit tests
+      - name: Run unit tests with coverage
         shell: bash -l {0}
         run: |
           set -eux
           conda activate test
-          pytest test -vv
+          pytest --cov=. --cov-report xml test -vv
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+exclude: 'build'
+
 default_language_version:
     python: python3
 
@@ -27,13 +29,15 @@ repos:
     rev: 4.0.1
     hooks:
     -   id: flake8
-        args:
-        - --config=.flake8
+        additional_dependencies:
+          - flake8-bugbear == 22.4.25
+          - pep8-naming == 0.12.1
+        args: ['- --config=.flake8']
 
 -   repo: https://github.com/omnilib/ufmt
     rev: v1.3.0
     hooks:
-    - id: ufmt
-      additional_dependencies:
-        - black == 21.4b2
-        - usort == 0.6.4
+    -   id: ufmt
+        additional_dependencies:
+          - black == 22.3.0
+          - usort == 1.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ Ideally, flake and ufmt should be run via pre-commit hooks.
 But if for some reason you want to run them separately follow this:
 
 ```
+pip install -r requirements-lint.txt
 flake8 (examples|test|torchmultimodal)
 ufmt format (examples|test|torchmultimodal)
 ```
@@ -70,7 +71,6 @@ ufmt format (examples|test|torchmultimodal)
 Alternatively, you can run on only those files you have modified, e.g.
 
 ```
-pip install flake8==4.0.1 ufmt==1.3.0 black==21.4b2 usort==1.0.2
 flake8 `git diff main --name-only`
 ufmt format `git diff main --name-only`
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-cov
 mypy
 pre-commit
 DALL-E==0.1

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,6 @@
+flake8==4.0.1
+flake8-bugbear==22.4.25
+pep8-naming==0.12.1
+ufmt==1.3.0
+black==22.3.0
+usort==1.0.2


### PR DESCRIPTION
Summary:
- Add code coverage to unit test Github workflow
- Generate coverage report in pull request

Test plan:
- Test locally:
```
pip install -r dev-requirements.txt
pytest --cov=. test -vv

---------- coverage: platform darwin, python 3.8.13-final-0 ----------
Name                                                                  Stmts   Miss  Cover
-----------------------------------------------------------------------------------------
torchmultimodal/__init__.py                                               2      0   100%
torchmultimodal/architectures/__init__.py                                 0      0   100%
torchmultimodal/architectures/clip.py                                    15      0   100%
torchmultimodal/architectures/late_fusion.py                             16      0   100%
torchmultimodal/architectures/two_tower.py                               38      2    95%
torchmultimodal/datasets/__init__.py                                      0      0   100%
torchmultimodal/models/__init__.py                                        0      0   100%
torchmultimodal/models/clip.py                                           45     45     0%
torchmultimodal/models/cnn_lstm.py                                       16      0   100%
torchmultimodal/models/flava.py                                         492     57    88%
torchmultimodal/modules/__init__.py                                       0      0   100%
torchmultimodal/modules/encoders/clip_resnet_encoder.py                 105      0   100%
torchmultimodal/modules/encoders/clip_text_encoder.py                    36      0   100%
torchmultimodal/modules/encoders/cnn_encoder.py                          18      0   100%
torchmultimodal/modules/encoders/embedding_encoder.py                    22      0   100%
torchmultimodal/modules/encoders/lstm_encoder.py                         13      0   100%
torchmultimodal/modules/encoders/mil_encoder.py                          27      0   100%
torchmultimodal/modules/encoders/weighted_embedding_encoder.py           28      0   100%
torchmultimodal/modules/fusions/attention_fusion.py                      25      0   100%
torchmultimodal/modules/fusions/concat_fusion.py                         12      1    92%
torchmultimodal/modules/fusions/deepset_fusion.py                        67      2    97%
torchmultimodal/modules/layers/mlp.py                                    22      0   100%
torchmultimodal/modules/layers/normalizations.py                          7      0   100%
torchmultimodal/modules/layers/quantization.py                           40      0   100%
torchmultimodal/modules/losses/contrastive_loss_with_temperature.py      53     12    77%
torchmultimodal/modules/losses/flava.py                                 194      8    96%
torchmultimodal/modules/losses/vqvae.py                                  10      0   100%
torchmultimodal/transforms/__init__.py                                    0      0   100%
torchmultimodal/transforms/clip_transform.py                             34      2    94%
torchmultimodal/transforms/text_transforms.py                            21      1    95%
torchmultimodal/utils/__init__.py                                         0      0   100%
torchmultimodal/utils/common.py                                          37     10    73%
torchmultimodal/utils/file_io.py                                         10      3    70%
-----------------------------------------------------------------------------------------
TOTAL                                                                  1405    143    90%
```
- Test in CI and pull request UI: Shows a dialogue from Codecov about coverage statistic related to this diff. Note that the warning "No coverage uploaded for pull reqest base" is expected as Codecov has never run on the `main` branch (see [more](https://docs.codecov.com/docs/error-reference?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=facebookresearch#missing-head-commit)).
