### PR TITLE
Renamed quantization to codebook

### DIFF
--- a/test/modules/layers/test_codebook.py
+++ b/test/modules/layers/test_codebook.py
@@ -8,12 +8,12 @@ import unittest
 
 import torch
 from test.test_utils import assert_expected, set_rng_seed
-from torchmultimodal.modules.layers.quantization import Quantization
+from torchmultimodal.modules.layers.codebook import Codebook
 
 
-class TestQuantization(unittest.TestCase):
+class TestCodebook(unittest.TestCase):
     """
-    Test the Quantization class
+    Test the Codebook class
     """
 
     def setUp(self):
@@ -38,7 +38,7 @@ class TestQuantization(unittest.TestCase):
             [[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]
         )
 
-        self.vq = Quantization(
+        self.vq = Codebook(
             num_embeddings=self.num_embeddings,
             embedding_dim=self.embedding_dim,
             decay=0.3,

--- a/torchmultimodal/modules/layers/codebook.py
+++ b/torchmultimodal/modules/layers/codebook.py
@@ -10,15 +10,15 @@ import torch
 from torch import nn, Size, Tensor
 
 
-class QuantizationOutput(NamedTuple):
+class CodebookOutput(NamedTuple):
     encoded_flat: Tensor  # the flattened encoder output
     quantized_flat: Tensor  # the chosen nearest embeddings
     codebook_indices: Tensor  # indices of the chosen embeddings
     quantized: Tensor  # the chosen embeddings (unflattened)
 
 
-class Quantization(nn.Module):
-    """Quantization provides an embedding layer that takes in the output of an encoder
+class Codebook(nn.Module):
+    """Codebook provides an embedding layer that takes in the output of an encoder
     and performs a nearest-neighbor lookup in the embedding space.
 
     Vector quantization was introduced in Oord et al. 2017 (https://arxiv.org/pdf/1711.00937.pdf)
@@ -179,7 +179,7 @@ class Quantization(nn.Module):
 
         return quantized_flat, codebook_indices
 
-    def forward(self, z: Tensor) -> QuantizationOutput:
+    def forward(self, z: Tensor) -> CodebookOutput:
         # First check if embedding is initialized correctly
         if not self._is_embedding_init and self.training:
             encoded_flat, permuted_shape = self._init_embedding_and_preprocess(z)
@@ -193,6 +193,4 @@ class Quantization(nn.Module):
         # Reshape back to original dims
         quantized = self._postprocess(quantized_flat, permuted_shape)
 
-        return QuantizationOutput(
-            encoded_flat, quantized_flat, codebook_indices, quantized
-        )
+        return CodebookOutput(encoded_flat, quantized_flat, codebook_indices, quantized)


### PR DESCRIPTION
Summary:
Quantization is an overloaded term and can also mean model quantization. TorchVision uses quantization in reference to model quantization (https://github.com/pytorch/vision/tree/main/torchvision/models/quantization) and it can get confusing if we name a layer Quantization. Changed the name to Codebook to be more in-line with naming by FLAVA, MUGEN, OpenAI.

Test plan:
`pytest -vv` to make sure nothing broke
