### PR TITLE
fix the device issue in WeightedEmbeddingEncoder

### DIFF
--- a/test/modules/encoders/test_weighted_embedding_encoder.py
+++ b/test/modules/encoders/test_weighted_embedding_encoder.py
@@ -83,53 +83,6 @@ class TestEmbeddingEncoder(unittest.TestCase):
         )
         assert_expected(actual, expected)
 
-    def test_forward_hash_no_padding(self):
-        input = torch.Tensor(
-            [
-                [0.2, 0.7, 0, 0.1],
-                [0.3, 0, 0.4, 0.3],
-            ]
-        )
-        weighted_embedding_encoder = WeightedEmbeddingEncoder(
-            embedding=self.embedding, pooling_function=torch.max, use_hash=True
-        )
-        actual = weighted_embedding_encoder(input)
-        expected = torch.Tensor(
-            [
-                [1.4, 1.4],
-                [0.4, 0.3],
-            ]
-        )
-        assert_expected(actual, expected)
-
-    def test_forward_hash_zero_padding(self):
-        input = torch.Tensor(
-            [
-                [0.2, 0.7, 0, 0.1],
-                [0.3, 0, 0.4, 0.3],
-            ]
-        )
-        embedding = deepcopy(self.embedding)
-        embedding.padding_idx = 0
-        weighted_embedding_encoder = WeightedEmbeddingEncoder(
-            embedding=embedding, pooling_function=torch.sum, use_hash=True
-        )
-        actual = weighted_embedding_encoder(input)
-        expected = torch.Tensor(
-            [
-                [1.8, 1.8],
-                [1.3, 0.9],
-            ]
-        )
-        assert_expected(actual, expected)
-
-    def test_forward_hash_invalid_padding(self):
-        embedding = deepcopy(self.embedding)
-        embedding.padding_idx = 2
-        self.assertRaises(
-            ValueError, WeightedEmbeddingEncoder, embedding, torch.sum, 1, True
-        )
-
     def test_scripting(self):
         input = torch.Tensor(
             [
@@ -138,7 +91,8 @@ class TestEmbeddingEncoder(unittest.TestCase):
             ]
         )
         weighted_embedding_encoder = WeightedEmbeddingEncoder(
-            embedding=self.embedding, pooling_function=torch.mean, use_hash=True
+            embedding=self.embedding,
+            pooling_function=torch.mean,
         )
         scripted_encoder = torch.jit.script(weighted_embedding_encoder)
         actual = scripted_encoder(input)

--- a/torchmultimodal/modules/encoders/weighted_embedding_encoder.py
+++ b/torchmultimodal/modules/encoders/weighted_embedding_encoder.py
@@ -19,11 +19,10 @@ class WeightedEmbeddingEncoder(nn.Module):
         pooling_function (Callable[[Tensor, int], Union[Tensor, Tuple]]): pooling function to combine the weighted embeddings,\
         example: torch.sum function should return a tensor or namedtuple containing the tensor in the values field like torch.max
         pooling_dim (int) : dimension along which the pooling function is applied
-        use_hash (bool): if hashing based on embedding vocab size if applied to input
-        before embedding layer
 
     Inputs:
-        weights (Tensor): Tensor containing weights
+        weights (Tensor): A float tensor of shape [batch_size x num_categories] containing the weights of a categorical feature.\
+            The weights represent multiplier factors for the corresponding category embedding vectors.
 
     """
 
@@ -32,35 +31,16 @@ class WeightedEmbeddingEncoder(nn.Module):
         embedding: nn.Embedding,
         pooling_function: Callable[[Tensor, int], Union[Tensor, Tuple]],
         pooling_dim: int = 1,
-        use_hash: bool = False,
     ) -> None:
         super().__init__()
-        if (
-            use_hash
-            and embedding.padding_idx is not None
-            and embedding.padding_idx != 0
-        ):
-            raise ValueError("embedding padding should be None or 0 if hashing is used")
         self.embedding = embedding
         self.pooling_function = pooling_function
         self.pooling_dim = pooling_dim
-        self.use_hash = use_hash
 
     def forward(self, weights: Tensor) -> Tensor:
         index = torch.arange(0, weights.size(1), dtype=torch.int)
-        if self.use_hash:
-            # TODO: pull this out into a common function T111523602
-            if self.embedding.padding_idx is None:
-                index = index % self.embedding.num_embeddings
-            else:
-                mask = ~index.eq(self.embedding.padding_idx)
-                non_zero_index = torch.masked_select(index, mask)
-                index[mask] = (non_zero_index - 1) % (
-                    self.embedding.num_embeddings - 1
-                ) + 1
-
+        index = index.to(weights.device)
         weighted_embeddings = self.embedding(index) * weights.unsqueeze(-1)
-
         pooled_embeddings = self.pooling_function(weighted_embeddings, self.pooling_dim)
         if isinstance(pooled_embeddings, Tensor):
             output: Tensor = pooled_embeddings


### PR DESCRIPTION
Summary: Moving indices to the same device as the input tensor with weights

Differential Revision: D36945044

