### PR TITLE
[ALBEF] First Draft of the ALBEF Model

### DIFF
--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -6,7 +6,7 @@
 
 import torch
 from test.test_utils import assert_expected, set_rng_seed
-from torch import nn
+from torch import nn, Tensor
 from torchmultimodal.models.albef import ALBEFModel
 
 
@@ -36,3 +36,13 @@ class TestALBEFModel:
         self.albef._dequeue_and_enqueue(image_feat_m, text_feat_m)
         assert_expected(self.albef.image_queue[:, 0:2], image_feat_m.T)
         assert_expected(self.albef.text_queue[:, 0:2], text_feat_m.T)
+
+    def test_momentum_update(self):
+        init_weight = Tensor([[1, 2, 3], [4, 5, 6]])
+        init_weight_m = Tensor([[6, 5, 4], [3, 2, 1]])
+        self.albef.models[0].weight = nn.Parameter(init_weight)
+        self.albef.models_m[0].weight = nn.Parameter(init_weight_m)
+        self.albef._momentum_update()
+        expected_weight_m = Tensor([[5.9750, 4.9850, 3.9950], [3.0050, 2.0150, 1.0250]])
+        assert_expected(self.albef.models[0].weight, init_weight)
+        assert_expected(self.albef.models_m[0].weight, expected_weight_m)

--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import nn
 from torchmultimodal.models.albef import ALBEFModel
@@ -28,3 +29,10 @@ class TestALBEFModel:
             for param, param_m in zip(model.parameters(), model_m.parameters()):
                 assert_expected(param, param_m)
                 assert not param_m.requires_grad
+
+    def test_dequeue_and_enqueue(self):
+        image_feat_m = torch.randn(2, 2)
+        text_feat_m = torch.randn(2, 2)
+        self.albef._dequeue_and_enqueue(image_feat_m, text_feat_m)
+        assert_expected(self.albef.image_queue[:, 0:2], image_feat_m.T)
+        assert_expected(self.albef.text_queue[:, 0:2], text_feat_m.T)

--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -26,15 +26,17 @@ class TestALBEFModel:
         self.albef._copy_params_momentum_models()
         for model, model_m in zip(self.albef.models, self.albef.models_m):
             for param, param_m in zip(model.parameters(), model_m.parameters()):
-                assert_expected(param, param_m)
+                assert_expected(param, param_m, rtol=0, atol=1e-4)
                 assert not param_m.requires_grad
 
     def test_dequeue_and_enqueue(self):
         image_feat_m = torch.randn(2, 2)
         text_feat_m = torch.randn(2, 2)
         self.albef._dequeue_and_enqueue(image_feat_m, text_feat_m)
-        assert_expected(self.albef.image_queue[:, 0:2], image_feat_m.T)
-        assert_expected(self.albef.text_queue[:, 0:2], text_feat_m.T)
+        assert_expected(
+            self.albef.image_queue[:, 0:2], image_feat_m.T, rtol=0, atol=1e-4
+        )
+        assert_expected(self.albef.text_queue[:, 0:2], text_feat_m.T, rtol=0, atol=1e-4)
 
     def test_momentum_update(self):
         init_weight = Tensor([[1, 2, 3], [4, 5, 6]])
@@ -43,8 +45,10 @@ class TestALBEFModel:
         self.albef.models_m[0].weight = nn.Parameter(init_weight_m)
         self.albef._momentum_update()
         expected_weight_m = Tensor([[5.9750, 4.9850, 3.9950], [3.0050, 2.0150, 1.0250]])
-        assert_expected(self.albef.models[0].weight, init_weight)
-        assert_expected(self.albef.models_m[0].weight, expected_weight_m)
+        assert_expected(self.albef.models[0].weight, init_weight, rtol=0, atol=1e-4)
+        assert_expected(
+            self.albef.models_m[0].weight, expected_weight_m, rtol=0, atol=1e-4
+        )
 
     def test_similarity(self):
         set_rng_seed(0)
@@ -81,10 +85,10 @@ class TestALBEFModel:
                 [-22.274969, 5.272466, 31.752522, 24.050060, -23.705740, -11.501695],
             ]
         )
-        assert_expected(output.sim_i2t, expected_sim_i2t)
-        assert_expected(output.sim_t2i, expected_sim_t2i)
-        assert_expected(output.sim_i2t_m, expected_sim_i2t_m)
-        assert_expected(output.sim_t2i_m, expected_sim_t2i_m)
+        assert_expected(output.sim_i2t, expected_sim_i2t, rtol=0, atol=1e-4)
+        assert_expected(output.sim_t2i, expected_sim_t2i, rtol=0, atol=1e-4)
+        assert_expected(output.sim_i2t_m, expected_sim_i2t_m, rtol=0, atol=1e-4)
+        assert_expected(output.sim_t2i_m, expected_sim_t2i_m, rtol=0, atol=1e-4)
 
     def test_neg_embeddings(self):
         set_rng_seed(0)
@@ -107,6 +111,6 @@ class TestALBEFModel:
             [[-0.403344, -0.596635, 0.182036], [0.403347, 0.838026, -0.719258]]
         ).unsqueeze(1)
         expected_text_atts_neg = Tensor([1.100604, -0.856675]).unsqueeze(1)
-        assert_expected(image_embeds_neg, expected_image_embeds_neg)
-        assert_expected(text_embeds_neg, expected_text_embeds_neg)
-        assert_expected(text_atts_neg, expected_text_atts_neg)
+        assert_expected(image_embeds_neg, expected_image_embeds_neg, rtol=0, atol=1e-4)
+        assert_expected(text_embeds_neg, expected_text_embeds_neg, rtol=0, atol=1e-4)
+        assert_expected(text_atts_neg, expected_text_atts_neg, rtol=0, atol=1e-4)

--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from test.test_utils import assert_expected, set_rng_seed
+from torch import nn
+from torchmultimodal.models.albef import ALBEFModel
+
+
+class TestALBEFModel:
+    set_rng_seed(0)
+    albef = ALBEFModel(
+        nn.Linear(3, 2),
+        nn.Linear(3, 2),
+        nn.Linear(3, 2),
+        nn.Linear(3, 2),
+        nn.Linear(3, 2),
+        embed_dim=2,
+        queue_size=4,
+    )
+
+    def test_copy_params_momentum_models(self):
+        self.albef.models_m = [nn.Linear(3, 2) for _ in range(5)]
+        self.albef._copy_params_momentum_models()
+        for model, model_m in zip(self.albef.models, self.albef.models_m):
+            for param, param_m in zip(model.parameters(), model_m.parameters()):
+                assert_expected(param, param_m)
+                assert not param_m.requires_grad

--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -11,7 +11,6 @@ from torchmultimodal.models.albef import ALBEFModel, ALBEFSimilarity
 
 
 class TestALBEFModel:
-    set_rng_seed(0)
     albef = ALBEFModel(
         nn.Linear(3, 2),
         nn.Linear(3, 2),
@@ -48,6 +47,7 @@ class TestALBEFModel:
         assert_expected(self.albef.models_m[0].weight, expected_weight_m)
 
     def test_similarity(self):
+        set_rng_seed(0)
         self.albef.image_queue = torch.randn(2, 4)
         self.albef.text_queue = torch.randn(2, 4)
         image_feat = torch.randn(2, 2)
@@ -59,26 +59,26 @@ class TestALBEFModel:
         )
         expected_sim_i2t = Tensor(
             [
-                [-1.447699, -9.017220, 0.746556, 9.711679, -6.985742, 0.365735],
-                [-2.416966, -2.708404, 9.974752, -2.098411, -8.639756, -0.250136],
+                [-3.660729, -11.191917, 1.252719, 9.129601, -0.882724, -0.818697],
+                [15.755546, 21.687363, 27.634123, -18.587852, 30.696188, -4.964930],
             ]
         )
         expected_sim_t2i = Tensor(
             [
-                [7.392047, 33.410320, 20.561050, 16.583294, 26.293110, -34.790211],
-                [8.461701, 11.472798, -7.857050, -7.127809, 13.020058, 2.605398],
+                [27.311251, -23.288742, -14.411922, -30.653456, -3.136197, 20.444725],
+                [16.565296, -26.082125, 8.684321, -19.420963, -24.787359, 16.908016],
             ]
         )
         expected_sim_i2t_m = Tensor(
             [
-                [-1.972124, 3.002172, 11.823727, -9.443038, -5.773357, -0.567474],
-                [-7.837631, -2.679799, 36.660282, -15.856747, -26.522240, -1.236609],
+                [-13.028821, -22.274969, -17.438065, 18.764980, -20.974815, 2.714235],
+                [8.504787, 5.272466, 22.941040, -5.002890, 23.104834, -4.742508],
             ]
         )
         expected_sim_t2i_m = Tensor(
             [
-                [-1.972124, -7.837631, -4.223857, -3.374927, -6.328424, 7.576523],
-                [3.002172, -2.679799, -10.703135, -9.112455, 0.313488, 11.622608],
+                [-13.028821, 8.504787, 10.671893, 14.442708, -3.490067, -8.771053],
+                [-22.274969, 5.272466, 31.752522, 24.050060, -23.705740, -11.501695],
             ]
         )
         assert_expected(output.sim_i2t, expected_sim_i2t)
@@ -87,6 +87,7 @@ class TestALBEFModel:
         assert_expected(output.sim_t2i_m, expected_sim_t2i_m)
 
     def test_neg_embeddings(self):
+        set_rng_seed(0)
         image_embeds = torch.randn(2, 1, 3)
         text_embeds = torch.randn(2, 1, 3)
         text_atts = torch.randn(2, 1)
@@ -100,12 +101,12 @@ class TestALBEFModel:
             image_embeds, text_embeds, text_atts, similarity
         )
         expected_image_embeds_neg = Tensor(
-            [[-1.209532, 1.344070, 2.383219], [0.273870, 0.567926, -0.673102]]
+            [[0.568431, -1.084522, -1.398595], [1.540996, -0.293429, -2.178789]]
         ).unsqueeze(1)
         expected_text_embeds_neg = Tensor(
-            [[0.875558, -2.672565, -0.031333], [-0.566464, -1.153617, -2.502301]]
+            [[-0.403344, -0.596635, 0.182036], [0.403347, 0.838026, -0.719258]]
         ).unsqueeze(1)
-        expected_text_atts_neg = Tensor([-0.523323, 0.498786]).unsqueeze(1)
+        expected_text_atts_neg = Tensor([1.100604, -0.856675]).unsqueeze(1)
         assert_expected(image_embeds_neg, expected_image_embeds_neg)
         assert_expected(text_embeds_neg, expected_text_embeds_neg)
         assert_expected(text_atts_neg, expected_text_atts_neg)

--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -46,3 +46,42 @@ class TestALBEFModel:
         expected_weight_m = Tensor([[5.9750, 4.9850, 3.9950], [3.0050, 2.0150, 1.0250]])
         assert_expected(self.albef.models[0].weight, init_weight)
         assert_expected(self.albef.models_m[0].weight, expected_weight_m)
+
+    def test_similarity(self):
+        self.albef.image_queue = torch.randn(2, 4)
+        self.albef.text_queue = torch.randn(2, 4)
+        image_feat = torch.randn(2, 2)
+        text_feat = torch.randn(2, 2)
+        image_feat_m = torch.randn(2, 2)
+        text_feat_m = torch.randn(2, 2)
+        output = self.albef._similarity(
+            image_feat, text_feat, image_feat_m, text_feat_m
+        )
+        expected_sim_i2t = Tensor(
+            [
+                [-1.447699, -9.017220, 0.746556, 9.711679, -6.985742, 0.365735],
+                [-2.416966, -2.708404, 9.974752, -2.098411, -8.639756, -0.250136],
+            ]
+        )
+        expected_sim_t2i = Tensor(
+            [
+                [7.392047, 33.410320, 20.561050, 16.583294, 26.293110, -34.790211],
+                [8.461701, 11.472798, -7.857050, -7.127809, 13.020058, 2.605398],
+            ]
+        )
+        expected_sim_i2t_m = Tensor(
+            [
+                [-1.972124, 3.002172, 11.823727, -9.443038, -5.773357, -0.567474],
+                [-7.837631, -2.679799, 36.660282, -15.856747, -26.522240, -1.236609],
+            ]
+        )
+        expected_sim_t2i_m = Tensor(
+            [
+                [-1.972124, -7.837631, -4.223857, -3.374927, -6.328424, 7.576523],
+                [3.002172, -2.679799, -10.703135, -9.112455, 0.313488, 11.622608],
+            ]
+        )
+        assert_expected(output.sim_i2t, expected_sim_i2t)
+        assert_expected(output.sim_t2i, expected_sim_t2i)
+        assert_expected(output.sim_i2t_m, expected_sim_i2t_m)
+        assert_expected(output.sim_t2i_m, expected_sim_t2i_m)

--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -7,7 +7,7 @@
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import nn, Tensor
-from torchmultimodal.models.albef import ALBEFModel
+from torchmultimodal.models.albef import ALBEFModel, ALBEFSimilarity
 
 
 class TestALBEFModel:
@@ -85,3 +85,27 @@ class TestALBEFModel:
         assert_expected(output.sim_t2i, expected_sim_t2i)
         assert_expected(output.sim_i2t_m, expected_sim_i2t_m)
         assert_expected(output.sim_t2i_m, expected_sim_t2i_m)
+
+    def test_neg_embeddings(self):
+        image_embeds = torch.randn(2, 1, 3)
+        text_embeds = torch.randn(2, 1, 3)
+        text_atts = torch.randn(2, 1)
+        similarity = ALBEFSimilarity(
+            sim_i2t=torch.randn(2, 5),
+            sim_t2i=torch.randn(2, 5),
+            sim_i2t_m=torch.randn(2, 5),
+            sim_t2i_m=torch.randn(2, 5),
+        )
+        image_embeds_neg, text_embeds_neg, text_atts_neg = self.albef._neg_embeddings(
+            image_embeds, text_embeds, text_atts, similarity
+        )
+        expected_image_embeds_neg = Tensor(
+            [[-1.209532, 1.344070, 2.383219], [0.273870, 0.567926, -0.673102]]
+        ).unsqueeze(1)
+        expected_text_embeds_neg = Tensor(
+            [[0.875558, -2.672565, -0.031333], [-0.566464, -1.153617, -2.502301]]
+        ).unsqueeze(1)
+        expected_text_atts_neg = Tensor([-0.523323, 0.498786]).unsqueeze(1)
+        assert_expected(image_embeds_neg, expected_image_embeds_neg)
+        assert_expected(text_embeds_neg, expected_text_embeds_neg)
+        assert_expected(text_atts_neg, expected_text_atts_neg)

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -70,6 +70,10 @@ class ALBEFModel(nn.Module):
         self.register_buffer("image_queue", torch.randn(embed_dim, queue_size))
         self.register_buffer("text_queue", torch.randn(embed_dim, queue_size))
         self.register_buffer("queue_ptr", torch.zeros(1, dtype=torch.long))
+
+        self.image_queue: torch.Tensor
+        self.text_queue: torch.Tensor
+        self.queue_ptr: torch.Tensor
         self.image_queue = nn.functional.normalize(self.image_queue, dim=0)
         self.text_queue = nn.functional.normalize(self.text_queue, dim=0)
 

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -173,6 +173,7 @@ class ALBEFModel(nn.Module):
         text_embeds_m = self.text_encoder_m(text, attention_mask=text_atts)
         image_feat_m = F.normalize(self.vision_proj_m(image_embeds_m[:, 0, :]), dim=-1)
         text_feat_m = F.normalize(self.text_proj_m(text_embeds_m[:, 0, :]), dim=-1)
+        self._dequeue_and_enqueue(image_feat_m, text_feat_m)
         return image_embeds_m, image_feat_m, text_feat_m
 
     @torch.no_grad()
@@ -215,7 +216,6 @@ class ALBEFModel(nn.Module):
 
         sim_i2t = image_feat @ text_feat_all / self.temp
         sim_t2i = text_feat @ image_feat_all / self.temp
-        self._dequeue_and_enqueue(image_feat_m, text_feat_m)
 
         return ALBEFSimilarity(
             sim_i2t=sim_i2t,

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -58,9 +58,9 @@ class ALBEFModel(nn.Module):
             temp (float): temperature parameter
             momentum (float): momentum parameter
 
-    Inputs: image (Tensor): Tensor containing image features
-            text (Tensor): Tensor containing text features
-            text_atts (Tensor): Tensor containing text attention mask
+    Inputs: image (Tensor): Tensor of shape (B, C, H, W) containing image features
+            text (Tensor): Tensor of shape (B, L) containing text features
+            text_atts (Tensor): Tensor of shape (B, L) containing text attention mask
     """
 
     def __init__(

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -217,10 +217,10 @@ class ALBEFModel(nn.Module):
     ) -> ALBEFSimilarity:
         with torch.no_grad():
             image_feat_all = torch.cat(
-                [image_feat_m.t(), self.image_queue.clone().detach()], dim=1
+                [image_feat_m.t(), self.image_queue.detach().clone()], dim=1
             )
             text_feat_all = torch.cat(
-                [text_feat_m.t(), self.text_queue.clone().detach()], dim=1
+                [text_feat_m.t(), self.text_queue.detach().clone()], dim=1
             )
             sim_i2t_m = image_feat_m @ text_feat_all / self.temp
             sim_t2i_m = text_feat_m @ image_feat_all / self.temp
@@ -251,12 +251,12 @@ class ALBEFModel(nn.Module):
 
         image_embeds_neg, text_embeds_neg, text_atts_neg = [], [], []
         for b in range(bs):
-            neg_idx = torch.multinomial(weights_t2i[b], 1).item()
+            neg_idx = int(torch.multinomial(weights_t2i[b], 1).item())
             image_embeds_neg.append(image_embeds[neg_idx])
         image_embeds_neg = torch.stack(image_embeds_neg, dim=0)
 
         for b in range(bs):
-            neg_idx = torch.multinomial(weights_i2t[b], 1).item()
+            neg_idx = int(torch.multinomial(weights_i2t[b], 1).item())
             text_embeds_neg.append(text_embeds[neg_idx])
             text_atts_neg.append(text_atts[neg_idx])
         text_embeds_neg = torch.stack(text_embeds_neg, dim=0)

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -1,0 +1,252 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+from collections import namedtuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+ALBEFOutput = namedtuple(
+    "ALBEFOutput",
+    [
+        "image_embeddings",
+        "image_embeddings_m",
+        "text_embeddings",
+        "text_atts",
+        "vl_embeddings",
+        "similarity",
+    ],
+    defaults=(None, None, None, None, None, None),
+)
+
+ALBEFSimilarity = namedtuple(
+    "ALBEFSimilarity",
+    ["sim_i2t", "sim_t2i", "sim_i2t_targets", "sim_t2i_targets"],
+    defaults=(None, None, None, None),
+)
+
+
+class ALBEFArchitecture(nn.Module):
+    def __init__(
+        self,
+        vision_encoder: nn.Module,
+        text_encoder: nn.Module,
+        multimodal_encoder: nn.Module,
+        vision_proj: nn.Module,
+        text_proj: nn.Module,
+        embed_dim: int = 256,
+        queue_size: int = 65534,
+        temp: float = 0.07,
+        momentum: float = 0.995,
+    ):
+        super().__init__()
+        self.vision_encoder = vision_encoder
+        self.text_encoder = text_encoder
+        self.multimodal_encoder = multimodal_encoder
+        self.vision_proj = vision_proj
+        self.text_proj = text_proj
+        self.vision_encoder_m = copy.deepcopy(vision_encoder)
+        self.text_encoder_m = copy.deepcopy(text_encoder)
+        self.multimodal_encoder_m = copy.deepcopy(multimodal_encoder)
+        self.vision_proj_m = copy.deepcopy(vision_proj)
+        self.text_proj_m = copy.deepcopy(text_proj)
+
+        self._copy_params()
+
+        self.queue_size = queue_size
+        self.temp = temp
+        self.momentum = momentum
+
+        self.register_buffer("image_queue", torch.randn(embed_dim, queue_size))
+        self.register_buffer("text_queue", torch.randn(embed_dim, queue_size))
+        self.register_buffer("queue_ptr", torch.zeros(1, dtype=torch.long))
+        self.image_queue = nn.functional.normalize(self.image_queue, dim=0)
+        self.text_queue = nn.functional.normalize(self.text_queue, dim=0)
+
+    def forward(
+        self,
+        image: torch.Tensor,
+        text: torch.Tensor,
+        text_atts: torch.Tensor = None,
+        alpha: float = 0.4,
+    ):
+        image_embeds, text_embeds, image_feat, text_feat = self._unimodal_embeddings(
+            image, text, text_atts
+        )
+        image_embeds_m, image_feat_m, text_feat_m = self._momentum_embeddings(
+            image, text, text_atts
+        )
+        similarity = self._similarity(
+            image_feat, text_feat, image_feat_m, text_feat_m, alpha
+        )
+        image_embeds_neg, text_embeds_neg, text_atts_neg = self._neg_embeddings(
+            image_embeds, text_embeds, text_atts, similarity
+        )
+        vl_embeds = self._multimodal_embeddings(
+            image_embeds,
+            text_embeds,
+            image_embeds_neg,
+            text_embeds_neg,
+            text_atts,
+            text_atts_neg,
+        )
+        return ALBEFOutput(
+            image_embeddings=image_embeds,
+            image_embeddings_m=image_embeds_m,
+            text_embeddings=text_embeds,
+            text_atts=text_atts,
+            vl_embeddings=vl_embeds,
+            similarity=similarity,
+        )
+
+    @torch.no_grad()
+    def _copy_params(self):
+        for model, model_m in [
+            [self.vision_encoder, self.vision_encoder_m],
+            [self.text_encoder, self.text_encoder_m],
+            [self.multimodal_encoder, self.multimodal_encoder_m],
+            [self.vision_proj, self.vision_proj_m],
+            [self.text_proj, self.text_proj_m],
+        ]:
+            for param, param_m in zip(model.parameters(), model_m.parameters()):
+                param_m.data.copy_(param.data)
+                param_m.requires_grad = False
+
+    def _unimodal_embeddings(self, image, text, text_atts):
+        image_embeds = self.vision_encoder(image)
+        text_embeds = self.text_encoder(text, attention_mask=text_atts)
+        image_feat = F.normalize(self.vision_proj(image_embeds[:, 0, :]), dim=-1)
+        text_feat = F.normalize(self.text_proj(text_embeds[:, 0, :]), dim=-1)
+        return image_embeds, text_embeds, image_feat, text_feat
+
+    @torch.no_grad()
+    def _momentum_embeddings(self, image, text, text_atts):
+        self._momentum_update()
+        image_embeds_m = self.vision_encoder_m(image)
+        text_embeds_m = self.text_encoder_m(text, attention_mask=text_atts)
+        image_feat_m = F.normalize(self.vision_proj_m(image_embeds_m[:, 0, :]), dim=-1)
+        text_feat_m = F.normalize(self.text_proj_m(text_embeds_m[:, 0, :]), dim=-1)
+        return image_embeds_m, image_feat_m, text_feat_m
+
+    @torch.no_grad()
+    def _momentum_update(self):
+        for model, model_m in [
+            [self.vision_encoder, self.vision_encoder_m],
+            [self.text_encoder, self.text_encoder_m],
+            [self.multimodal_encoder, self.multimodal_encoder_m],
+            [self.vision_proj, self.vision_proj_m],
+            [self.text_proj, self.text_proj_m],
+        ]:
+            for param, param_m in zip(model.parameters(), model_m.parameters()):
+                param_m.data = param_m.data * self.momentum + param.data * (
+                    1 - self.momentum
+                )
+
+    @torch.no_grad()
+    def _concat_all_gather(self, tensor):
+        if torch.is_distributed(tensor):
+            tensors_gather = [
+                torch.ones_like(tensor)
+                for _ in range(torch.distributed.get_world_size())
+            ]
+            torch.disstributed.all_gather(tensors_gather, tensor, async_op=False)
+            output = torch.cat(tensors_gather, dim=0)
+            return output
+        else:
+            return tensor
+
+    @torch.no_grad()
+    def _update_queue(self, image_feat_m, text_feat_m):
+        image_feats = self._concat_all_gather(image_feat_m)
+        text_feats = self._concat_all_gather(text_feat_m)
+        batch_size = image_feats.shape[0]
+        ptr = int(self.queue_ptr)
+        assert self.queue_size % batch_size == 0
+
+        self.image_queue[:, ptr : ptr + batch_size] = image_feats.T
+        self.text_queue[:, ptr : ptr + batch_size] = text_feats.T
+        ptr = (ptr + batch_size) % self.queue_size
+        self.queue_ptr[0] = ptr
+
+    def _similarity(self, image_feat, text_feat, image_feat_m, text_feat_m, alpha):
+        with torch.no_grad():
+            image_feat_all = torch.cat(
+                [image_feat_m.t(), self.image_queue.clone().detach()], dim=1
+            )
+            text_feat_all = torch.cat(
+                [text_feat_m.t(), self.text_queue.clone().detach()], dim=1
+            )
+            sim_i2t_m = image_feat_m @ text_feat_all / self.temp
+            sim_t2i_m = text_feat_m @ image_feat_all / self.temp
+
+            sim_targets = torch.zeros(sim_i2t_m.size()).to(image_feat.device)
+            sim_targets.fill_diagonal_(1)
+
+            sim_i2t_targets = (
+                alpha * F.softmax(sim_i2t_m, dim=1) + (1 - alpha) * sim_targets
+            )
+            sim_t2i_targets = (
+                alpha * F.softmax(sim_t2i_m, dim=1) + (1 - alpha) * sim_targets
+            )
+
+        sim_i2t = image_feat @ text_feat_all / self.temp
+        sim_t2i = text_feat @ image_feat_all / self.temp
+        self._update_queue(image_feat_m, text_feat_m)
+
+        return ALBEFSimilarity(
+            sim_i2t=sim_i2t,
+            sim_t2i=sim_t2i,
+            sim_i2t_targets=sim_i2t_targets,
+            sim_t2i_targets=sim_t2i_targets,
+        )
+
+    def _neg_embeddings(self, image_embeds, text_embeds, text_atts, similarity):
+        with torch.no_grad():
+            bs = image_embeds.size(0)
+            weights_i2t = F.softmax(similarity.sim_i2t[:, :bs], dim=1)
+            weights_t2i = F.softmax(similarity.sim_t2i[:, :bs], dim=1)
+            weights_i2t.fill_diagonal_(0)
+            weights_t2i.fill_diagonal_(0)
+
+        image_embeds_neg, text_embeds_neg, text_atts_neg = [], [], []
+        for b in range(bs):
+            neg_idx = torch.multinomial(weights_t2i[b], 1).item()
+            image_embeds_neg.append(image_embeds[neg_idx])
+        image_embeds_neg = torch.stack(image_embeds_neg, dim=0)
+
+        for b in range(bs):
+            neg_idx = torch.multinomial(weights_i2t[b], 1).item()
+            text_embeds_neg.append(text_embeds[neg_idx])
+            text_atts_neg.append(text_atts[neg_idx])
+        text_embeds_neg = torch.stack(text_embeds_neg, dim=0)
+        text_atts_neg = torch.stack(text_atts_neg, dim=0)
+        return image_embeds_neg, text_embeds_neg, text_atts_neg
+
+    def _multimodal_embeddings(
+        self,
+        image_embeds,
+        text_embeds,
+        image_embeds_neg,
+        text_embeds_neg,
+        text_atts,
+        text_atts_neg,
+    ):
+        image_embeds_all = torch.cat([image_embeds_neg, image_embeds], dim=0)
+        text_embeds_all = torch.cat([text_embeds, text_embeds_neg], dim=0)
+        text_atts_all = torch.cat([text_atts, text_atts_neg], dim=0)
+        output_pos = self.multimodal_encoder(
+            image_embeds=image_embeds, text_embeds=text_embeds, text_atts=text_atts
+        )
+        output_neg = self.multimodal_encoder(
+            image_embeds=image_embeds_all,
+            text_embeds=text_embeds_all,
+            text_atts=text_atts_all,
+        )
+        vl_embeddings = torch.cat([output_pos, output_neg], dim=0)
+        return vl_embeddings

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 
 import torch
 import torch.nn.functional as F
-from torch import nn
+from torch import nn, Tensor
 
 from torchmultimodal.modules.losses.contrastive_loss_with_temperature import (
     _gather_embeddings_and_labels,
@@ -71,17 +71,17 @@ class ALBEFModel(nn.Module):
         self.register_buffer("text_queue", torch.randn(embed_dim, queue_size))
         self.register_buffer("queue_ptr", torch.zeros(1, dtype=torch.long))
 
-        self.image_queue: torch.Tensor
-        self.text_queue: torch.Tensor
-        self.queue_ptr: torch.Tensor
+        self.image_queue: Tensor
+        self.text_queue: Tensor
+        self.queue_ptr: Tensor
         self.image_queue = nn.functional.normalize(self.image_queue, dim=0)
         self.text_queue = nn.functional.normalize(self.text_queue, dim=0)
 
     def forward(
         self,
-        image: torch.Tensor,
-        text: torch.Tensor,
-        text_atts: torch.Tensor = None,
+        image: Tensor,
+        text: Tensor,
+        text_atts: Tensor = None,
         alpha: float = 0.4,
     ):
         image_embeds, text_embeds, image_feat, text_feat = self._unimodal_embeddings(

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -166,7 +166,10 @@ class ALBEFModel(nn.Module):
         )
         batch_size = image_feats.shape[0]
         ptr = int(self.queue_ptr)
-        assert self.queue_size % batch_size == 0
+
+        assert (
+            self.queue_size % batch_size == 0
+        ), "queue_size should be divisible by batch_size"
 
         self.image_queue[:, ptr : ptr + batch_size] = image_feats.T
         self.text_queue[:, ptr : ptr + batch_size] = text_feats.T


### PR DESCRIPTION
Summary:
<!-- Change Summary -->
This is a draft of the ALBEF model, based on the [pre-training](https://github.com/salesforce/ALBEF/blob/6224e78e5292757ca9c7d5add3e415010955a58b/models/model_pretrain.py) logic in the ALBEF repo. 

Here's the [paper](https://arxiv.org/pdf/2107.07651.pdf). 

In addition to the 3 embeddings (image, text, multimodal), `forward` also returns similarity (for `loss_ita`), momentum image embeds  and text attention mask (for `loss_mlm`). 

The original plan was to create an ALBEF architecture, but there are specific computations that need to happen in order to compute the multimodal embedding (momentum updates and similarity calculation), so we thought this serves more as a model rather than an architecture. 

TODO: inside `_update_queue` there is an assertion for simplicity purpose (to match the original repo and and make sure that the outputs match). But eventually want to remove the assertion (which might introduce some randomness when computing similarity with momentum embeddings)

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
I am working on writing tests, but just wanted to put out a draft to get some initial feedback. 

