### PR TITLE
Add MDETR text encoder

### DIFF
--- a/test/modules/encoders/test_mdetr_text_encoder.py
+++ b/test/modules/encoders/test_mdetr_text_encoder.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from copy import deepcopy
+
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.encoders.mdetr_text_encoder import (
+    MDETRTextEmbeddings,
+    MDETRTextEncoder,
+    WrappedTransformerEncoder,
+)
+from torchmultimodal.utils.common import filter_dict
+from torchtext.models.roberta.bundler import ROBERTA_BASE_ENCODER
+
+
+class TestMDETRTextEncoder(unittest.TestCase):
+    def setUp(self):
+        self.max_position_embeddings = 514
+        self.hidden_size = 768
+        self.embeddings = MDETRTextEmbeddings(
+            hidden_size=self.hidden_size,
+            vocab_size=50265,
+            pad_token_id=1,
+            type_vocab_size=1,
+            max_position_embeddings=self.max_position_embeddings,
+            layer_norm_eps=1e-05,
+            hidden_dropout_prob=0.1,
+        )
+        set_rng_seed(0)
+        self._populate_embedding_weights()
+
+        self.roberta_encoder = ROBERTA_BASE_ENCODER.get_model()
+        # Remove extra args due to TorchText RoBERTa encoder's forward taking in tokens instead of embeddings
+        wrapped_args = filter_dict(
+            lambda x: x not in ["vocab_size", "padding_idx", "max_seq_len", "scaling"],
+            ROBERTA_BASE_ENCODER.encoderConf.__dict__,
+        )
+        self.wrapped_transformer_encoder = WrappedTransformerEncoder(**wrapped_args)
+        self._populate_wrapped_transformer_weights()
+
+        self.text_encoder = MDETRTextEncoder(
+            embeddings=self.embeddings, encoder=self.wrapped_transformer_encoder
+        )
+        self.text_encoder.eval()
+
+        self.input_ids = torch.tensor(
+            [
+                [0, 100, 64, 192, 5, 3778, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                [
+                    0,
+                    1708,
+                    190,
+                    114,
+                    38,
+                    1395,
+                    192,
+                    5,
+                    3778,
+                    6,
+                    38,
+                    216,
+                    14,
+                    24,
+                    8785,
+                    2,
+                ],
+            ],
+            dtype=torch.int,
+        )
+        self.attention_mask = torch.tensor(
+            [
+                [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            ],
+            dtype=torch.int,
+        )
+        self.batch_size, self.input_length = self.input_ids.size()
+
+    def test_mdetr_text_embeddings(self):
+        expected = torch.Tensor(
+            [
+                0.62926,
+                0.71966,
+                0.59531,
+                0.54416,
+                0.61227,
+                0.67181,
+                0.61707,
+                0.47298,
+                0.72058,
+                0.68760,
+                0.75449,
+                0.52463,
+                0.49111,
+                0.57840,
+                0.44969,
+                0.71950,
+            ]
+        )
+        out = self.embeddings(self.input_ids, self.attention_mask)
+        actual = out[1, :, 1]
+        self.assertEqual(
+            out.size(), (self.batch_size, self.input_length, self.hidden_size)
+        )
+        assert_expected(actual, expected, rtol=0.0, atol=1e-4)
+
+    def test_mdetr_wrapped_transformer(self):
+        set_rng_seed(0)
+        inp = torch.rand((2, 16, 768))
+        expected = torch.Tensor(
+            [
+                0.10437,
+                0.10304,
+                0.10998,
+                0.10926,
+                0.10760,
+                0.10326,
+                0.10478,
+                0.10586,
+                0.10500,
+                0.11583,
+                0.10339,
+                0.10585,
+                0.10405,
+                0.10533,
+                0.11012,
+                0.11071,
+            ]
+        )
+        out = self.wrapped_transformer_encoder(inp, self.attention_mask)
+        actual = out[1, :, 1]
+        self.assertEqual(
+            out.size(), (self.batch_size, self.input_length, self.hidden_size)
+        )
+        assert_expected(actual, expected, rtol=0.0, atol=1e-4)
+
+    def test_mdetr_text_encoder(self):
+        expected = torch.Tensor(
+            [
+                0.04690,
+                0.06246,
+                0.05839,
+                0.05727,
+                0.06413,
+                0.05640,
+                0.06599,
+                0.04888,
+                0.07137,
+                0.05381,
+                0.06141,
+                0.06225,
+                0.04788,
+                0.06256,
+                0.05058,
+                0.06433,
+            ]
+        )
+        out = self.text_encoder(self.input_ids, self.attention_mask)
+        actual = out[1, :, 1]
+        self.assertEqual(
+            out.size(), (self.batch_size, self.input_length, self.hidden_size)
+        )
+        assert_expected(actual, expected, rtol=0.0, atol=1e-4)
+
+    # Unlike with the encoder where all weights are already present in the TorchText checkpoint,
+    # for the embedding we need to construct our own weights since word_embeddings are not present
+    # in the TorchText model bundle.
+    def _populate_embedding_weights(self):
+        embeddings_state_dict = {}
+        for k, v in self.embeddings.state_dict().items():
+            # These have already been set on init and shouldn't be changed
+            if k == "position_ids":
+                embeddings_state_dict[k] = v
+            # Set these to match the HF RoBERTa weights
+            elif k == "token_type_embeddings.weight":
+                embeddings_state_dict[k] = torch.zeros(v.size())
+            # Set all other weights randomly
+            else:
+                embeddings_state_dict[k] = torch.rand(v.size())
+        self.embeddings.load_state_dict(embeddings_state_dict)
+
+    def _populate_wrapped_transformer_weights(self):
+        transformer_state_dict = deepcopy(
+            self.roberta_encoder.encoder.transformer.state_dict()
+        )
+        # Remove embedding weights, but keep final layer norm weights
+        wrapped_state_dict = filter_dict(
+            lambda x: "embedding" not in x or "layer_norm" in x, transformer_state_dict
+        )
+        self.wrapped_transformer_encoder.load_state_dict(wrapped_state_dict)

--- a/torchmultimodal/modules/encoders/mdetr_text_encoder.py
+++ b/torchmultimodal/modules/encoders/mdetr_text_encoder.py
@@ -1,0 +1,223 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Union
+
+import torch
+from torch import nn, Tensor
+
+
+def create_position_ids_from_input_ids(input_ids, padding_idx):
+    """
+    Replace non-padding symbols with their position numbers. Position numbers begin at padding_idx+1. Padding symbols
+    are ignored. This is modified from fairseq's `utils.make_positions`.
+
+    Args:
+        x: torch.Tensor x:
+
+    Returns: torch.Tensor
+    """
+    # The series of casts and type-conversions here are carefully balanced to both work with ONNX export and XLA.
+    mask = input_ids.ne(padding_idx).int()
+    incremental_indices = torch.cumsum(mask, dim=1).type_as(mask) * mask
+    return incremental_indices.long() + padding_idx
+
+
+# TODO (later): Possibly refactor into a common class with FLAVA text embeddings class
+class MDETRTextEmbeddings(nn.Module):
+    """This class is identical to FLAVA's TextEmbeddings class except for its handling of position IDs."""
+
+    def __init__(
+        self,
+        hidden_size: int = 768,
+        vocab_size: int = 30522,
+        pad_token_id: int = 0,
+        type_vocab_size: int = 2,
+        max_position_embeddings: int = 512,
+        layer_norm_eps: float = 1e-12,
+        hidden_dropout_prob: float = 0.1,
+    ):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(
+            vocab_size, hidden_size, padding_idx=pad_token_id
+        )
+        self.padding_idx = pad_token_id
+        self.position_embeddings = nn.Embedding(
+            max_position_embeddings, hidden_size, padding_idx=self.padding_idx
+        )
+        self.token_type_embeddings = nn.Embedding(type_vocab_size, hidden_size)
+
+        # self.LayerNorm is not snake-cased to stick with TensorFlow model variable name and be able to load
+        # any TensorFlow checkpoint file
+        self.LayerNorm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.dropout = nn.Dropout(hidden_dropout_prob)
+        # position_ids (1, len position emb) is contiguous in memory and exported when serialized
+        position_ids_range = torch.arange(max_position_embeddings).expand((1, -1))
+        self.register_buffer("position_ids", position_ids_range.clone())
+        self.register_buffer(
+            "token_type_ids",
+            torch.zeros(position_ids_range.size(), dtype=torch.long),
+            persistent=False,
+        )
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        attention_mask: Optional[Tensor] = None,
+        token_type_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        inputs_embeds: Optional[Tensor] = None,
+    ):
+        batch_size, seq_length = input_ids.size()
+        device = input_ids.device
+
+        if position_ids is None:
+            # Create the position ids from the input token ids. Any padded tokens remain padded.
+            position_ids = create_position_ids_from_input_ids(
+                input_ids, self.padding_idx
+            )
+
+        if attention_mask is None:
+            attention_mask = torch.ones(((batch_size, seq_length)), device=device)
+
+        # Setting the token_type_ids to the registered buffer in constructor where it is all zeros, which usually occurs
+        # when its auto-generated, registered buffer helps users when tracing the model without passing token_type_ids, solves
+        # issue #5664
+        if token_type_ids is None:
+            if hasattr(self, "token_type_ids"):
+                buffered_token_type_ids = self.token_type_ids[:, :seq_length]  # type: ignore
+                buffered_token_type_ids_expanded = buffered_token_type_ids.expand(
+                    batch_size, seq_length
+                )
+                token_type_ids = buffered_token_type_ids_expanded
+            else:
+                token_type_ids = torch.zeros(
+                    batch_size,
+                    seq_length,
+                    dtype=torch.long,
+                    device=device,
+                )
+
+        if inputs_embeds is None:
+            inputs_embeds = self.word_embeddings(input_ids)
+        token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        embeddings = inputs_embeds + token_type_embeddings
+        position_embeddings = self.position_embeddings(position_ids)
+        embeddings += position_embeddings
+
+        embeddings = self.LayerNorm(embeddings)
+        embeddings = self.dropout(embeddings)
+        return embeddings
+
+
+# Wrap TorchText's TransformerEncoder to take in embeddings instead of tokens
+class WrappedTransformerEncoder(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int,
+        num_encoder_layers: int,
+        num_attention_heads: int,
+        ffn_dimension: Optional[int] = None,
+        dropout: float = 0.1,
+        normalize_before: bool = False,
+        return_all_layers: bool = False,
+    ):
+        super().__init__()
+        ffn_dimension = ffn_dimension or 4 * embedding_dim
+        layer = torch.nn.TransformerEncoderLayer(
+            d_model=embedding_dim,
+            nhead=num_attention_heads,
+            dim_feedforward=ffn_dimension,
+            dropout=dropout,
+            activation="gelu",
+            batch_first=True,
+            norm_first=normalize_before,
+        )
+        self.layers = torch.nn.TransformerEncoder(
+            encoder_layer=layer, num_layers=num_encoder_layers
+        )
+        self.normalize_before = normalize_before
+        self.embedding_layer_norm = nn.LayerNorm(embedding_dim)
+        self.return_all_layers = return_all_layers
+
+    def _forward_return_all_layers(
+        self,
+        embeddings: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+        padding_mask: Optional[torch.Tensor] = None,
+    ) -> List[torch.Tensor]:
+        encoded = embeddings
+        states = [encoded]
+        for layer in self.layers.layers:
+            encoded = layer(encoded, src_key_padding_mask=attn_mask)
+            states.append(encoded)
+        if self.normalize_before:
+            for i, state in enumerate(states):
+                states[i] = self.embedding_layer_norm(state)
+        return states
+
+    def _forward_return_last_layer(
+        self,
+        embeddings: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+        padding_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        encoded = embeddings
+        for layer in self.layers.layers:
+            encoded = layer(encoded, src_key_padding_mask=attn_mask)
+        if self.normalize_before:
+            encoded = self.embedding_layer_norm(encoded)
+        return encoded
+
+    def forward(
+        self,
+        embeddings: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+        padding_mask: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        out: Union[torch.Tensor, List[torch.Tensor]]
+        if self.return_all_layers:
+            out = self._forward_return_all_layers(embeddings, attn_mask, padding_mask)
+        else:
+            out = self._forward_return_last_layer(embeddings, attn_mask, padding_mask)
+
+        return out
+
+
+class MDETRTextEncoder(nn.Module):
+    def __init__(self, embeddings: nn.Module, encoder: nn.Module):
+        super().__init__()
+        self.embeddings = embeddings
+        self.encoder = encoder
+
+    # Note: MDETR's RoBERTa encoder also returns pooler outputs in forward, but
+    # these are only used for contrastive loss. Since contrastive loss is not used anywhere,
+    # we omit the pooler for the time being.
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+    ):
+        # Cast mask to bool and invert it
+        # In PyTorch attention masks, True means the position is masked,
+        # while in Hugging Face transformers the masks are inverted.
+        attention_mask = ~attention_mask.bool()
+
+        embedding_output = self.embeddings(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            token_type_ids=token_type_ids,
+        )
+
+        out = self.encoder(
+            embedding_output,
+            attn_mask=attention_mask,
+        )
+
+        return out

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -8,7 +8,7 @@ import hashlib
 import os
 from collections import OrderedDict
 from dataclasses import fields
-from typing import Optional
+from typing import Any, Callable, Dict, Optional
 
 import torch
 
@@ -113,3 +113,9 @@ class NestedTensor(object):
 
     def __repr__(self):
         return repr(self.tensors)
+
+
+def filter_dict(
+    key_condition: Callable[..., bool], d: Dict[Any, Any]
+) -> Dict[Any, Any]:
+    return {k: v for k, v in d.items() if key_condition(k)}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This commit adds support for MDETR's RoBERTa text encoder.
We make some modifications to TorchText's RoBERTa encoder to make
things more modular and ensure the implementation matches the one from
Hugging Face (as used by MDETR). The changes include

1) A class MDETRTextEmbeddings. This is similar to the TextEmbeddings class from
FLAVA, but handles position IDs differently.

2) A WrappedTransformerEncoder class. This class will take MDETR text embeddings
and feed them through the transformer encoder. The main difference between this class
and the TorchText one is that the TorchText class includes embeddings as part of the encoder.

3) A class MDETRTextEncoder to stitch (1) and (2) together

We add a test for each of these three classes and compare to the result obtained when
loading directly from a pretrained MDETR checkpoint.

Similar to the image backbone commit, once the changes look good at a high level I will
add docstrings and the like.

Tested with
```
$ python -m pytest -v test/modules/encoders/test_mdetr_text_encoder.py
    test/modules/encoders/test_mdetr_text_encoder.py::TestMDETRTextEncoder::test_mdetr_text_embeddings PASSED
    test/modules/encoders/test_mdetr_text_encoder.py::TestMDETRTextEncoder::test_mdetr_text_encoder PASSED
    test/modules/encoders/test_mdetr_text_encoder.py::TestMDETRTextEncoder::test_mdetr_wrapped_transformer PASSED
```