### PR TITLE
[MUGEN] Add multihead full/axial attention

### DIFF
--- a/test/modules/layers/test_attention.py
+++ b/test/modules/layers/test_attention.py
@@ -36,7 +36,7 @@ class TestAttention(unittest.TestCase):
             1, self.n_heads, *self.input_shape, self.hidden_dim // self.n_heads
         )
         self.full = FullAttention(self.input_shape, causal=False, attn_dropout=0.0)
-        self.ax = AxialAttention(3, 2)  # only on third axis of input
+        self.ax = AxialAttention(3, 1)  # only on second axis of input
         self.mha = MultiHeadAttention(
             self.input_shape,
             self.hidden_dim,
@@ -96,12 +96,12 @@ class TestAttention(unittest.TestCase):
                 [
                     [
                         [
-                            [[0.7199, 2.2441, -0.7576], [0.4518, 1.5191, -0.2356]],
-                            [[-1.1097, -0.1524, 0.3367], [0.0885, -0.2590, 0.4254]],
+                            [[0.8644, 2.3747, -0.8809], [-0.7204, 0.0344, 0.4795]],
+                            [[0.8348, 2.4704, -0.9301], [-0.5203, 0.0964, 0.5355]],
                         ],
                         [
-                            [[-0.1849, 0.3928, 0.3666], [-0.5445, 0.0442, -0.0061]],
-                            [[0.8435, -1.4510, -1.1567], [0.2037, -0.9690, -0.4564]],
+                            [[-0.7800, -0.5387, -0.4397], [0.7498, -1.2456, -0.9972]],
+                            [[-0.7235, -0.5575, -0.4205], [0.7629, -1.2702, -1.0178]],
                         ],
                     ]
                 ]

--- a/test/modules/layers/test_attention.py
+++ b/test/modules/layers/test_attention.py
@@ -25,7 +25,7 @@ class TestAttention(unittest.TestCase):
         set_rng_seed(4)
         self.hidden_dim = 3
         self.n_heads = 1
-        self.input_shape = torch.tensor((2, 2, 2))
+        self.input_shape = (2, 2, 2)
         self.q = torch.randn(
             1, self.n_heads, *self.input_shape, self.hidden_dim // self.n_heads
         )
@@ -36,7 +36,7 @@ class TestAttention(unittest.TestCase):
             1, self.n_heads, *self.input_shape, self.hidden_dim // self.n_heads
         )
         self.full = FullAttention(self.input_shape, causal=False, attn_dropout=0.0)
-        self.ax = AxialAttention(3, 1)  # only on second axis of input
+        self.ax = AxialAttention(1)  # only on second axis of input
         self.mha = MultiHeadAttention(
             self.input_shape,
             self.hidden_dim,

--- a/test/modules/layers/test_attention.py
+++ b/test/modules/layers/test_attention.py
@@ -1,0 +1,146 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.layers.attention import (
+    AxialAttention,
+    FullAttention,
+    MultiHeadAttention,
+    scaled_dot_product_attention,
+)
+
+
+class TestAttention(unittest.TestCase):
+    """
+    Test all Attention classes
+    """
+
+    def setUp(self):
+        set_rng_seed(4)
+        self.hidden_dim = 3
+        self.n_heads = 1
+        self.input_shape = torch.tensor((2, 2, 2))
+        self.q = torch.randn(
+            1, self.n_heads, *self.input_shape, self.hidden_dim // self.n_heads
+        )
+        self.k = torch.randn(
+            1, self.n_heads, *self.input_shape, self.hidden_dim // self.n_heads
+        )
+        self.v = torch.randn(
+            1, self.n_heads, *self.input_shape, self.hidden_dim // self.n_heads
+        )
+        self.full = FullAttention(self.input_shape, causal=False, attn_dropout=0.0)
+        self.ax = AxialAttention(3, 2)  # only on third axis of input
+        self.mha = MultiHeadAttention(
+            self.input_shape,
+            self.hidden_dim,
+            self.hidden_dim,
+            self.n_heads,
+            1,
+            causal=False,
+            attn_module=self.full,
+        )
+
+    def test_scaled_dot_product_attention(self):
+        actual = scaled_dot_product_attention(self.q, self.k, self.v)
+        expected = torch.tensor(
+            [
+                [
+                    [
+                        [
+                            [[0.7199, 2.2441, -0.7576], [0.4518, 1.5191, -0.2356]],
+                            [[-1.1097, -0.1524, 0.3367], [0.0885, -0.2590, 0.4254]],
+                        ],
+                        [
+                            [[-0.1849, 0.3928, 0.3666], [-0.5445, 0.0442, -0.0061]],
+                            [[0.8435, -1.4510, -1.1567], [0.2037, -0.9690, -0.4564]],
+                        ],
+                    ]
+                ]
+            ]
+        )
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_full_attention(self):
+        actual = self.full(self.q, self.k, self.v)
+        # Output of full attention should be same as scaled_dot_product_attention
+        # since input dims are flattened
+        expected = torch.tensor(
+            [
+                [
+                    [
+                        [
+                            [[0.4130, 0.5607, -0.6003], [0.1206, -0.0833, -0.1378]],
+                            [[0.5494, -0.1801, -0.8837], [0.3011, 0.7369, -0.2519]],
+                        ],
+                        [
+                            [[0.1344, 0.5524, 0.0436], [0.6117, 0.6719, -0.8588]],
+                            [[0.1731, 0.8062, 0.0261], [-0.2240, -0.5229, -0.2820]],
+                        ],
+                    ]
+                ]
+            ]
+        )
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_axial_attention(self):
+        actual = self.ax(self.q, self.k, self.v)
+        expected = torch.tensor(
+            [
+                [
+                    [
+                        [
+                            [[0.7199, 2.2441, -0.7576], [0.4518, 1.5191, -0.2356]],
+                            [[-1.1097, -0.1524, 0.3367], [0.0885, -0.2590, 0.4254]],
+                        ],
+                        [
+                            [[-0.1849, 0.3928, 0.3666], [-0.5445, 0.0442, -0.0061]],
+                            [[0.8435, -1.4510, -1.1567], [0.2037, -0.9690, -0.4564]],
+                        ],
+                    ]
+                ]
+            ]
+        )
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_split_multihead(self):
+        x = torch.randn(1, *self.input_shape, 6)
+        self.mha.n_head = 2
+        out = self.mha._split_multihead(x)
+        actual = torch.tensor(out.shape)
+        expected = torch.tensor((1, 2, *self.input_shape, 3))
+        assert_expected(actual, expected)
+
+    def test_combine_multihead(self):
+        out = self.mha._combine_multihead(self.q)
+        actual = torch.tensor(out.shape)
+        expected = torch.tensor((1, *self.input_shape, self.hidden_dim))
+        assert_expected(actual, expected)
+
+    def test_multi_head_attention(self):
+        # New tensors because need unflattened shape
+        q = torch.randn(1, *self.input_shape, self.hidden_dim)
+        k = torch.randn(1, *self.input_shape, self.hidden_dim)
+        v = torch.randn(1, *self.input_shape, self.hidden_dim)
+        actual = self.mha(q, k, v)
+        expected = torch.tensor(
+            [
+                [
+                    [
+                        [[-0.1824, 0.2826, 0.4706], [-0.1540, 0.2962, 0.4301]],
+                        [[-0.1795, 0.2889, 0.4178], [-1.2837, -0.2228, -0.6794]],
+                    ],
+                    [
+                        [[-0.5227, 0.1744, 0.3691], [-0.3784, 0.2148, 0.3581]],
+                        [[-1.0747, -0.1513, -0.4717], [-1.3936, -0.2522, -0.7915]],
+                    ],
+                ]
+            ]
+        )
+        assert_expected(actual, expected, rtol=0, atol=1e-4)

--- a/torchmultimodal/modules/layers/attention.py
+++ b/torchmultimodal/modules/layers/attention.py
@@ -26,7 +26,7 @@ class MultiHeadAttention(nn.Module):
         dim_q (int): dimensionality of query
         dim_kv (int): dimensionality of key/value
         n_head (int): number of attention heads
-        n_layer (int): ?
+        n_layer (int): number of attention layers being used in higher level stack
         causal (bool): use causal attention or not
         attn_module (nn.Module): module of attention mechanism to use
 
@@ -35,6 +35,8 @@ class MultiHeadAttention(nn.Module):
                           a [b, 1, ..., 1, c] tensor if decode_step is not None
 
     """
+
+    # TODO: remove dependency on n_layer, higher level detail should not be a parameter
 
     def __init__(
         self,

--- a/torchmultimodal/modules/layers/attention.py
+++ b/torchmultimodal/modules/layers/attention.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Tuple
+
+import torch
+from torch import nn, Tensor
+from torch.nn import functional as F
+from torchmultimodal.utils.common import shift_dim, view_range
+
+
+class MultiHeadAttention(nn.Module):
+    """Compute multihead attention with flexible attention function
+
+    Args:
+        shape (Tuple): ?
+        dim_q (int): dimensionality of input into query weights
+        dim_kv (int): dimensionality of input into key and value weights
+        n_head (int): number of attention heads
+        n_layer (int): ?
+        causal (bool): use causal attention or not
+        attn_module (nn.Module): module of attention function to use
+
+    Inputs:
+        q, k, v (Tensor): a [b, d1, ..., dn, c] tensor or
+                          a [b, 1, ..., 1, c] tensor if decode_step is not None
+
+    """
+
+    def __init__(
+        self,
+        shape: Tuple,
+        dim_q: int,
+        dim_kv: int,
+        n_head: int,
+        n_layer: int,
+        causal: bool,
+        attn_module: nn.Module,
+    ):
+        super().__init__()
+        self.causal = causal
+        self.shape = shape
+
+        self.d_k = dim_q // n_head
+        self.d_v = dim_kv // n_head
+        self.n_head = n_head
+        self.w_qs = nn.Linear(dim_q, n_head * self.d_k, bias=False)  # q
+        self.w_qs.weight.data.normal_(std=1.0 / torch.sqrt(torch.tensor(dim_q)))
+
+        self.w_ks = nn.Linear(dim_kv, n_head * self.d_k, bias=False)  # k
+        self.w_ks.weight.data.normal_(std=1.0 / torch.sqrt(torch.tensor(dim_kv)))
+
+        self.w_vs = nn.Linear(dim_kv, n_head * self.d_v, bias=False)  # v
+        self.w_vs.weight.data.normal_(std=1.0 / torch.sqrt(torch.tensor(dim_kv)))
+
+        self.fc = nn.Linear(n_head * self.d_v, dim_q, bias=True)  # c
+        self.fc.weight.data.normal_(std=1.0 / torch.sqrt(torch.tensor(dim_q * n_layer)))
+
+        self.attn = attn_module
+
+        self.cache: Dict[str, Tensor] = dict()
+
+    def forward(self, q, k, v, decode_step=None, decode_idx=None):
+        # compute k, q, v
+        d_k, d_v, n_head = self.d_k, self.d_v, self.n_head
+        q = view_range(self.w_qs(q), -1, None, (n_head, d_k))
+        k = view_range(self.w_ks(k), -1, None, (n_head, d_k))
+        v = view_range(self.w_vs(v), -1, None, (n_head, d_v))
+
+        # b x n_head x seq_len x d
+        # (b, *d_shape, n_head, d) ->  (b, n_head, *d_shape, d)
+        q = shift_dim(q, -2, 1)
+        k = shift_dim(k, -2, 1)
+        v = shift_dim(v, -2, 1)
+
+        # fast decoding
+        if decode_step is not None:
+            if decode_step == 0:
+                if self.causal:
+                    k_shape = (
+                        q.shape[0],
+                        n_head,
+                        *self.shape,
+                        self.d_k,
+                    )  # B x n_head x 3 x 32 x 32 x d
+                    v_shape = (q.shape[0], n_head, *self.shape, self.d_v)
+                    self.cache = dict(
+                        k=torch.zeros(k_shape, dtype=k.dtype, device=q.device),
+                        v=torch.zeros(v_shape, dtype=v.dtype, device=q.device),
+                    )
+                else:
+                    # cache only once in the non-causal case
+                    self.cache = dict(k=k.clone(), v=v.clone())
+            if self.causal:
+                idx = (
+                    slice(None, None),
+                    slice(None, None),
+                    *[slice(i, i + 1) for i in decode_idx],
+                )
+                self.cache["k"][idx] = k
+                self.cache["v"][idx] = v
+            k, v = self.cache["k"], self.cache["v"]
+
+        a = self.attn(q, k, v, decode_step, decode_idx)
+
+        # (b, *d_shape, n_head, d) -> (b, *d_shape, n_head * d)
+        a = shift_dim(a, 1, -2).flatten(start_dim=-2)
+        a = self.fc(a)  # (b x seq_len x embd_dim)
+
+        return a
+
+
+class FullAttention(nn.Module):
+    def __init__(self, shape, causal, attn_dropout):
+        super().__init__()
+        self.causal = causal
+        self.attn_dropout = attn_dropout
+
+        seq_len = int(torch.prod(shape).item())
+        if self.causal:
+            self.register_buffer("mask", torch.tril(torch.ones(seq_len, seq_len)))
+
+    def forward(self, q, k, v, decode_step, decode_idx):
+        mask = torch.Tensor(self.mask) if self.causal else None
+        if decode_step is not None and mask is not None:
+            mask = mask[[decode_step]]
+
+        elif mask is not None and q.size(2) < mask.size(0):
+            mask = mask[range(q.size(2)), :][:, range(q.size(2))]
+
+        old_shape = q.shape[2:-1]
+        q = q.flatten(start_dim=2, end_dim=-2)
+        k = k.flatten(start_dim=2, end_dim=-2)
+        v = v.flatten(start_dim=2, end_dim=-2)
+
+        out = scaled_dot_product_attention(
+            q, k, v, mask=mask, attn_dropout=self.attn_dropout, training=self.training
+        )
+
+        return view_range(out, 2, 3, old_shape)
+
+
+class AxialAttention(nn.Module):
+    def __init__(self, n_dim, axial_dim):
+        super().__init__()
+        if axial_dim < 0:
+            axial_dim = 2 + n_dim + 1 + axial_dim
+        else:
+            axial_dim += 2  # account for batch, head, dim
+        self.axial_dim = axial_dim
+
+    def forward(self, q, k, v, decode_step, decode_idx):
+        q = shift_dim(q, self.axial_dim, -2).flatten(end_dim=-3)
+        k = shift_dim(k, self.axial_dim, -2).flatten(end_dim=-3)
+        v = shift_dim(v, self.axial_dim, -2)
+        old_shape = list(v.shape)
+        v = v.flatten(end_dim=-3)
+
+        out = scaled_dot_product_attention(q, k, v, training=self.training)
+        out = out.view(*old_shape)
+        out = shift_dim(out, -2, self.axial_dim)
+        return out
+
+
+def scaled_dot_product_attention(q, k, v, mask=None, attn_dropout=0.0, training=True):
+    # Performs scaled dot-product attention over the second to last dimension dn
+
+    # (b, n_head, d1, ..., dn, d)
+    attn = torch.matmul(q, k.transpose(-1, -2))
+    attn = attn / torch.sqrt(q.shape[-1])
+    if mask is not None:
+        attn = attn.masked_fill(mask == 0, float("-inf"))
+    attn_float = F.softmax(attn, dim=-1)
+    attn = attn_float.type_as(attn)  # b x n_head x d1 x ... x dn x d
+    attn = F.dropout(attn, p=attn_dropout, training=training)
+
+    a = torch.matmul(attn, v)  # b x n_head x d1 x ... x dn x d
+
+    return a

--- a/torchmultimodal/modules/layers/attention.py
+++ b/torchmultimodal/modules/layers/attention.py
@@ -63,7 +63,7 @@ class MultiHeadAttention(nn.Module):
 
         self.cache: Dict[str, Tensor] = dict()
 
-    def _split_multihead(self, x: Tensor):
+    def _split_multihead(self, x: Tensor) -> Tensor:
         # Splits input tensor of size (b x (d1...dn) x hidden)
         # into (b x (d1...dn) x n_head x emb_dim)
         x = x.unflatten(-1, (self.n_head, -1))
@@ -71,7 +71,7 @@ class MultiHeadAttention(nn.Module):
         x = shift_dim(x, -2, 1)
         return x
 
-    def _combine_multihead(self, x: Tensor):
+    def _combine_multihead(self, x: Tensor) -> Tensor:
         # Moves head dim back to original location and concatenates heads
         # (b x n_head x (d1...dn) x emb_dim) -> (b x (d1...dn) x hidden)
         return shift_dim(x, 1, -2).flatten(start_dim=-2)


### PR DESCRIPTION
Summary:
Introduces the `MultiHeadAttention` module which is used in MUGEN in the encoder and decoder for Video VQVAE and the GPT decoder. This module differs from PyTorch Core in that it allows for a flexible attention function by passing in the attention module you want to use to calculate attention instead of defaulting to full attention. For Video VQVAE, axial attention is needed to reduce cost of computing attention across three dimensions of the input. Axial Attention and Full Attention are introduced as separate modules to be used in `MultiHeadAttention` for this reason.

Test plan:
On a local notebook, compared the outputs from our implementation to the outputs from the MUGEN implementation and ensured they were equivalent. Then, used these as expected outputs in unit tests for each module and its methods in `test_attention.py`

`pytest -vv`
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/33648637/172207332-b6972a68-5c92-4402-b0fd-1f532040570c.png">

