### PR TITLE
[FLAVA]Add transformers to flava requirements

### DIFF
--- a/examples/flava/requirements.txt
+++ b/examples/flava/requirements.txt
@@ -5,3 +5,4 @@ requests==2.27.1
 DALL-E==0.1
 omegaconf==2.1.2
 hydra-core==1.1.2
+transformers==4.16.0


### PR DESCRIPTION
Summary:
Add HF transformers dependency which was missing

Test plan:
tested readme on a fresh conda env
python finetune.py config=configs/finetuning/qnli.yaml model.pretrained_model_key=flava_full training.lightning.gpus=0 training.lightning.accelerator=cpu

