### PR TITLE
re-factor the inputs in weighted embedding encoder

### DIFF
--- a/test/modules/encoders/test_weighted_embedding_encoder.py
+++ b/test/modules/encoders/test_weighted_embedding_encoder.py
@@ -20,10 +20,7 @@ class TestEmbeddingEncoder(unittest.TestCase):
         embedding_weights = torch.Tensor(
             [
                 [1, 1],
-                [
-                    2,
-                    2,
-                ],
+                [2, 2],
                 [1, 0],
             ]
         )
@@ -32,8 +29,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
     def test_forward_sum_pooling(self):
         input = torch.Tensor(
             [
-                [1, 0, 0.25, 0.75],
-                [0, 1, 0.6, 0.4],
+                [0.25, 0.75, 0],
+                [0.6, 0, 0.4],
             ]
         )
         weighted_embedding_encoder = WeightedEmbeddingEncoder(
@@ -42,8 +39,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
         actual = weighted_embedding_encoder(input)
         expected = torch.Tensor(
             [
-                [1.25, 1.25],
-                [1.4, 1.4],
+                [1.75, 1.75],
+                [1.0, 0.6],
             ]
         )
         assert_expected(actual, expected)
@@ -51,8 +48,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
     def test_forward_mean_pooling(self):
         input = torch.Tensor(
             [
-                [1, 0, 0.25, 0.75],
-                [0, 1, 0.6, 0.4],
+                [0.25, 0.75, 0],
+                [0.6, 0, 0.4],
             ]
         )
         weighted_embedding_encoder = WeightedEmbeddingEncoder(
@@ -61,8 +58,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
         actual = weighted_embedding_encoder(input)
         expected = torch.Tensor(
             [
-                [0.625, 0.625],
-                [0.7, 0.7],
+                [1.75 / 3, 1.75 / 3],
+                [1.0 / 3, 0.2],
             ]
         )
         assert_expected(actual, expected)
@@ -70,8 +67,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
     def test_forward_max_pooling(self):
         input = torch.Tensor(
             [
-                [1, 0, 0.25, 0.75],
-                [0, 1, 0.6, 0.4],
+                [0.25, 0.75, 0],
+                [0.6, 0, 0.4],
             ]
         )
         weighted_embedding_encoder = WeightedEmbeddingEncoder(
@@ -80,8 +77,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
         actual = weighted_embedding_encoder(input)
         expected = torch.Tensor(
             [
-                [0.75, 0.75],
-                [0.8, 0.8],
+                [1.5, 1.5],
+                [0.6, 0.6],
             ]
         )
         assert_expected(actual, expected)
@@ -89,8 +86,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
     def test_forward_hash_no_padding(self):
         input = torch.Tensor(
             [
-                [1, 3, 0.25, 0.75],
-                [6, 1, 0.6, 0.4],
+                [0.2, 0.7, 0, 0.1],
+                [0.3, 0, 0.4, 0.3],
             ]
         )
         weighted_embedding_encoder = WeightedEmbeddingEncoder(
@@ -99,8 +96,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
         actual = weighted_embedding_encoder(input)
         expected = torch.Tensor(
             [
-                [0.75, 0.75],
-                [0.8, 0.8],
+                [1.4, 1.4],
+                [0.4, 0.3],
             ]
         )
         assert_expected(actual, expected)
@@ -108,8 +105,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
     def test_forward_hash_zero_padding(self):
         input = torch.Tensor(
             [
-                [0, 1, 0.25, 0.75],
-                [6, 1, 0.6, 0.4],
+                [0.2, 0.7, 0, 0.1],
+                [0.3, 0, 0.4, 0.3],
             ]
         )
         embedding = deepcopy(self.embedding)
@@ -120,8 +117,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
         actual = weighted_embedding_encoder(input)
         expected = torch.Tensor(
             [
-                [1.75, 1.75],
-                [1.4, 0.8],
+                [1.8, 1.8],
+                [1.3, 0.9],
             ]
         )
         assert_expected(actual, expected)
@@ -136,8 +133,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
     def test_scripting(self):
         input = torch.Tensor(
             [
-                [1, 0, 0.25, 0.75],
-                [0, 1, 0.6, 0.4],
+                [0.25, 0.75, 0],
+                [0.6, 0, 0.4],
             ]
         )
         weighted_embedding_encoder = WeightedEmbeddingEncoder(
@@ -147,8 +144,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
         actual = scripted_encoder(input)
         expected = torch.Tensor(
             [
-                [0.625, 0.625],
-                [0.7, 0.7],
+                [1.75 / 3, 1.75 / 3],
+                [1.0 / 3, 0.2],
             ]
         )
         assert_expected(actual, expected)

--- a/torchmultimodal/modules/encoders/weighted_embedding_encoder.py
+++ b/torchmultimodal/modules/encoders/weighted_embedding_encoder.py
@@ -23,8 +23,7 @@ class WeightedEmbeddingEncoder(nn.Module):
         before embedding layer
 
     Inputs:
-        x (Tensor): Tensor bsz x len where first half (0 : len/2) of tensor are embedding indices
-        and the second half are corresponding weights for the embedding indices
+        weights (Tensor): Tensor containing weights
 
     """
 
@@ -47,13 +46,8 @@ class WeightedEmbeddingEncoder(nn.Module):
         self.pooling_dim = pooling_dim
         self.use_hash = use_hash
 
-    def forward(self, x: Tensor) -> Tensor:
-        index, weights = torch.split(
-            x,
-            int(x.size()[1] / 2),
-            dim=1,
-        )
-        index = index.long()
+    def forward(self, weights: Tensor) -> Tensor:
+        index = torch.arange(0, weights.size(1), dtype=torch.int)
         if self.use_hash:
             # TODO: pull this out into a common function T111523602
             if self.embedding.padding_idx is None:


### PR DESCRIPTION
Summary:
- previously, the encoder enforced the input tensor to consist of both indices and weights
- the new refactor makes an assumption that embedding indices correspond to the weight positions in the weight tensor (i.e. the standalone `weights` tensor is sufficient)
    - this also implies that the weight order is preserved across examples and batches

Differential Revision: D36898016

