### PR TITLE
Adding a MUGEN utility for permuting and implemented in codebook

### DIFF
--- a/test/utils/test_common.py
+++ b/test/utils/test_common.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from test.test_utils import assert_expected
+
+from torchmultimodal.utils.common import shift_dim
+
+
+class TestCommonUtils(unittest.TestCase):
+    """
+    Test the utils in common.py
+    """
+
+    def setUp(self):
+        self.test_random_tensor = torch.randn(2, 2, 2, 2, 2)
+
+    def test_shift_dim(self):
+        actual = shift_dim(self.test_random_tensor, 1, -1)
+        expected = self.test_random_tensor.permute(0, 2, 3, 4, 1).contiguous()
+        assert_expected(actual, expected)
+
+        actual = shift_dim(self.test_random_tensor, -3, 3)
+        expected = self.test_random_tensor.permute(0, 1, 3, 2, 4).contiguous()
+        assert_expected(actual, expected)

--- a/torchmultimodal/modules/layers/codebook.py
+++ b/torchmultimodal/modules/layers/codebook.py
@@ -8,6 +8,7 @@ from typing import NamedTuple, Tuple
 
 import torch
 from torch import nn, Size, Tensor
+from torchmultimodal.utils.common import shift_dim
 
 
 class CodebookOutput(NamedTuple):
@@ -83,8 +84,7 @@ class Codebook(nn.Module):
 
     def _preprocess(self, encoded: Tensor) -> Tuple[Tensor, Size]:
         # Rearrange from batch x channel x n dims to batch x n dims x channel
-        new_dims = (0,) + tuple(range(2, len(encoded.shape))) + (1,)
-        encoded_permuted = encoded.permute(new_dims).contiguous()
+        encoded_permuted = shift_dim(encoded, 1, -1)
         permuted_shape = encoded_permuted.shape
 
         # Flatten input
@@ -102,8 +102,7 @@ class Codebook(nn.Module):
         # Rearrange back to batch x channel x n dims
         num_dims = len(permuted_shape)
         quantized_permuted = quantized_flat.view(permuted_shape)
-        old_dims = (0,) + (num_dims - 1,) + tuple(range(1, num_dims - 1))
-        quantized = quantized_permuted.permute(old_dims).contiguous()
+        quantized = shift_dim(quantized_permuted, -1, 1)
 
         return quantized
 

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -11,6 +11,7 @@ from dataclasses import fields
 from typing import Optional
 
 import torch
+from torch import Tensor
 
 
 def get_current_device():
@@ -18,6 +19,50 @@ def get_current_device():
         return f"cuda:{torch.cuda.current_device()}"
     else:
         return torch.device("cpu")
+
+
+def shift_dim(
+    x: Tensor, src_dim: int = -1, dest_dim: int = -1, make_contiguous: bool = True
+):
+    """Permutes tensor x by moving src_dim to dest_dim.
+    i.e. shift_dim(x, 1, -1) would be (b, c, t, h, w) -> (b, t, h, w, c)
+
+    Code taken from VideoGPT
+    https://github.com/wilson1yan/VideoGPT/blob/master/videogpt/utils.py
+
+    Args:
+        x (Tensor): input Tensor you want to permute
+        src_dim (int, optional): the axis you want to move. Negative indexing supported. Defaults to -1.
+        dest_dim (int, optional): the axis you want to move to. Negative indexing supported. Defaults to -1.
+        make_contiguous (bool, optional): if you want the output tensor to be contiguous in memory. Defaults to True.
+
+    Returns:
+        Tensor: permuted Tensor
+    """
+    n_dims = len(x.shape)
+    # Remap negative dim
+    if src_dim < 0:
+        src_dim = n_dims + src_dim
+    if dest_dim < 0:
+        dest_dim = n_dims + dest_dim
+
+    assert 0 <= src_dim < n_dims and 0 <= dest_dim < n_dims
+
+    dims = list(range(n_dims))
+    del dims[src_dim]
+
+    permutation = []
+    ctr = 0
+    for i in range(n_dims):
+        if i == dest_dim:
+            permutation.append(src_dim)
+        else:
+            permutation.append(dims[ctr])
+            ctr += 1
+    x = x.permute(permutation)
+    if make_contiguous:
+        x = x.contiguous()
+    return x
 
 
 class PretrainedMixin:


### PR DESCRIPTION
Summary:
`shift_dim` is a commonly used utility throughout the MUGEN codebase. Including it in a small separate PR so subsequent PRs for MUGEN can use `shift_dim` quickly.

Test plan:
`pytest test/modules/layers/test_codebook.py -vv`
`pytest test/utils/test_common.py -vv`