### PR TITLE
Cnn encoder unittest

### DIFF
--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -49,7 +49,7 @@ class TestCNNEncoder(unittest.TestCase):
                 [1.377135, -1.410758, 1.394166],
             ]
         )
-        assert_expected(actual, expected)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
 
     def test_multiple_layer(self):
         input = torch.rand(3, 3, 8, 8)
@@ -58,7 +58,7 @@ class TestCNNEncoder(unittest.TestCase):
         expected = Tensor(
             [[-0.482730, -0.253406], [1.391524, 1.298026], [-0.908794, -1.044622]]
         )
-        assert_expected(actual, expected)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
 
     def test_fixed_weight_and_bias(self):
         cnn_encoder = CNNEncoder([1], [1], [2])
@@ -68,7 +68,7 @@ class TestCNNEncoder(unittest.TestCase):
         )
         actual = cnn_encoder(self.input)
         expected = Tensor([[-0.434959, 0.807781], [-1.429150, 1.056329]])
-        assert_expected(actual, expected)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
 
     def test_scripting(self):
         cnn_encoder = CNNEncoder([1], [1], [2])
@@ -79,4 +79,4 @@ class TestCNNEncoder(unittest.TestCase):
         scripted_encoder = torch.jit.script(cnn_encoder)
         actual = scripted_encoder(self.input)
         expected = Tensor([[-0.434959, 0.807781], [-1.429150, 1.056329]])
-        assert_expected(actual, expected)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -10,7 +10,7 @@ import torch
 from torch import nn, Tensor
 from test.test_utils import assert_expected
 from torchmultimodal.modules.encoders.cnn_encoder import CNNEncoder
-class TestCnnEncoder(unittest.TestCase):
+class TestCNNEncoder(unittest.TestCase):
     def setUp(self):
         self.input = Tensor(
             [

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -18,21 +18,18 @@ class TestCNNEncoder(unittest.TestCase):
                 [[1,3,5],[2,4,6]]
             ]
         ).unsqueeze(1)
+        self.input_dims = [0,1,2,3]
+        self.output_dims = [1,2,4,5]
+        self.kernel_sizes = [6,7,8,9]
 
     def test_invalid_arg_lengths(self):
-        input_dims = [1,2]
-        output_dims = [3,4,5]
-        kernel_sizes = [6,7,8]
         self.assertRaises(
-            AssertionError, CNNEncoder, input_dims, output_dims, kernel_sizes
+            AssertionError, CNNEncoder, self.input_dims[1:], self.output_dims, self.kernel_sizes
         )
 
     def test_invalid_output_dims(self):
-        input_dims = [0,1,2,3]
-        output_dims = [1,2,4,5]
-        kernel_sizes = [8,9,10,11]
         self.assertRaises(
-            AssertionError, CNNEncoder, input_dims, output_dims, kernel_sizes
+            AssertionError, CNNEncoder, self.input_dims, self.output_dims, self.kernel_sizes
         )
 
     def test_single_layer_output_shape(self):

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -31,6 +31,7 @@ class TestCnnEncoder(unittest.TestCase):
         input = torch.zeros(5,3,128,128)
         cnn_encoder = CNNEncoder([3],[3],[5])
         actual = cnn_encoder(input)
+        # expected size = (N, C * H/2 * W/2)
         expected = torch.zeros(5,12288)
         assert_expected(actual, expected)
 
@@ -41,6 +42,7 @@ class TestCnnEncoder(unittest.TestCase):
         for i in range(3):
             cnn_encoder.cnn[i][0].bias = zero_bias
         actual = cnn_encoder(input)
+        # expected size = (N, C * H/(2^3) * W/(2^3))
         expected = torch.zeros(5,768)
         assert_expected(actual, expected)
 

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -10,7 +10,6 @@ import torch
 from torch import nn, Tensor
 from test.test_utils import assert_expected
 from torchmultimodal.modules.encoders.cnn_encoder import CNNEncoder
-
 class TestCnnEncoder(unittest.TestCase):
     def test_invalid_arg_lengths(self):
         input_dims = [1,2]
@@ -44,3 +43,9 @@ class TestCnnEncoder(unittest.TestCase):
         actual = cnn_encoder(input)
         expected = torch.zeros(5,768)
         assert_expected(actual, expected)
+
+    def test_varying_dims_and_kernels(self):
+        input = torch.rand(5,3,128,128)
+        cnn_encoder = CNNEncoder([3,2,1],[2,1,2],[3,5,7])
+        out = cnn_encoder(input)
+        self.assertEqual(out.size(), torch.Size([5,512]))

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -7,81 +7,76 @@
 import unittest
 
 import torch
-from torch import nn, Tensor
 from test.test_utils import assert_expected, set_rng_seed
+from torch import nn, Tensor
 from torchmultimodal.modules.encoders.cnn_encoder import CNNEncoder
+
+
 class TestCNNEncoder(unittest.TestCase):
     def setUp(self):
         set_rng_seed(0)
-        self.input = Tensor(
-            [
-                [[1,2,3],[4,5,6]],
-                [[1,3,5],[2,4,6]]
-            ]
-        ).unsqueeze(1)
-        self.input_dims = [0,1,2,3]
-        self.output_dims = [1,2,4,5]
-        self.kernel_sizes = [6,7,8,9]
+        self.input = Tensor([1, 2, 3, 4, 5, 6, 1, 3, 5, 2, 4, 6]).reshape(2, 1, 2, 3)
+        self.input_dims = [0, 1, 2, 3]
+        self.output_dims = [1, 2, 4, 5]
+        self.kernel_sizes = [6, 7, 8, 9]
 
     def test_invalid_arg_lengths(self):
         self.assertRaises(
-            AssertionError, CNNEncoder, self.input_dims[1:], self.output_dims, self.kernel_sizes
+            AssertionError,
+            CNNEncoder,
+            self.input_dims[1:],
+            self.output_dims,
+            self.kernel_sizes,
         )
 
     def test_invalid_output_dims(self):
         self.assertRaises(
-            AssertionError, CNNEncoder, self.input_dims, self.output_dims, self.kernel_sizes
+            AssertionError,
+            CNNEncoder,
+            self.input_dims,
+            self.output_dims,
+            self.kernel_sizes,
         )
 
     def test_single_layer(self):
-        input = torch.rand(3,3,2,2)
-        cnn_encoder = CNNEncoder([3],[3],[5])
+        input = torch.rand(3, 3, 2, 2)
+        cnn_encoder = CNNEncoder([3], [3], [5])
         actual = cnn_encoder(input)
         expected = Tensor(
             [
-                [-0.452341,  0.680854, -0.557894],
-                [-0.924794,  0.729902, -0.836271],
-                [ 1.377135, -1.410758,  1.394166]
+                [-0.452341, 0.680854, -0.557894],
+                [-0.924794, 0.729902, -0.836271],
+                [1.377135, -1.410758, 1.394166],
             ]
         )
         assert_expected(actual, expected)
 
     def test_multiple_layer(self):
-        input = torch.rand(3,3,8,8)
-        cnn_encoder = CNNEncoder([3,2,1],[2,1,2],[3,5,7])
+        input = torch.rand(3, 3, 8, 8)
+        cnn_encoder = CNNEncoder([3, 2, 1], [2, 1, 2], [3, 5, 7])
         actual = cnn_encoder(input)
         expected = Tensor(
-            [
-                [-0.482730, -0.253406],
-                [ 1.391524,  1.298026],
-                [-0.908794, -1.044622]
-            ]
+            [[-0.482730, -0.253406], [1.391524, 1.298026], [-0.908794, -1.044622]]
         )
         assert_expected(actual, expected)
 
     def test_fixed_weight_and_bias(self):
-        cnn_encoder = CNNEncoder([1],[1],[2])
-        cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.]))
-        cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[1.,1.],[1.,1.]]).unsqueeze(0).unsqueeze(0))
-        actual = cnn_encoder(self.input)
-        expected = Tensor(
-            [
-                [-0.6324555, 0.6324555],
-                [-1.2649111, 1.2649111]
-            ]
+        cnn_encoder = CNNEncoder([1], [1], [2])
+        cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.5]))
+        cnn_encoder.cnn[0][0].weight = nn.Parameter(
+            Tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0).unsqueeze(0)
         )
+        actual = cnn_encoder(self.input)
+        expected = Tensor([[-0.434959, 0.807781], [-1.429150, 1.056329]])
         assert_expected(actual, expected)
 
     def test_scripting(self):
-        cnn_encoder = CNNEncoder([1],[1],[2])
-        cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.]))
-        cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[1.,1.],[1.,1.]]).unsqueeze(0).unsqueeze(0))
+        cnn_encoder = CNNEncoder([1], [1], [2])
+        cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.5]))
+        cnn_encoder.cnn[0][0].weight = nn.Parameter(
+            Tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0).unsqueeze(0)
+        )
         scripted_encoder = torch.jit.script(cnn_encoder)
         actual = scripted_encoder(self.input)
-        expected = Tensor(
-            [
-                [-0.6324555, 0.6324555],
-                [-1.2649111, 1.2649111]
-            ]
-        )
+        expected = Tensor([[-0.434959, 0.807781], [-1.429150, 1.056329]])
         assert_expected(actual, expected)

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+from torch import nn, Tensor
+from test.test_utils import assert_expected
 from torchmultimodal.modules.encoders.cnn_encoder import CNNEncoder
 
 class TestCnnEncoder(unittest.TestCase):
@@ -18,10 +20,27 @@ class TestCnnEncoder(unittest.TestCase):
             AssertionError, CNNEncoder, input_dims, output_dims, kernel_sizes
         )
 
-    def test_invalid_output_dim(self):
+    def test_invalid_output_dims(self):
         input_dims = [0,1,2,3]
         output_dims = [1,2,4,5]
         kernel_sizes = [8,9,10,11]
         self.assertRaises(
             AssertionError, CNNEncoder, input_dims, output_dims, kernel_sizes
         )
+
+    def test_single_layer_output_shape(self):
+        input = torch.zeros(5,3,128,128)
+        cnn_encoder = CNNEncoder([3],[3],[5])
+        actual = cnn_encoder(input)
+        expected = torch.zeros(5,12288)
+        assert_expected(actual, expected)
+
+    def test_multilayers_output_shape(self):
+        input = torch.zeros(5,3,128,128)
+        cnn_encoder = CNNEncoder([3,3,3],[3,3,3],[5,5,5])
+        zero_bias = nn.Parameter(Tensor([0.,0.,0.]))
+        for i in range(3):
+            cnn_encoder.cnn[i][0].bias = zero_bias
+        actual = cnn_encoder(input)
+        expected = torch.zeros(5,768)
+        assert_expected(actual, expected)

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -49,3 +49,42 @@ class TestCnnEncoder(unittest.TestCase):
         cnn_encoder = CNNEncoder([3,2,1],[2,1,2],[3,5,7])
         out = cnn_encoder(input)
         self.assertEqual(out.size(), torch.Size([5,512]))
+
+    def test_fixed_weight_and_bias(self):
+        input = Tensor(
+            [
+                [[[1,2,3],[4,5,6]]],
+                [[[1,3,5],[2,4,6]]]
+            ]
+        )
+        cnn_encoder = CNNEncoder([1],[1],[2])
+        cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.]))
+        cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[[[1.,1.],[1.,1.]]]]))
+        actual = cnn_encoder(input)
+        expected = Tensor(
+            [
+                [-0.6324555, 0.6324555],
+                [-1.2649111, 1.2649111]
+            ]
+        )
+        assert_expected(actual, expected)
+
+    def test_scripting(self):
+        input = Tensor(
+            [
+                [[[1,2,3],[4,5,6]]],
+                [[[1,3,5],[2,4,6]]]
+            ]
+        )
+        cnn_encoder = CNNEncoder([1],[1],[2])
+        cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.]))
+        cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[[[1.,1.],[1.,1.]]]]))
+        scripted_encoder = torch.jit.script(cnn_encoder)
+        actual = scripted_encoder(input)
+        expected = Tensor(
+            [
+                [-0.6324555, 0.6324555],
+                [-1.2649111, 1.2649111]
+            ]
+        )
+        assert_expected(actual, expected)

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from torchmultimodal.modules.encoders.cnn_encoder import CNNEncoder
+
+class TestCnnEncoder(unittest.TestCase):
+    def test_invalid_dim_lengths(self):
+        input_dims = [1,2]
+        output_dims = [3,4,5]
+        kernel_dims = [6,7,8]
+        self.assertRaises(
+            AssertionError, CNNEncoder, input_dims, output_dims, kernel_dims
+        )

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -10,10 +10,18 @@ import torch
 from torchmultimodal.modules.encoders.cnn_encoder import CNNEncoder
 
 class TestCnnEncoder(unittest.TestCase):
-    def test_invalid_dim_lengths(self):
+    def test_invalid_arg_lengths(self):
         input_dims = [1,2]
         output_dims = [3,4,5]
-        kernel_dims = [6,7,8]
+        kernel_sizes = [6,7,8]
         self.assertRaises(
-            AssertionError, CNNEncoder, input_dims, output_dims, kernel_dims
+            AssertionError, CNNEncoder, input_dims, output_dims, kernel_sizes
+        )
+
+    def test_invalid_output_dim(self):
+        input_dims = [0,1,2,3]
+        output_dims = [1,2,4,5]
+        kernel_sizes = [8,9,10,11]
+        self.assertRaises(
+            AssertionError, CNNEncoder, input_dims, output_dims, kernel_sizes
         )

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -61,7 +61,7 @@ class TestCnnEncoder(unittest.TestCase):
         )
         cnn_encoder = CNNEncoder([1],[1],[2])
         cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.]))
-        cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[[[1.,1.],[1.,1.]]]]))
+        cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[1.,1.],[1.,1.]]).unsqueeze(0).unsqueeze(0))
         actual = cnn_encoder(input)
         expected = Tensor(
             [
@@ -80,7 +80,7 @@ class TestCnnEncoder(unittest.TestCase):
         )
         cnn_encoder = CNNEncoder([1],[1],[2])
         cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.]))
-        cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[[[1.,1.],[1.,1.]]]]))
+        cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[1.,1.],[1.,1.]]).unsqueeze(0).unsqueeze(0))
         scripted_encoder = torch.jit.script(cnn_encoder)
         actual = scripted_encoder(input)
         expected = Tensor(

--- a/test/modules/encoders/test_cnn_encoder.py
+++ b/test/modules/encoders/test_cnn_encoder.py
@@ -11,6 +11,14 @@ from torch import nn, Tensor
 from test.test_utils import assert_expected
 from torchmultimodal.modules.encoders.cnn_encoder import CNNEncoder
 class TestCnnEncoder(unittest.TestCase):
+    def setUp(self):
+        self.input = Tensor(
+            [
+                [[1,2,3],[4,5,6]],
+                [[1,3,5],[2,4,6]]
+            ]
+        ).unsqueeze(1)
+
     def test_invalid_arg_lengths(self):
         input_dims = [1,2]
         output_dims = [3,4,5]
@@ -53,16 +61,10 @@ class TestCnnEncoder(unittest.TestCase):
         self.assertEqual(out.size(), torch.Size([5,512]))
 
     def test_fixed_weight_and_bias(self):
-        input = Tensor(
-            [
-                [[[1,2,3],[4,5,6]]],
-                [[[1,3,5],[2,4,6]]]
-            ]
-        )
         cnn_encoder = CNNEncoder([1],[1],[2])
         cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.]))
         cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[1.,1.],[1.,1.]]).unsqueeze(0).unsqueeze(0))
-        actual = cnn_encoder(input)
+        actual = cnn_encoder(self.input)
         expected = Tensor(
             [
                 [-0.6324555, 0.6324555],
@@ -72,17 +74,11 @@ class TestCnnEncoder(unittest.TestCase):
         assert_expected(actual, expected)
 
     def test_scripting(self):
-        input = Tensor(
-            [
-                [[[1,2,3],[4,5,6]]],
-                [[[1,3,5],[2,4,6]]]
-            ]
-        )
         cnn_encoder = CNNEncoder([1],[1],[2])
         cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.]))
         cnn_encoder.cnn[0][0].weight = nn.Parameter(Tensor([[1.,1.],[1.,1.]]).unsqueeze(0).unsqueeze(0))
         scripted_encoder = torch.jit.script(cnn_encoder)
-        actual = scripted_encoder(input)
+        actual = scripted_encoder(self.input)
         expected = Tensor(
             [
                 [-0.6324555, 0.6324555],

--- a/torchmultimodal/modules/encoders/cnn_encoder.py
+++ b/torchmultimodal/modules/encoders/cnn_encoder.py
@@ -36,6 +36,8 @@ class CNNEncoder(nn.Module):
         assert len(input_dims) == len(output_dims) and len(output_dims) == len(
             kernel_sizes
         ), "input_dims, output_dims, and kernel_sizes should all have the same length"
+        assert input_dims[1:] == output_dims[:-1], \
+            "output_dims should match input_dims offset by one"
         for in_channels, out_channels, kernel_size in zip(
             input_dims,
             output_dims,

--- a/torchmultimodal/modules/encoders/cnn_encoder.py
+++ b/torchmultimodal/modules/encoders/cnn_encoder.py
@@ -36,8 +36,9 @@ class CNNEncoder(nn.Module):
         assert len(input_dims) == len(output_dims) and len(output_dims) == len(
             kernel_sizes
         ), "input_dims, output_dims, and kernel_sizes should all have the same length"
-        assert input_dims[1:] == output_dims[:-1], \
-            "output_dims should match input_dims offset by one"
+        assert (
+            input_dims[1:] == output_dims[:-1]
+        ), "output_dims should match input_dims offset by one"
         for in_channels, out_channels, kernel_size in zip(
             input_dims,
             output_dims,


### PR DESCRIPTION
Summary:
<!-- Change Summary -->
* add assertion in `cnn_encoder.py` to check `output_dims` match `input_dims` offset by 1
* add unit tests in `test_cnn_encoder.py` for invalid, single layer, and multilayer args. 

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
* all unit tests passed

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
