### PR TITLE
[Test] Change test_shift_dim to use pytest

### DIFF
--- a/test/utils/test_common.py
+++ b/test/utils/test_common.py
@@ -4,27 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-
 import torch
 from test.test_utils import assert_expected
 
 from torchmultimodal.utils.common import shift_dim
 
 
-class TestCommonUtils(unittest.TestCase):
-    """
-    Test the utils in common.py
-    """
+def test_shift_dim():
+    test_random_tensor = torch.randn(2, 2, 2, 2, 2)
+    actual = shift_dim(test_random_tensor, 1, -1)
+    expected = test_random_tensor.permute(0, 2, 3, 4, 1).contiguous()
+    assert_expected(actual, expected)
 
-    def setUp(self):
-        self.test_random_tensor = torch.randn(2, 2, 2, 2, 2)
-
-    def test_shift_dim(self):
-        actual = shift_dim(self.test_random_tensor, 1, -1)
-        expected = self.test_random_tensor.permute(0, 2, 3, 4, 1).contiguous()
-        assert_expected(actual, expected)
-
-        actual = shift_dim(self.test_random_tensor, -3, 3)
-        expected = self.test_random_tensor.permute(0, 1, 3, 2, 4).contiguous()
-        assert_expected(actual, expected)
+    actual = shift_dim(test_random_tensor, -3, 3)
+    expected = test_random_tensor.permute(0, 1, 3, 2, 4).contiguous()
+    assert_expected(actual, expected)


### PR DESCRIPTION
Summary:
- Change the test framework to align with the other tests (see next PR) in the same file

Test Plan:
```
(torchmm) langong-mbp:gpt_attention langong$ python -m pytest --cov=torchmultimodal/utils/ test/utils/test_common.py -k "test_shift_dim"

Name                                Stmts   Miss  Cover
-------------------------------------------------------
torchmultimodal/utils/__init__.py       0      0   100%
torchmultimodal/utils/common.py        66     28    58%
torchmultimodal/utils/file_io.py       10      3    70%
-------------------------------------------------------
TOTAL                                  76     31    59%


=========== 1 passed, 5 deselected in 1.33s ===============
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84
* #69
* __->__ #68
* #67

Differential Revision: [D37100722](https://our.internmc.facebook.com/intern/diff/D37100722)