### PR TITLE
Include conv layers with same padding from MUGEN

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@ max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
 ignore =
-    E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,
+    E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,N812
     # shebang has extra meaning in fbcode lints, so I think it's not worth trying
     # to line this up with executable bit
     EXE001,

--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,10 @@
 [flake8]
-# Suggested config from pytorch that we can adapat
+# Suggested config from pytorch that we can adapt
 select = B,C,E,F,N,P,T4,W,B9
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
+# N812 ignored because import torch.nn.functional as F is PyTorch convention
 ignore =
     E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,N812
     # shebang has extra meaning in fbcode lints, so I think it's not worth trying

--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,7 @@ max-line-length = 120
 # E501 is not flexible enough, we're using B950 instead
 # N812 ignored because import torch.nn.functional as F is PyTorch convention
 ignore =
-    E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,N812
+    E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,N812,
     # shebang has extra meaning in fbcode lints, so I think it's not worth trying
     # to line this up with executable bit
     EXE001,

--- a/test/modules/layers/test_conv.py
+++ b/test/modules/layers/test_conv.py
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# import unittest
+
+# import torch
+# from test.test_utils import assert_expected

--- a/test/modules/layers/test_conv.py
+++ b/test/modules/layers/test_conv.py
@@ -86,9 +86,11 @@ class TestSamePadConv3d(unittest.TestCase):
     def test_calculate_same_padding_output(self):
         for i, (inp, kernel, stride) in enumerate(self.test_cases):
             pad_actual = calculate_same_padding(kernel, stride, inp.shape[2:])
-            assert (
-                pad_actual == self.pad_expected[i]
-            ), f"padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}"
+            self.assertEqual(
+                pad_actual,
+                self.pad_expected[i],
+                f"padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}",
+            )
 
     def test_samepadconv3d_forward(self):
         for i, (inp, kernel, stride) in enumerate(self.test_cases):

--- a/test/modules/layers/test_conv.py
+++ b/test/modules/layers/test_conv.py
@@ -4,7 +4,125 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# import unittest
+import unittest
+from itertools import product
 
-# import torch
-# from test.test_utils import assert_expected
+import torch
+from test.test_utils import assert_expected
+from torchmultimodal.modules.layers.conv import (
+    calculate_same_padding,
+    calculate_transpose_padding,
+    SamePadConv3d,
+    SamePadConvTranspose3d,
+)
+
+
+class TestSamePadConv3d(unittest.TestCase):
+    """
+    Test the SamePadConv3d class and associated helpers
+    """
+
+    def setUp(self):
+        inputs = [torch.ones(1, 1, 8, 8, 8), torch.ones(1, 1, 7, 7, 7)]
+        kernels = [(4, 4, 4), (3, 3, 3)]
+        strides = [(2, 2, 2), (3, 3, 3)]
+        self.test_cases = list(product(*[inputs, kernels, strides]))
+        self.pad_expected = [
+            (1, 1, 1, 1, 1, 1),
+            (1, 1, 1, 1, 1, 1),
+            (1, 0, 1, 0, 1, 0),
+            (1, 0, 1, 0, 1, 0),
+            (2, 1, 2, 1, 2, 1),
+            (2, 1, 2, 1, 2, 1),
+            (1, 1, 1, 1, 1, 1),
+            (1, 1, 1, 1, 1, 1),
+        ]
+        self.out_shape_conv_expected = [
+            torch.tensor([1, 1, 4, 4, 4]),
+            torch.tensor([1, 1, 3, 3, 3]),
+            torch.tensor([1, 1, 4, 4, 4]),
+            torch.tensor([1, 1, 3, 3, 3]),
+            torch.tensor([1, 1, 4, 4, 4]),
+            torch.tensor([1, 1, 3, 3, 3]),
+            torch.tensor([1, 1, 4, 4, 4]),
+            torch.tensor([1, 1, 3, 3, 3]),
+        ]
+        self.out_shape_convtranspose_expected = [
+            torch.tensor([1, 1, 16, 16, 16]),
+            torch.tensor([1, 1, 24, 24, 24]),
+            torch.tensor([1, 1, 16, 16, 16]),
+            torch.tensor([1, 1, 24, 24, 24]),
+            torch.tensor([1, 1, 14, 14, 14]),
+            torch.tensor([1, 1, 21, 21, 21]),
+            torch.tensor([1, 1, 14, 14, 14]),
+            torch.tensor([1, 1, 21, 21, 21]),
+        ]
+        self.transpose_pad_expected = [
+            (3, 3, 3),
+            (4, 4, 4),
+            (2, 2, 2),
+            (2, 2, 2),
+            (4, 4, 4),
+            (5, 5, 5),
+            (3, 3, 3),
+            (3, 3, 3),
+        ]
+        self.output_pad_expected = [
+            (0, 0, 0),
+            (1, 1, 1),
+            (1, 1, 1),
+            (1, 1, 1),
+            (0, 0, 0),
+            (0, 0, 0),
+            (1, 1, 1),
+            (0, 0, 0),
+        ]
+
+    def test_calculate_same_padding_assert(self):
+        with self.assertRaises(ValueError):
+            _ = calculate_same_padding((3, 3), (2, 2, 2), (5, 5))
+            _ = calculate_same_padding(3, (2, 2), (5, 5, 5))
+
+    def test_calculate_same_padding_output(self):
+        for i, (inp, kernel, stride) in enumerate(self.test_cases):
+            pad_actual = calculate_same_padding(kernel, stride, inp.shape[2:])
+            assert (
+                pad_actual == self.pad_expected[i]
+            ), f"padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}"
+
+    def test_samepadconv3d_forward(self):
+        for i, (inp, kernel, stride) in enumerate(self.test_cases):
+            conv = SamePadConv3d(1, 1, kernel, stride, padding=0)
+            out = conv(inp)
+            out_shape_conv_actual = torch.tensor(out.shape)
+            assert_expected(out_shape_conv_actual, self.out_shape_conv_expected[i])
+
+    def test_calculate_transpose_padding_assert(self):
+        with self.assertRaises(ValueError):
+            _ = calculate_transpose_padding((3, 3), (2, 2, 2), (5, 5))
+            _ = calculate_transpose_padding(3, (2, 2), (5, 5, 5))
+        with self.assertRaises(ValueError):
+            _ = calculate_transpose_padding((3, 3), (2, 2), (5, 5), (1, 0, 1))
+            _ = calculate_transpose_padding(3, 2, (5, 5, 5), (1, 1, 1, 1, 1, 1, 1))
+
+    def test_calculate_transpose_padding_output(self):
+        for i, (inp, kernel, stride) in enumerate(self.test_cases):
+            pad = calculate_same_padding(kernel, stride, inp.shape[2:])
+            transpose_pad_actual, output_pad_actual = calculate_transpose_padding(
+                kernel, stride, inp.shape[2:], pad
+            )
+            assert (
+                transpose_pad_actual == self.transpose_pad_expected[i]
+            ), f"transpose padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}"
+            assert (
+                output_pad_actual == self.output_pad_expected[i]
+            ), f"output padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}"
+
+    def test_samepadconvtranspose3d_forward(self):
+        for i, (inp, kernel, stride) in enumerate(self.test_cases):
+            conv = SamePadConvTranspose3d(1, 1, kernel, stride)
+            out = conv(inp)
+            out_shape_convtranspose_actual = torch.tensor(out.shape)
+            assert_expected(
+                out_shape_convtranspose_actual, self.out_shape_convtranspose_expected[i]
+            )

--- a/test/modules/layers/test_conv.py
+++ b/test/modules/layers/test_conv.py
@@ -111,12 +111,16 @@ class TestSamePadConv3d(unittest.TestCase):
             transpose_pad_actual, output_pad_actual = calculate_transpose_padding(
                 kernel, stride, inp.shape[2:], pad
             )
-            assert (
-                transpose_pad_actual == self.transpose_pad_expected[i]
-            ), f"transpose padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}"
-            assert (
-                output_pad_actual == self.output_pad_expected[i]
-            ), f"output padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}"
+            self.assertEqual(
+                transpose_pad_actual,
+                self.transpose_pad_expected[i],
+                f"transpose padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}",
+            )
+            self.assertEqual(
+                output_pad_actual,
+                self.output_pad_expected[i],
+                f"output padding incorrect for shape {inp.shape}, kernel {kernel}, stride {stride}",
+            )
 
     def test_samepadconvtranspose3d_forward(self):
         for i, (inp, kernel, stride) in enumerate(self.test_cases):

--- a/torchmultimodal/modules/layers/codebook.py
+++ b/torchmultimodal/modules/layers/codebook.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import NamedTuple, Tuple
+from typing import NamedTuple, Tuple, Union
 
 import torch
 from torch import nn, Size, Tensor
@@ -48,7 +48,7 @@ class Codebook(nn.Module):
         embedding_dim: int,
         decay: float = 0.99,
         epsilon: float = 1e-7,
-    ):
+    ) -> None:
         super().__init__()
         # Embedding weights and parameters for EMA update will be registered to buffer, as they
         # will not be updated by the optimizer but are still model parameters.
@@ -68,7 +68,7 @@ class Codebook(nn.Module):
         # Flag to track if we need to initialize embedding with encoder output
         self._is_embedding_init = False
 
-    def _tile(self, x):
+    def _tile(self, x) -> Tensor:
         # Repeat encoder vectors in cases where the encoder output does not have enough vectors
         # to initialize the codebook on first forward pass
         num_encoder_vectors, num_channels = x.shape
@@ -98,7 +98,9 @@ class Codebook(nn.Module):
 
         return encoded_flat, permuted_shape
 
-    def _postprocess(self, quantized_flat: Tensor, permuted_shape: Size) -> Tensor:
+    def _postprocess(
+        self, quantized_flat: Tensor, permuted_shape: Union[Size, Tuple]
+    ) -> Tensor:
         # Rearrange back to batch x channel x n dims
         num_dims = len(permuted_shape)
         quantized_permuted = quantized_flat.view(permuted_shape)

--- a/torchmultimodal/modules/layers/conv.py
+++ b/torchmultimodal/modules/layers/conv.py
@@ -13,6 +13,23 @@ from torch.nn.modules.utils import _ntuple, _triple
 
 
 class SamePadConv3d(nn.Module):
+    """Performs a same padded convolution on a 3D input. This maintains input shape with unit
+    stride, and divides input dims by non-unit stride.
+
+    Code taken from VideoGPT
+    https://github.com/wilson1yan/VideoGPT/blob/master/videogpt/vqvae.py
+
+    Args:
+        in_channels (int): number of channels in input, same as Conv3d
+        out_channels (int): number of channels for output, same as Conv3d
+        kernel_size (int or Tuple): size of convolutional filter, same as Conv3d
+        stride (int or Tuple): stride for convolution, same as Conv3d
+        bias (bool): use a bias for convolutional layer or not, same as Conv3d
+
+    Inputs:
+        x (Tensor): input of dims B x C x D1 x D2 x D3
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -38,6 +55,7 @@ class SamePadConv3d(nn.Module):
         )
 
     def forward(self, x: Tensor) -> Tensor:
+        # Calculate padding needed based on input shape only once to reduce run time
         if self.pad_input is None:
             self.pad_input = calculate_same_padding(
                 self.kernel_size, self.stride, x.shape[2:]
@@ -46,6 +64,23 @@ class SamePadConv3d(nn.Module):
 
 
 class SamePadConvTranspose3d(nn.Module):
+    """Performs a same padded transposed convolution on a 3D input. This maintains input shape
+    with unit stride, and multiplies input dims by non-unit stride.
+
+    Code taken from VideoGPT
+    https://github.com/wilson1yan/VideoGPT/blob/master/videogpt/vqvae.py
+
+    Args:
+        in_channels (int): number of channels in input, same as Conv3d
+        out_channels (int): number of channels for output, same as Conv3d
+        kernel_size (int or Tuple): size of convolutional filter, same as Conv3d
+        stride (int or Tuple): stride for convolution, same as Conv3d
+        bias (bool): use a bias for convolutional layer or not, same as Conv3d
+
+    Inputs:
+        x (Tensor): input of dims B x C x D1 x D2 x D3
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -66,6 +101,7 @@ class SamePadConvTranspose3d(nn.Module):
         )
 
     def forward(self, x) -> Tensor:
+        # Calculate padding needed based on input shape only once to reduce run time
         if self.pad_input is None:
             self.pad_input = calculate_same_padding(
                 self.kernel_size, self.stride, x.shape[2:]

--- a/torchmultimodal/modules/layers/conv.py
+++ b/torchmultimodal/modules/layers/conv.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import cast, Tuple, Union
+
+from torch import nn
+from torch.nn import functional as F
+
+from torchmultimodal.utils.common import calculate_same_padding
+
+
+class SamePadConv3d(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: Union[int, Tuple[int, int, int]],
+        stride: Union[int, Tuple[int, int, int]] = 1,
+        bias: bool = True,
+    ):
+        super().__init__()
+        if isinstance(kernel_size, int):
+            kernel_size = (kernel_size,) * 3
+        if isinstance(stride, int):
+            stride = (stride,) * 3
+
+        self.pad_input = calculate_same_padding(kernel_size, stride)
+
+        self.conv = nn.Conv3d(
+            in_channels, out_channels, kernel_size, stride=stride, padding=0, bias=bias
+        )
+
+    def forward(self, x):
+        return self.conv(F.pad(x, self.pad_input))
+
+
+class SamePadConvTranspose3d(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: Union[int, Tuple[int, int, int]],
+        stride: Union[int, Tuple[int, int, int]] = 1,
+        bias: bool = True,
+    ):
+        super().__init__()
+        if isinstance(kernel_size, int):
+            kernel_size = (kernel_size,) * 3
+        if isinstance(stride, int):
+            stride = (stride,) * 3
+
+        self.pad_input = calculate_same_padding(kernel_size, stride)
+
+        input_padding = tuple([k - 1 for k in kernel_size])
+        input_padding = cast(Tuple[int, int, int], input_padding)
+        output_padding = tuple(
+            [4 - k if s == 2 else 0 for k, s in zip(kernel_size, stride)]
+        )
+        output_padding = cast(Tuple[int, int, int], output_padding)
+
+        self.convt = nn.ConvTranspose3d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            bias=bias,
+            padding=input_padding,
+            output_padding=output_padding,
+        )  # only works for kernel=3 (besides default kernel=4) when stride=2
+
+    def forward(self, x):
+        return self.convt(F.pad(x, self.pad_input))

--- a/torchmultimodal/modules/layers/conv.py
+++ b/torchmultimodal/modules/layers/conv.py
@@ -73,7 +73,7 @@ class SamePadConvTranspose3d(nn.Module):
             self.pad_input = calculate_same_padding(
                 self.kernel_size, self.stride, x.shape[2:]
             )
-            self.convt.padding, self.convt.output_padding = calculate_transpose_padding(
+            self.conv.padding, self.conv.output_padding = calculate_transpose_padding(
                 self.kernel_size, self.stride, x.shape[2:], self.pad_input
             )
         return self.conv(F.pad(x, self.pad_input))

--- a/torchmultimodal/modules/layers/conv.py
+++ b/torchmultimodal/modules/layers/conv.py
@@ -70,8 +70,8 @@ class SamePadConv3d(nn.Module):
 
 
 class SamePadConvTranspose3d(nn.Module):
-    """Performs a same padded transposed convolution on a 3D input. This maintains input shape
-    with unit stride, and multiplies input dims by non-unit stride.
+    """Performs a same padded transposed convolution on a 3D input.
+    This ensures output shape in input shape multiplied by stride.
 
     Code taken from VideoGPT
     https://github.com/wilson1yan/VideoGPT/blob/master/videogpt/vqvae.py

--- a/torchmultimodal/modules/layers/conv.py
+++ b/torchmultimodal/modules/layers/conv.py
@@ -4,12 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
+from itertools import repeat
 from typing import Tuple, Union
 
 from torch import nn, Size, Tensor
 from torch.nn import functional as F
-from torch.nn.common_types import _size_3_t, _size_any_t
-from torch.nn.modules.utils import _ntuple, _triple
 
 
 class SamePadConv3d(nn.Module):
@@ -34,16 +34,22 @@ class SamePadConv3d(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        kernel_size: _size_3_t,
-        stride: _size_3_t = 1,
+        kernel_size: Union[int, Tuple[int, int, int]],
+        stride: Union[int, Tuple[int, int, int]] = 1,
         bias: bool = True,
         **kwargs
     ) -> None:
         super().__init__()
 
         self.pad_input: Tuple = None
-        self.kernel_size = _triple(kernel_size)
-        self.stride = _triple(stride)
+        self.kernel_size = kernel_size
+        self.stride = stride
+
+        if "padding" in kwargs:
+            warnings.warn(
+                "Padding was specified but will not be used in favor of same padding, \
+                use Conv3d directly for custom padding"
+            )
 
         self.conv = nn.Conv3d(
             in_channels,
@@ -85,22 +91,28 @@ class SamePadConvTranspose3d(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        kernel_size: _size_3_t,
-        stride: _size_3_t = 1,
+        kernel_size: Union[int, Tuple[int, int, int]],
+        stride: Union[int, Tuple[int, int, int]] = 1,
         bias: bool = True,
         **kwargs
     ) -> None:
         super().__init__()
 
         self.pad_input: Tuple = None
-        self.kernel_size = _triple(kernel_size)
-        self.stride = _triple(stride)
+        self.kernel_size = kernel_size
+        self.stride = stride
+
+        if "padding" in kwargs:
+            warnings.warn(
+                "Padding was specified but will not be used in favor of same padding, \
+                use ConvTranspose3d directly for custom padding"
+            )
 
         self.conv = nn.ConvTranspose3d(
             in_channels, out_channels, kernel_size, stride=stride, bias=bias, **kwargs
         )
 
-    def forward(self, x) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         # Calculate padding needed based on input shape only once to reduce run time
         if self.pad_input is None:
             self.pad_input = calculate_same_padding(
@@ -113,8 +125,8 @@ class SamePadConvTranspose3d(nn.Module):
 
 
 def calculate_same_padding(
-    kernel_size: _size_any_t,
-    stride: _size_any_t,
+    kernel_size: Union[int, Tuple[int, ...]],
+    stride: Union[int, Tuple[int, ...]],
     input_shape: Union[Size, Tuple],
 ) -> Tuple:
     """Calculates padding amount on each dimension based on given kernel size and stride.
@@ -137,9 +149,11 @@ def calculate_same_padding(
         Tuple: the padding amount in a tuple of tuples for each dimension
     """
 
-    convert_to_tuple = _ntuple(len(input_shape))
-    kernel_size = convert_to_tuple(kernel_size)
-    stride = convert_to_tuple(stride)
+    n_dims = len(input_shape)
+    if isinstance(kernel_size, int):
+        kernel_size = tuple(repeat(kernel_size, n_dims))
+    if isinstance(stride, int):
+        stride = tuple(repeat(stride, n_dims))
 
     if not (len(kernel_size) == len(stride) == len(input_shape)):
         raise ValueError("dims for kernel, stride, and input must match")
@@ -160,10 +174,10 @@ def calculate_same_padding(
 
 
 def calculate_transpose_padding(
-    kernel_size: _size_any_t,
-    stride: _size_any_t,
+    kernel_size: Union[int, Tuple[int, ...]],
+    stride: Union[int, Tuple[int, ...]],
     input_shape: Union[Size, Tuple],
-    input_pad: _size_any_t = 0,
+    input_pad: Union[int, Tuple[int, ...]] = 0,
 ) -> Tuple[Tuple, Tuple]:
     """Calculates padding for transposed convolution based on input dims, kernel size, and stride.
 
@@ -174,22 +188,25 @@ def calculate_transpose_padding(
     argument effectively expands the output. These two knobs are adjusted to meet desired output dim.
 
     Args:
-        kernel_size (Tuple): size of convolutional kernel
-        stride (Tuple): stride amount of kernel
+        kernel_size (int or Tuple): size of convolutional kernel
+        stride (int or Tuple): stride amount of kernel
         input_shape (Tuple or Size): tuple describing shape of input, without batch or channel dimension
-        input_pad (Tuple): amount of padding added to input, must be twice length of kernel/stride/input_shape
+        input_pad (int or Tuple): amount of padding added to input, must be twice length of kernel/stride/input_shape
 
     Returns:
         Tuple: padding and output_padding to be used in ConvTranspose layers
     """
 
-    convert_to_tuple = _ntuple(len(input_shape))
-    kernel_size = convert_to_tuple(kernel_size)
-    stride = convert_to_tuple(stride)
+    n_dims = len(input_shape)
+    if isinstance(kernel_size, int):
+        kernel_size = tuple(repeat(kernel_size, n_dims))
+    if isinstance(stride, int):
+        stride = tuple(repeat(stride, n_dims))
+    if isinstance(input_pad, int):
+        input_pad = tuple(repeat(input_pad, n_dims * 2))
 
     if not (len(kernel_size) == len(stride) == len(input_shape)):
         raise ValueError("dims for kernel, stride, and input must match")
-    input_pad = _ntuple(len(input_shape) * 2)(input_pad)
     if len(input_pad) % 2 != 0 or len(input_pad) // 2 != len(input_shape):
         raise ValueError("input_pad length must be twice the number of dims")
 
@@ -198,11 +215,18 @@ def calculate_transpose_padding(
     # Calculate current projected output dim and adjust padding and output_padding to match
     # input_dim * stride for a ConvTranspose layer
     for i, (d, k, s) in enumerate(zip(input_shape, kernel_size, stride)):
+        # Calculate the output dim after transpose convolution:
+        # out_dim = kernel + (in_dim + pad - 1) * stride
+        # This needs to be adjusted with padding to meet desired dim, in_dim * stride
         output_shape_actual = k + (d + input_pad[2 * i] + input_pad[2 * i + 1] - 1) * s
         output_shape_expected = d * s
+        # This controls padding argument in ConvTranspose,
+        # where output dim is effectively trimmed by 2 * transpose_pad
         transpose_pad.append(
             max((output_shape_actual - output_shape_expected + 1) // 2, 0)
         )
+        # This controls output_padding argument in ConvTranspose,
+        # where output dim is expanded by 1 * output_pad
         output_pad.append(
             output_shape_expected - (output_shape_actual - transpose_pad[-1] * 2)
         )

--- a/torchmultimodal/modules/layers/conv.py
+++ b/torchmultimodal/modules/layers/conv.py
@@ -60,7 +60,7 @@ class SamePadConvTranspose3d(nn.Module):
         self.kernel_size = _triple(kernel_size)
         self.stride = _triple(stride)
 
-        self.convt = nn.ConvTranspose3d(
+        self.conv = nn.ConvTranspose3d(
             in_channels,
             out_channels,
             kernel_size,
@@ -129,7 +129,13 @@ def calculate_transpose_padding(
     input_shape: Union[Size, Tuple],
     input_pad: Tuple[int, ...] = None,
 ) -> Tuple[Tuple, Tuple]:
-    """Calculates
+    """Calculates padding for transposed convolution based on input dims, kernel size, and stride.
+
+    Pads to match the 'SAME' padding in Keras, i.e., with a stride of 1 output is guaranteed
+    to have the same shape as input, with stride 2 the dimensions of output are doubled.
+
+    The 'padding' argument in ConvTranspose effectively trims the output, and the 'output_padding'
+    argument effectively expands the output. These two knobs are adjusted to meet desired output dim.
 
     Args:
         kernel_size (Tuple): size of convolutional kernel

--- a/torchmultimodal/modules/layers/conv.py
+++ b/torchmultimodal/modules/layers/conv.py
@@ -4,10 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import cast, Tuple, Union
+from itertools import repeat
+from typing import Tuple, Union
 
 from torch import nn, Size, Tensor
 from torch.nn import functional as F
+from torch.nn.common_types import _size_3_t
+from torch.nn.modules.utils import _triple
 
 
 class SamePadConv3d(nn.Module):
@@ -15,26 +18,31 @@ class SamePadConv3d(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        kernel_size: Union[int, Tuple[int, int, int]],
-        stride: Union[int, Tuple[int, int, int]] = 1,
+        kernel_size: _size_3_t,
+        stride: _size_3_t = 1,
         bias: bool = True,
     ) -> None:
         super().__init__()
-        if isinstance(kernel_size, int):
-            kernel_size = (kernel_size,) * 3
-        if isinstance(stride, int):
-            stride = (stride,) * 3
 
-        self.kernel_size = kernel_size
-        self.stride = stride
+        self.pad_input: Tuple = None
+        self.kernel_size = _triple(kernel_size)
+        self.stride = _triple(stride)
 
         self.conv = nn.Conv3d(
-            in_channels, out_channels, kernel_size, stride=stride, padding=0, bias=bias
+            in_channels,
+            out_channels,
+            self.kernel_size,
+            stride=self.stride,
+            padding=0,
+            bias=bias,
         )
 
     def forward(self, x: Tensor) -> Tensor:
-        pad_input = calculate_same_padding(self.kernel_size, self.stride, x.shape)
-        return self.conv(F.pad(x, pad_input))
+        if self.pad_input is None:
+            self.pad_input = calculate_same_padding(
+                self.kernel_size, self.stride, x.shape[2:]
+            )
+        return self.conv(F.pad(x, self.pad_input))
 
 
 class SamePadConvTranspose3d(nn.Module):
@@ -42,21 +50,15 @@ class SamePadConvTranspose3d(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        kernel_size: Union[int, Tuple[int, int, int]],
-        stride: Union[int, Tuple[int, int, int]] = 1,
+        kernel_size: _size_3_t,
+        stride: _size_3_t = 1,
         bias: bool = True,
     ) -> None:
         super().__init__()
 
-        self.kernel_size = kernel_size
-        self.stride = stride
-
-        input_padding = tuple([k - 1 for k in kernel_size])
-        input_padding = cast(Tuple[int, int, int], input_padding)
-        output_padding = tuple(
-            [4 - k if s == 2 else 0 for k, s in zip(kernel_size, stride)]
-        )
-        output_padding = cast(Tuple[int, int, int], output_padding)
+        self.pad_input: Tuple = None
+        self.kernel_size = _triple(kernel_size)
+        self.stride = _triple(stride)
 
         self.convt = nn.ConvTranspose3d(
             in_channels,
@@ -64,26 +66,30 @@ class SamePadConvTranspose3d(nn.Module):
             kernel_size,
             stride=stride,
             bias=bias,
-            padding=input_padding,
-            output_padding=output_padding,
-        )  # only works for kernel=3 (besides default kernel=4) when stride=2
-        # TODO: refactor this to work for all kernel sizes and strides
+        )
 
     def forward(self, x) -> Tensor:
-        pad_input = calculate_same_padding(self.kernel_size, self.stride, x.shape)
-        return self.convt(F.pad(x, pad_input))
+        if self.pad_input is None:
+            self.pad_input = calculate_same_padding(
+                self.kernel_size, self.stride, x.shape[2:]
+            )
+            self.convt.padding, self.convt.output_padding = calculate_transpose_padding(
+                self.kernel_size, self.stride, x.shape[2:], self.pad_input
+            )
+        return self.conv(F.pad(x, self.pad_input))
 
 
 def calculate_same_padding(
-    kernel_size: Union[int, Tuple[int, ...]],
-    stride: Union[int, Tuple[int, ...]],
+    kernel_size: Tuple[int, ...],
+    stride: Tuple[int, ...],
     input_shape: Union[Size, Tuple],
-) -> Tuple[int, ...]:
+) -> Tuple:
     """Calculates padding amount on each dimension based on given kernel size and stride.
 
     Pads to match the 'SAME' padding in Keras, i.e., with a stride of 1 output is guaranteed
-    to have the same shape as input, with stride 2 the dimensions of output are halved, and
-    stride > 2 the output is ceil(input_dim // stride). Follows same padding notes from TF:
+    to have the same shape as input, with stride 2 the dimensions of output are halved. If
+    stride does not divide into input evenly, then output = ceil(input / stride), following
+    the TensorFlow implementation explained here:
     https://www.tensorflow.org/api_docs/python/tf/nn#notes_on_padding_2
 
     Code taken from VideoGPT
@@ -92,23 +98,73 @@ def calculate_same_padding(
     Args:
         kernel_size (int or Tuple): size of convolutional kernel
         stride (int or Tuple): stride amount of kernel
+        input_shape (Tuple or Size): tuple describing shape of input, without batch or channel dimension
 
     Returns:
         Tuple: the padding amount in a tuple of tuples for each dimension
     """
 
-    n_dims = len(input_shape[2:])
+    assert (
+        len(kernel_size) == len(stride) == len(input_shape)
+    ), "dims for kernel, stride, and input must match"
 
-    if isinstance(kernel_size, int):
-        kernel_size = (kernel_size,) * n_dims
-    if isinstance(stride, int):
-        stride = (stride,) * n_dims
-
-    total_pad = tuple(
-        [max(k - (d % s), 0) for k, s, d in zip(kernel_size, stride, input_shape)]
-    )
+    total_pad = []
+    for k, s, d in zip(kernel_size, stride, input_shape):
+        if d % s == 0:
+            pad = max(k - s, 0)
+        else:
+            pad = max(k - (d % s), 0)
+        total_pad.append(pad)
     pad_input = []
     for p in total_pad[::-1]:  # reverse since F.pad starts from last dim
-        pad_input.append((p // 2 + p % 2, p // 2))
-    pad_input = tuple(sum(pad_input, tuple()))
+        pad_input.append(p // 2 + p % 2)
+        pad_input.append(p // 2)
+    pad_input = tuple(pad_input)
     return pad_input
+
+
+def calculate_transpose_padding(
+    kernel_size: Tuple[int, ...],
+    stride: Tuple[int, ...],
+    input_shape: Union[Size, Tuple],
+    input_pad: Tuple[int, ...] = None,
+) -> Tuple[Tuple, Tuple]:
+    """Calculates
+
+    Args:
+        kernel_size (Tuple): size of convolutional kernel
+        stride (Tuple): stride amount of kernel
+        input_shape (Tuple or Size): tuple describing shape of input, without batch or channel dimension
+        input_pad (Tuple): amount of padding added to input, must be twice length of kernel/stride/input_shape
+
+    Returns:
+        Tuple: padding and output_padding to be used in ConvTranspose layers
+    """
+
+    assert (
+        len(kernel_size) == len(stride) == len(input_shape)
+    ), "dims for kernel, stride, and input must match"
+    if input_pad is None:
+        input_pad = tuple(repeat(0, len(input_shape) * 2))
+    assert len(input_pad) % 2 == 0 and len(input_pad) // 2 == len(
+        input_shape
+    ), "input_pad length must be twice the number of dims"
+
+    transpose_pad = []
+    output_pad = []
+    # Calculate current projected output dim and adjust padding and output_padding to match
+    # input_dim * stride for a ConvTranspose layer
+    for i, (d, k, s) in enumerate(zip(input_shape, kernel_size, stride)):
+        output_shape_actual = k + (d + input_pad[2 * i] + input_pad[2 * i + 1] - 1) * s
+        output_shape_expected = d * s
+        transpose_pad.append(
+            max((output_shape_actual - output_shape_expected + 1) // 2, 0)
+        )
+        output_pad.append(
+            output_shape_expected - (output_shape_actual - transpose_pad[-1] * 2)
+        )
+
+    transpose_pad = tuple(transpose_pad)
+    output_pad = tuple(output_pad)
+
+    return transpose_pad, output_pad

--- a/torchmultimodal/modules/layers/conv.py
+++ b/torchmultimodal/modules/layers/conv.py
@@ -6,10 +6,8 @@
 
 from typing import cast, Tuple, Union
 
-from torch import nn
+from torch import nn, Size, Tensor
 from torch.nn import functional as F
-
-from torchmultimodal.utils.common import calculate_same_padding
 
 
 class SamePadConv3d(nn.Module):
@@ -20,21 +18,23 @@ class SamePadConv3d(nn.Module):
         kernel_size: Union[int, Tuple[int, int, int]],
         stride: Union[int, Tuple[int, int, int]] = 1,
         bias: bool = True,
-    ):
+    ) -> None:
         super().__init__()
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size,) * 3
         if isinstance(stride, int):
             stride = (stride,) * 3
 
-        self.pad_input = calculate_same_padding(kernel_size, stride)
+        self.kernel_size = kernel_size
+        self.stride = stride
 
         self.conv = nn.Conv3d(
             in_channels, out_channels, kernel_size, stride=stride, padding=0, bias=bias
         )
 
-    def forward(self, x):
-        return self.conv(F.pad(x, self.pad_input))
+    def forward(self, x: Tensor) -> Tensor:
+        pad_input = calculate_same_padding(self.kernel_size, self.stride, x.shape)
+        return self.conv(F.pad(x, pad_input))
 
 
 class SamePadConvTranspose3d(nn.Module):
@@ -45,14 +45,11 @@ class SamePadConvTranspose3d(nn.Module):
         kernel_size: Union[int, Tuple[int, int, int]],
         stride: Union[int, Tuple[int, int, int]] = 1,
         bias: bool = True,
-    ):
+    ) -> None:
         super().__init__()
-        if isinstance(kernel_size, int):
-            kernel_size = (kernel_size,) * 3
-        if isinstance(stride, int):
-            stride = (stride,) * 3
 
-        self.pad_input = calculate_same_padding(kernel_size, stride)
+        self.kernel_size = kernel_size
+        self.stride = stride
 
         input_padding = tuple([k - 1 for k in kernel_size])
         input_padding = cast(Tuple[int, int, int], input_padding)
@@ -70,6 +67,48 @@ class SamePadConvTranspose3d(nn.Module):
             padding=input_padding,
             output_padding=output_padding,
         )  # only works for kernel=3 (besides default kernel=4) when stride=2
+        # TODO: refactor this to work for all kernel sizes and strides
 
-    def forward(self, x):
-        return self.convt(F.pad(x, self.pad_input))
+    def forward(self, x) -> Tensor:
+        pad_input = calculate_same_padding(self.kernel_size, self.stride, x.shape)
+        return self.convt(F.pad(x, pad_input))
+
+
+def calculate_same_padding(
+    kernel_size: Union[int, Tuple[int, ...]],
+    stride: Union[int, Tuple[int, ...]],
+    input_shape: Union[Size, Tuple],
+) -> Tuple[int, ...]:
+    """Calculates padding amount on each dimension based on given kernel size and stride.
+
+    Pads to match the 'SAME' padding in Keras, i.e., with a stride of 1 output is guaranteed
+    to have the same shape as input, with stride 2 the dimensions of output are halved, and
+    stride > 2 the output is ceil(input_dim // stride). Follows same padding notes from TF:
+    https://www.tensorflow.org/api_docs/python/tf/nn#notes_on_padding_2
+
+    Code taken from VideoGPT
+    https://github.com/wilson1yan/VideoGPT/blob/master/videogpt/vqvae.py
+
+    Args:
+        kernel_size (int or Tuple): size of convolutional kernel
+        stride (int or Tuple): stride amount of kernel
+
+    Returns:
+        Tuple: the padding amount in a tuple of tuples for each dimension
+    """
+
+    n_dims = len(input_shape[2:])
+
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size,) * n_dims
+    if isinstance(stride, int):
+        stride = (stride,) * n_dims
+
+    total_pad = tuple(
+        [max(k - (d % s), 0) for k, s, d in zip(kernel_size, stride, input_shape)]
+    )
+    pad_input = []
+    for p in total_pad[::-1]:  # reverse since F.pad starts from last dim
+        pad_input.append((p // 2 + p % 2, p // 2))
+    pad_input = tuple(sum(pad_input, tuple()))
+    return pad_input

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -8,7 +8,7 @@ import hashlib
 import os
 from collections import OrderedDict
 from dataclasses import fields
-from typing import Optional, Tuple, Union
+from typing import Optional
 
 import torch
 from torch import Tensor
@@ -19,38 +19,6 @@ def get_current_device():
         return f"cuda:{torch.cuda.current_device()}"
     else:
         return torch.device("cpu")
-
-
-def calculate_same_padding(
-    kernel_size: Union[int, Tuple[int, ...]], stride: Union[int, Tuple[int, ...]]
-):
-    """Calculates padding amount on each dimension based on given kernel size and stride.
-
-    Pads to match the 'SAME' padding in Keras, i.e., with a stride of 1 output is guaranteed
-    to have the same shape as input, with stride 2 the dimensions of output are halved.
-
-    Code taken from VideoGPT
-    https://github.com/wilson1yan/VideoGPT/blob/master/videogpt/vqvae.py
-
-    Args:
-        kernel_size (int or Tuple): size of convolutional kernel
-        stride (int or Tuple): stride amount of kernel
-
-    Returns:
-        Tuple: the padding amount in a tuple of tuples for each dimension
-    """
-    if isinstance(kernel_size, int):
-        kernel_size = (kernel_size,) * 3
-    if isinstance(stride, int):
-        stride = (stride,) * 3
-
-    # assumes that the input shape is divisible by stride
-    total_pad = tuple([k - s for k, s in zip(kernel_size, stride)])
-    pad_input = []
-    for p in total_pad[::-1]:  # reverse since F.pad starts from last dim
-        pad_input.append((p // 2 + p % 2, p // 2))
-    pad_input = tuple(sum(pad_input, tuple()))
-    return pad_input
 
 
 def shift_dim(

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -8,7 +8,7 @@ import hashlib
 import os
 from collections import OrderedDict
 from dataclasses import fields
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 
@@ -18,6 +18,16 @@ def get_current_device():
         return f"cuda:{torch.cuda.current_device()}"
     else:
         return torch.device("cpu")
+
+
+def calculate_same_padding(kernel_size: Tuple[int, ...], stride: Tuple[int, ...]):
+    # assumes that the input shape is divisible by stride
+    total_pad = tuple([k - s for k, s in zip(kernel_size, stride)])
+    pad_input = []
+    for p in total_pad[::-1]:  # reverse since F.pad starts from last dim
+        pad_input.append((p // 2 + p % 2, p // 2))
+    pad_input = tuple(sum(pad_input, tuple()))
+    return pad_input
 
 
 class PretrainedMixin:


### PR DESCRIPTION
Summary:
Ported `SamePadConv3D` layers from MUGEN codebase with some redesign to apply to more input dim/kernel/stride cases. Small changes for mypy and an added rule to ignore for flake8.

Test plan:
Added unit tests. Local testing on notebook to compare outputs from original MUGEN implementation and ours to make sure they are exact same shape and value.

`SamePadConvTranspose3d`
![image](https://user-images.githubusercontent.com/33648637/172452130-f752e9da-316b-4495-8439-23454b0dcd0c.png)


`SamePadConv3d`
![image](https://user-images.githubusercontent.com/33648637/172452035-d6cf9ff3-81fa-40b9-8786-d932d7decad5.png)


`pytest -vv`
<img width="936" alt="image" src="https://user-images.githubusercontent.com/33648637/171509362-ac510fbe-7210-4409-a143-5f59ab0d5502.png">
