### PR TITLE
Create test_build.yml

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,0 +1,24 @@
+name: Test build workflow
+on:
+  workflow_dispatch:
+jobs:
+  build_wheel:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8, 3.9]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Build wheel
+        run: |
+          pip3 install wheel
+          python setup.py bdist_wheel
+      - name: Install wheel
+        run: |
+          pip3 install dist/torchmultimodal*.whl


### PR DESCRIPTION
Summary:
Add a test_build.yml to build wheel, test install it and upload to GHA. This is the first step toward setting up our release CI. 
Next step would be to  install torch* dependencies and run the tests

Test plan:
- This workflow should be manually triggerable but cant test that till the merge happens 
- So created a PR with the workflow trigger as PR temporarily --> Run on the PR https://github.com/facebookresearch/multimodal/actions/runs/2405089199
Able to download the wheel

