### PR TITLE
[MUGEN]Spatialtemporal position embedding;tensor slicing utility

### DIFF
--- a/test/modules/layers/test_attention.py
+++ b/test/modules/layers/test_attention.py
@@ -1,0 +1,147 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+import torch
+from test.test_utils import assert_expected
+from torchmultimodal.modules.layers.attention import BroadcastPositionEmbedding
+
+
+@pytest.fixture(scope="class")
+def build_pos_emb():
+    def _build_pos_emb(dim, shape=torch.Size([1, 2]), embedding_dim=6):
+        return BroadcastPositionEmbedding(
+            shape=shape,
+            embedding_dim=embedding_dim,
+            dim=dim,
+        )
+
+    return _build_pos_emb
+
+
+class TestBroadcastPositionEmbedding:
+
+    TEST_BROADCAST_DATA = [
+        (
+            -1,
+            [
+                torch.tensor([[0.0, 1.0, 2.0]]),
+                torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 8]]),
+            ],
+            [
+                torch.tensor([[[[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]]]),
+                torch.tensor([[[[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]]),
+            ],
+        ),
+        (
+            1,
+            [
+                torch.tensor([[0.0], [1.0], [2.0]]),
+                torch.tensor([[3.0, 6.0], [4.0, 7.0], [5.0, 8.0]]),
+            ],
+            [
+                torch.tensor([[[[0.0, 0.0]], [[1.0, 1.0]], [[2.0, 2.0]]]]),
+                torch.tensor([[[[3.0, 6.0]], [[4.0, 7.0]], [[5.0, 8.0]]]]),
+            ],
+        ),
+    ]
+
+    TEST_DECODE_DATA = [
+        (
+            -1,
+            torch.tensor([1, 2, 6]),
+            torch.tensor(
+                [[[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]]]]
+            ),
+            [
+                torch.tensor([[[[7.0, 8.0, 9.0, 10.0, 11.0, 12.0]]]]),
+                torch.tensor([[[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]]]]),
+            ],
+        ),
+        (
+            1,
+            torch.tensor([1, 6, 2]),
+            torch.tensor(
+                [
+                    [
+                        [[0.0, 7.0]],
+                        [[1.0, 8.0]],
+                        [[2.0, 9.0]],
+                        [[3.0, 10.0]],
+                        [[4.0, 11.0]],
+                        [[5.0, 12.0]],
+                    ]
+                ]
+            ),
+            [
+                torch.tensor(
+                    [[[[7.0]], [[8.0]], [[9.0]], [[10.0]], [[11.0]], [[12.0]]]]
+                ),
+                torch.tensor([[[[0.0]], [[1.0]], [[2.0]], [[3.0]], [[4.0]], [[5.0]]]]),
+            ],
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        "dim, expected",
+        [
+            (-1, [torch.Size([1, 3]), torch.Size([2, 3])]),
+            (1, [torch.Size([3, 1]), torch.Size([3, 2])]),
+        ],
+    )
+    def test_init_sets_embedding(self, dim, expected, build_pos_emb):
+        """Test the embeddings are initialized with the correct dimensions"""
+        pos_emb = build_pos_emb(dim)
+        for i, (key, _) in enumerate(pos_emb.embedding.items()):
+            assert_expected(pos_emb.embedding[key].shape, expected[i])
+
+    def test_init_bad_dim(self, build_pos_emb):
+        """Test raising error when the embedding is given at an illegal location"""
+        with pytest.raises(ValueError):
+            build_pos_emb(dim=-2)
+
+    def test_init_bad_embedding_dim(self, build_pos_emb):
+        """Test raising error when the embedding dim is not allowed"""
+        with pytest.raises(ValueError):
+            build_pos_emb(dim=-1, embedding_dim=5)
+
+    def test_seq_len(self, build_pos_emb):
+        pos_emb = build_pos_emb(-1)
+        assert_expected(pos_emb.seq_len, 2)
+
+    @pytest.mark.parametrize("dim, embedding, expected", TEST_BROADCAST_DATA)
+    def test_broadcast(self, dim, embedding, expected, build_pos_emb):
+        """Test embedding along each dim is broadcasted correctly"""
+        pos_emb = build_pos_emb(dim)
+        for i, emb in enumerate(embedding):
+            assert_expected(pos_emb._broadcast(emb, i), expected[i])
+
+    @pytest.mark.parametrize(
+        "dim, x_shape, embedding_broadcast, expected", TEST_DECODE_DATA
+    )
+    def test_decode(self, dim, x_shape, embedding_broadcast, expected, build_pos_emb):
+        """Test the embedding at a previous location is selected for each decode step"""
+        pos_emb = build_pos_emb(dim)
+        for decode_step, _ in enumerate(pos_emb.decode_idxs):
+            actual = pos_emb._decode(decode_step, embedding_broadcast, x_shape)
+            assert_expected(actual, expected[decode_step])
+
+    @pytest.mark.parametrize(
+        "dim, expected", [(-1, torch.Size([1, 2, 6])), (1, torch.Size([1, 6, 2]))]
+    )
+    def test_forward(self, dim, expected, build_pos_emb):
+        pos_emb = build_pos_emb(dim)
+        assert_expected(pos_emb().shape, expected)
+
+    def test_forward_decode(self, build_pos_emb):
+        """Test the decode statement inside ``forward`` is hit when ``decode_step`` is given"""
+        pos_emb = build_pos_emb(dim=-1)
+        x = torch.zeros(1, *(pos_emb.shape), pos_emb.embedding_dim).flatten(
+            start_dim=1, end_dim=-2
+        )
+        actual = pos_emb(x, decode_step=0).shape
+        expected = torch.Size([1, 1, 6])
+        assert_expected(actual, expected)

--- a/test/utils/test_common.py
+++ b/test/utils/test_common.py
@@ -3,11 +3,12 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import pytest
 
 import torch
 from test.test_utils import assert_expected
 
-from torchmultimodal.utils.common import shift_dim
+from torchmultimodal.utils.common import shift_dim, tensor_slice
 
 
 def test_shift_dim():
@@ -19,3 +20,41 @@ def test_shift_dim():
     actual = shift_dim(test_random_tensor, -3, 3)
     expected = test_random_tensor.permute(0, 1, 3, 2, 4).contiguous()
     assert_expected(actual, expected)
+
+
+@pytest.fixture(scope="class")
+def test_input():
+    return torch.tensor([[[0, 1], [2, 3], [5, 6]]])
+
+
+class TestTensorSlice:
+    def test_default(self, test_input):
+        actual = tensor_slice(test_input, [0, 1, 0], [1, 1, 2])
+        expected = torch.tensor([[[2, 3]]])
+        assert_expected(actual, expected)
+
+    def test_size_minus_one(self, test_input):
+        """Test size -1"""
+        actual = tensor_slice(test_input, [0, 1, 0], [1, -1, 2])
+        expected = torch.tensor([[[2, 3], [5, 6]]])
+        assert_expected(actual, expected)
+
+    def test_uneven_begin_size(self, test_input):
+        """Test uneven begin and size vectors"""
+        actual = tensor_slice(test_input, [0, 1, 0], [1, 1])
+        expected = torch.tensor([[[2, 3], [5, 6]]])
+        expected = torch.tensor([[[2, 3]]])
+        assert_expected(actual, expected)
+
+        actual = tensor_slice(test_input, [0, 1], [1, 1, 2])
+        expected = torch.tensor([[[2, 3], [5, 6]]])
+        expected = torch.tensor([[[2, 3]]])
+        assert_expected(actual, expected)
+
+    @pytest.mark.xfail(raises=ValueError, reason="Invalid begin")
+    def test_invalid_begin(self, test_input):
+        tensor_slice(test_input, [-1, 1, 0], [1, 1, 2])
+
+    @pytest.mark.xfail(raises=ValueError, reason="Invalid size")
+    def test_invalid_size(self, test_input):
+        tensor_slice(test_input, [0, 1, 0], [-2, 1, 2])

--- a/torchmultimodal/modules/layers/attention.py
+++ b/torchmultimodal/modules/layers/attention.py
@@ -1,0 +1,143 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import itertools
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+import torch
+import torch.nn as nn
+
+from torchmultimodal.utils.common import tensor_slice
+
+
+class BroadcastPositionEmbedding(nn.Module):
+    r"""Spatiotemporal broadcasted positional embeddings.
+
+    Each embedding vector of the ``i``-th dim is repeated by ``N`` times, where
+    :math:`N = \prod_{j>i}\text{dim}[j]`.
+
+    Args:
+        shape (torch.Size): shape of raw data before batching and embedding
+        embedding_dim (int): the size of each embedding vector
+        dim (Optional[int]): dimension of embedding w.r.t. the other dimensions of batched data, e.g., ``-1``
+            corresponds to embedding being the last dimension. Default is ``-1``.
+
+    Raises:
+        ValueError: if ``dim`` is neither ``-1`` nor ``1``
+        ValueError: if ``embedding_dim`` is not an integer multiple of ``len(shape)``
+
+    Inputs:
+        x (Optional[torch.Tensor]): flattened input data, e.g., ``(batch, time * height * width, embedding_dim)``
+            if ``dim=-1``.
+        decode_step (Optional[int]): position of the data that requires decoding.
+    """
+
+    def __init__(
+        self, shape: torch.Size, embedding_dim: int, dim: Optional[int] = -1
+    ) -> None:
+        super().__init__()
+        if dim not in [-1, 1]:
+            raise ValueError(
+                f"Only first or last for the embedding dim is supported but got {dim}"
+            )
+        if embedding_dim % len(shape) != 0:
+            raise ValueError(
+                f"Embedding dim {embedding_dim} modulo len(shape) {len(shape)} is not zero"
+            )
+
+        self.shape = shape
+        self.n_dim = n_dim = len(shape)
+        self.embedding_dim = embedding_dim
+        self.dim = dim
+
+        self.embedding = nn.ParameterDict(
+            {
+                f"d_{i}": nn.Parameter(
+                    torch.randn(shape[i], embedding_dim // n_dim) * 0.01
+                    if dim == -1
+                    else torch.randn(embedding_dim // n_dim, shape[i]) * 0.01
+                )
+                for i in range(n_dim)
+            }
+        )
+
+    @property
+    def seq_len(self) -> int:
+        """Dimension of flattened data, e.g., time * height * width"""
+        return np.prod(self.shape)
+
+    @property
+    def decode_idxs(self) -> List[Tuple[int]]:
+        """Indices along the dims of data, e.g., ``(time, height, width)``."""
+        return list(itertools.product(*[range(s) for s in self.shape]))
+
+    def _broadcast(self, emb: torch.Tensor, i: int) -> torch.Tensor:
+        """Broadcasts the ``i``-th embedding matrix ``(self.shape[i], self.embedding_dim // n_dim)`` along the other
+        dims of ``self.shape``. The embedding dim is kept at ``self.dim``.
+
+        For example::
+
+            >>> pos_emb = BroadcastPositionEmbedding(shape=(2, 4), embedding_dim=6)
+            >>> print(pos_emb.embedding["d_0"]).shape
+            torch.Size([2, 3])
+            >>> out = pos_emb._broadcast(torch.tensor([[0, 0, 0],[0, 0, 1]]), i=0)
+            >>> print(out)
+            tensor([[[[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+                    [[0, 0, 1], [0, 0, 1], [0, 0, 1], [0, 0, 1]]]])
+
+        The input is broadcasted along dim ``4`` since it's the ``0``-th embedding constructed w.r.t dim ``2``.
+        """
+        if self.dim == -1:
+            # (1, 1, ..., 1, self.shape[i], 1, ..., -1)
+            emb = emb.view(
+                1, *((1,) * i), self.shape[i], *((1,) * (self.n_dim - i - 1)), -1
+            )
+            # (1, *self.shape, -1)
+            emb = emb.expand(1, *self.shape, -1)
+        else:
+            emb = emb.view(
+                1, -1, *((1,) * i), self.shape[i], *((1,) * (self.n_dim - i - 1))
+            )
+            emb = emb.expand(1, -1, *self.shape)
+
+        return emb
+
+    def _decode(
+        self, decode_step: int, embeddings: torch.Tensor, x_shape: torch.Size
+    ) -> torch.Tensor:
+        """Returns the embedding vector immediately before the decoding location."""
+        decode_idx = self.decode_idxs[decode_step - 1]
+        if self.dim == -1:
+            embeddings = tensor_slice(
+                embeddings,
+                [0, *decode_idx, 0],
+                [x_shape[0], *(1,) * self.n_dim, x_shape[-1]],
+            )
+        elif self.dim == 1:
+            embeddings = tensor_slice(
+                embeddings,
+                [0, 0, *decode_idx],
+                [x_shape[0], x_shape[1], *(1,) * self.n_dim],
+            )
+
+        return embeddings
+
+    def forward(
+        self, x: Optional[torch.Tensor] = None, decode_step: Optional[int] = None
+    ) -> torch.Tensor:
+        embeddings = []
+        for i in range(self.n_dim):
+            emb = self.embedding[f"d_{i}"]
+            emb = self._broadcast(emb, i)
+            embeddings.append(emb)
+
+        embeddings = torch.cat(embeddings, dim=self.dim)
+
+        if decode_step is not None:
+            embeddings = self._decode(decode_step, embeddings, x.shape)
+
+        return embeddings.flatten(start_dim=1, end_dim=-2)

--- a/torchmultimodal/modules/layers/attention.py
+++ b/torchmultimodal/modules/layers/attention.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import itertools
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -71,7 +71,7 @@ class BroadcastPositionEmbedding(nn.Module):
         return np.prod(self.shape)
 
     @property
-    def decode_idxs(self) -> List[Tuple[int]]:
+    def decode_idxs(self):
         """Indices along the dims of data, e.g., ``(time, height, width)``."""
         return list(itertools.product(*[range(s) for s in self.shape]))
 

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -8,7 +8,7 @@ import hashlib
 import os
 from collections import OrderedDict
 from dataclasses import fields
-from typing import Optional
+from typing import List, Optional
 
 import torch
 from torch import Tensor
@@ -63,6 +63,36 @@ def shift_dim(
     if make_contiguous:
         x = x.contiguous()
     return x
+
+
+def tensor_slice(x: Tensor, begin: List[int], size: List[int]) -> Tensor:
+    """Slices a tensor dimension-wise.
+
+    The input tensor is sliced at each dimension by specifying the start and
+    the increments.
+
+    Args:
+        x (Tensor): tensor to be sliced.
+        begin (List[int]): list of starts corresponding to each dimension.
+        size (List[int]): list of increments with respect to the starts for each
+            dimension.
+
+    Returns:
+        The sliced tensor.
+
+    Raises:
+        ValueError: if any of ``begin`` indices is negative
+        ValueError: if any of ``size`` is less than ``-1``
+    """
+    if not all([b >= 0 for b in begin]):
+        raise ValueError("All starting indices must be non-negative.")
+    if not all([s >= -1 for s in size]):
+        raise ValueError("All sizes must be either non-negative or -1.")
+
+    size = [l - b if s == -1 else s for s, b, l in zip(size, begin, x.shape)]
+
+    slices = [slice(b, b + s) for b, s in zip(begin, size)]
+    return x[slices]
 
 
 class PretrainedMixin:


### PR DESCRIPTION
Summary:
- Spatial-temporal position embedding is the first layer of the multimodal GPT attention stack
- Refactor [`AddBroadcastEmbedding`](https://github.com/mugen-org/MUGEN_baseline/blob/main/lib/models/gpt/attention.py#L256) and the associated utility [`tesor_slice`](https://github.com/mugen-org/MUGEN_baseline/blob/main/lib/models/gpt/utils.py#L75)
- Use `pytest` to perform parametrized tests, test setup and etc. as the starting point to migrate our testing framework away from python `unittest`.

Test Plan:
```
(torchmm) langong-mbp:gpt_attention langong$ python -m pytest --cov=torchmultimodal/modules/layers test/modules/layers/test_position_embedding.py
================================================================================ test session starts =================================================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/langong/gpt_attention
plugins: cov-3.0.0
collected 7 items

test/modules/layers/test_position_embedding.py .......                                                                                                                         [100%]

---------- coverage: platform darwin, python 3.8.13-final-0 ----------
Name                                                   Stmts   Miss  Cover
--------------------------------------------------------------------------
torchmultimodal/modules/layers/attention.py               97     97     0%
torchmultimodal/modules/layers/codebook.py                81     81     0%
torchmultimodal/modules/layers/conv.py                    74     74     0%
torchmultimodal/modules/layers/mlp.py                     22     22     0%
torchmultimodal/modules/layers/normalizations.py           7      7     0%
torchmultimodal/modules/layers/position_embedding.py      38      0   100%
torchmultimodal/modules/layers/transformer.py            133    133     0%
--------------------------------------------------------------------------
TOTAL                                                    452    414     8%


====================== 7 passed in 2.38s ==================
```

```
(torchmm) langong-mbp:gpt_attention langong$ python -m pytest --cov=torchmultimodal/utils/ test/utils/test_common.py -vv
================================================================================ test session starts =================================================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/langong/local/miniconda3/envs/torchmm/bin/python
cachedir: .pytest_cache
rootdir: /Users/langong/gpt_attention
plugins: cov-3.0.0
collected 6 items

test/utils/test_common.py::test_shift_dim PASSED                                                                                                                               [ 16%]
test/utils/test_common.py::TestTensorSlice::test_default PASSED                                                                                                                [ 33%]
test/utils/test_common.py::TestTensorSlice::test_size_minus_one PASSED                                                                                                         [ 50%]
test/utils/test_common.py::TestTensorSlice::test_uneven_begin_size PASSED                                                                                                      [ 66%]
test/utils/test_common.py::TestTensorSlice::test_invalid_begin XFAIL (Invalid begin)                                                                                           [ 83%]
test/utils/test_common.py::TestTensorSlice::test_invalid_size XFAIL (Invalid size)                                                                                             [100%]

---------- coverage: platform darwin, python 3.8.13-final-0 ----------
Name                                Stmts   Miss  Cover
-------------------------------------------------------
torchmultimodal/utils/__init__.py       0      0   100%
torchmultimodal/utils/common.py        66     21    68%
torchmultimodal/utils/file_io.py       10      3    70%
-------------------------------------------------------
TOTAL                                  76     24    68%


===================== 4 passed, 2 xfailed in 1.41s ============================
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84
* __->__ #69
* #68
* #67

Differential Revision: [D37100730](https://our.internmc.facebook.com/intern/diff/D37100730)