### PR TITLE
[Lint] Merge flake8 dependencies into dev-requirements.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Ideally, flake and ufmt should be run via pre-commit hooks.
 But if for some reason you want to run them separately follow this:
 
 ```
-pip install -r requirements-lint.txt
+pip install -r dev-requirements.txt
 flake8 (examples|test|torchmultimodal)
 ufmt format (examples|test|torchmultimodal)
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,9 @@ pytest-cov
 mypy
 pre-commit
 DALL-E==0.1
+flake8==4.0.1
+flake8-bugbear==22.4.25
+pep8-naming==0.12.1
+ufmt==1.3.0
+black==22.3.0
+usort==1.0.2

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,6 +1,0 @@
-flake8==4.0.1
-flake8-bugbear==22.4.25
-pep8-naming==0.12.1
-ufmt==1.3.0
-black==22.3.0
-usort==1.0.2


### PR DESCRIPTION
Summary:
This is a follow-up PR to address comments in https://github.com/facebookresearch/multimodal/pull/50

Test plan:
```
pip install -r dev-requirements.txt
flake8 --version
4.0.1 (flake8-bugbear: 22.4.25, mccabe: 0.6.1, naming: 0.12.1, pycodestyle: 2.8.0, pyflakes: 2.4.0)
```
