### PR TITLE
Modularize TextEmbeddings

### DIFF
--- a/test/modules/embeddings/test_text_embeddings.py
+++ b/test/modules/embeddings/test_text_embeddings.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.embeddings.text_embeddings import BERTEmbeddings
+
+
+class TestBERTEmbeddings(unittest.TestCase):
+    def setUp(self):
+        set_rng_seed(0)
+        self.embedding = BERTEmbeddings()
+        self.input_ids = torch.randint(low=1, high=150, size=(5, 10)).long()
+        self.segment_ids = torch.ones(5, 10).long()
+
+    def test_text_embedding_shape(self):
+        output = self.embedding(self.input_ids, self.segment_ids)
+        assert_expected(output.shape, torch.Size([5, 10, 768]))
+
+    def test_text_embedding_values(self):
+        output = self.embedding(self.input_ids, self.segment_ids)
+
+        actual_first_values = output[0, :, 0]
+        actual_last_values = output[-1, :, -1]
+
+        expected_first_values = torch.Tensor(
+            [
+                -0.5289,
+                0.4380,
+                -0.2358,
+                0.1231,
+                -0.3958,
+                0.1124,
+                0.3287,
+                0.3287,
+                0.6593,
+                -0.6662,
+            ]
+        )
+
+        expected_last_values = torch.Tensor(
+            [
+                0.6998,
+                1.9490,
+                0.8495,
+                1.8604,
+                1.0771,
+                0.7184,
+                1.5674,
+                1.2117,
+                0.0000,
+                1.3389,
+            ]
+        )
+
+        assert_expected(actual_first_values, expected_first_values, rtol=0.0, atol=1e-4)
+        assert_expected(actual_last_values, expected_last_values, rtol=0.0, atol=1e-4)

--- a/torchmultimodal/models/flava.py
+++ b/torchmultimodal/models/flava.py
@@ -16,8 +16,8 @@ from functools import partial
 from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 
 import torch
-from packaging import version
 from torch import device, nn, Tensor
+from torchmultimodal.modules.embeddings.text_embeddings import BERTEmbeddings
 from torchmultimodal.modules.layers.mlp import MLP
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
 from torchmultimodal.modules.layers.transformer import (
@@ -115,7 +115,7 @@ def flava_text_encoder(
     type_vocab_size: int = 2,
     max_position_embeddings: int = 512,
 ):
-    embeddings = TextEmbeddings(
+    embeddings = BERTEmbeddings(
         hidden_size=hidden_size,
         vocab_size=vocab_size,
         pad_token_id=pad_token_id,
@@ -824,89 +824,6 @@ class ImageTransformerWithVAE(nn.Module):
             attentions=output.attentions,
             image_labels=image_labels,
         )
-
-
-class TextEmbeddings(nn.Module):
-    """Construct the embeddings from word, position and token_type embeddings following BERT."""
-
-    def __init__(
-        self,
-        hidden_size: int = 768,
-        vocab_size: int = 30522,
-        pad_token_id: int = 0,
-        type_vocab_size: int = 2,
-        max_position_embeddings: int = 512,
-        layer_norm_eps: float = 1e-12,
-        hidden_dropout_prob: float = 0.1,
-    ):
-        super().__init__()
-        self.word_embeddings = nn.Embedding(
-            vocab_size, hidden_size, padding_idx=pad_token_id
-        )
-        self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
-        self.token_type_embeddings = nn.Embedding(type_vocab_size, hidden_size)
-
-        # self.LayerNorm is not snake-cased to stick with TensorFlow model variable name and be able to load
-        # any TensorFlow checkpoint file
-        self.LayerNorm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
-        self.dropout = nn.Dropout(hidden_dropout_prob)
-        # position_ids (1, len position emb) is contiguous in memory and exported when serialized
-        self.register_buffer(
-            "position_ids", torch.arange(max_position_embeddings).expand((1, -1))
-        )
-        if version.parse(torch.__version__) > version.parse("1.6.0"):
-            self.register_buffer(
-                "token_type_ids",
-                torch.zeros(self.position_ids.size(), dtype=torch.long),
-                persistent=False,
-            )
-
-    def forward(
-        self,
-        input_ids: Optional[Tensor] = None,
-        token_type_ids: Optional[Tensor] = None,
-        position_ids: Optional[Tensor] = None,
-        inputs_embeds: Optional[Tensor] = None,
-        past_key_values_length: int = 0,
-    ):
-        if input_ids is not None:
-            input_shape = input_ids.size()
-        else:
-            input_shape = inputs_embeds.size()[:-1]
-
-        seq_length = input_shape[1]
-
-        if position_ids is None:
-            position_ids = self.position_ids[
-                :, past_key_values_length : seq_length + past_key_values_length
-            ]
-
-        # Setting the token_type_ids to the registered buffer in constructor where it is all zeros, which usually occurs
-        # when its auto-generated, registered buffer helps users when tracing the model without passing token_type_ids, solves
-        # issue #5664
-        if token_type_ids is None:
-            if hasattr(self, "token_type_ids"):
-                buffered_token_type_ids = self.token_type_ids[:, :seq_length]
-                buffered_token_type_ids_expanded = buffered_token_type_ids.expand(
-                    input_shape[0], seq_length
-                )
-                token_type_ids = buffered_token_type_ids_expanded
-            else:
-                token_type_ids = torch.zeros(
-                    input_shape, dtype=torch.long, device=self.position_ids.device
-                )
-
-        if inputs_embeds is None:
-            inputs_embeds = self.word_embeddings(input_ids)
-        token_type_embeddings = self.token_type_embeddings(token_type_ids)
-
-        embeddings = inputs_embeds + token_type_embeddings
-        position_embeddings = self.position_embeddings(position_ids)
-        embeddings += position_embeddings
-
-        embeddings = self.LayerNorm(embeddings)
-        embeddings = self.dropout(embeddings)
-        return embeddings
 
 
 class TextTransformer(nn.Module):

--- a/torchmultimodal/modules/embeddings/text_embeddings.py
+++ b/torchmultimodal/modules/embeddings/text_embeddings.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from torch import nn, Tensor
+
+
+class BERTEmbeddings(nn.Module):
+    """Construct the embeddings from word, position and token_type embeddings following BERT.
+
+    Args:
+        hidden_size (int): size of hidden dims
+        vocab_size (int): size of vocabulary used by embeddings
+        pad_token_id (int): id denoting a padding token
+        type_vocab_size (int): number of valid token types?
+        max_position_embeddings (int): maximum valid position for a token embedding
+        layer_norm_eps (float): a value added to the denominator of a LayerNorm for numerical stability
+        hidden_dropout_prob (float): dropout probability for each hidden layer
+
+    Inputs:
+        input_ids (Tensor): sequence of token ids of len n
+        token_type_ids (Tensor): sequence of token type ids of len n
+        position_ids (Tensor): sequence of position ids of len n
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 768,
+        vocab_size: int = 30522,
+        pad_token_id: int = 0,
+        type_vocab_size: int = 2,
+        max_position_embeddings: int = 512,
+        layer_norm_eps: float = 1e-12,
+        hidden_dropout_prob: float = 0.1,
+    ):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(
+            vocab_size, hidden_size, padding_idx=pad_token_id
+        )
+        self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
+        self.token_type_embeddings = nn.Embedding(type_vocab_size, hidden_size)
+
+        # self.LayerNorm is not snake-cased to stick with TensorFlow model variable name and be able to load
+        # any TensorFlow checkpoint file
+        self.LayerNorm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.dropout = nn.Dropout(hidden_dropout_prob)
+        # position_ids (1, len position emb) is contiguous in memory and exported when serialized
+        self.register_buffer(
+            "position_ids", torch.arange(max_position_embeddings).expand((1, -1))
+        )
+        self.register_buffer(
+            "token_type_ids",
+            torch.zeros(self.position_ids.size(), dtype=torch.long),
+            persistent=False,
+        )
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        token_type_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+    ):
+        input_shape = input_ids.size()
+        seq_length = input_shape[1]
+
+        position_ids = position_ids or self.position_ids[:, seq_length]
+
+        # Setting the token_type_ids to the registered buffer in constructor where it is all zeros, which usually occurs
+        # when its auto-generated, registered buffer helps users when tracing the model without passing token_type_ids, solves
+        # issue #5664
+        if token_type_ids is None:
+            if hasattr(self, "token_type_ids"):
+                buffered_token_type_ids = self.token_type_ids[:, :seq_length]
+                buffered_token_type_ids_expanded = buffered_token_type_ids.expand(
+                    input_shape[0], seq_length
+                )
+                token_type_ids = buffered_token_type_ids_expanded
+            else:
+                token_type_ids = torch.zeros(
+                    input_shape, dtype=torch.long, device=self.position_ids.device
+                )
+
+        inputs_embeddings = self.word_embeddings(input_ids)
+        token_type_embeddings = self.token_type_embeddings(token_type_ids)
+        position_embeddings = self.position_embeddings(position_ids)
+
+        embeddings = inputs_embeddings + token_type_embeddings + position_embeddings
+
+        embeddings = self.LayerNorm(embeddings)
+        embeddings = self.dropout(embeddings)
+        return embeddings


### PR DESCRIPTION
Summary:
- Moved `TextEmbeddings` class from `flava.py` to its own module
- Created `embeddings` dir to hold `text_embeddings` and future embeddings modules
- Created test

Differential Revision: D36634188

