### PR TITLE
[Refactor] Make dropout layer optional in MLP

### DIFF
--- a/test/modules/layers/test_mlp.py
+++ b/test/modules/layers/test_mlp.py
@@ -9,6 +9,7 @@ from functools import partial
 
 import torch
 from test.test_utils import assert_expected, set_rng_seed
+from torch import nn
 from torchmultimodal.modules.layers.mlp import MLP
 
 
@@ -73,6 +74,23 @@ class TestMLP(unittest.TestCase):
             ]
         )
         assert_expected(actual, expected)
+
+    def test_dropout_default(self):
+        mlp = MLP(
+            in_dim=self.in_dim,
+            out_dim=self.out_dim,
+            hidden_dims=self.hidden_dims,
+        )
+        assert any(isinstance(layer, nn.Dropout) for layer in mlp.model.children())
+
+    def test_no_dropout(self):
+        mlp = MLP(
+            in_dim=self.in_dim,
+            out_dim=self.out_dim,
+            hidden_dims=self.hidden_dims,
+            dropout=0.0,
+        )
+        assert not all(isinstance(layer, nn.Dropout) for layer in mlp.model.children())
 
     def test_torchscript(self):
         mlp = MLP(in_dim=self.in_dim, out_dim=self.out_dim)

--- a/torchmultimodal/modules/layers/mlp.py
+++ b/torchmultimodal/modules/layers/mlp.py
@@ -57,7 +57,8 @@ class MLP(nn.Module):
             if normalization:
                 layers.append(normalization(hidden_dim))
             layers.append(activation())
-            layers.append(nn.Dropout(dropout))
+            if dropout > 0:
+                layers.append(nn.Dropout(dropout))
             in_dim = hidden_dim
         layers.append(nn.Linear(in_dim, out_dim))
         self.model = nn.Sequential(*layers)


### PR DESCRIPTION
Summary:
The transformer layer of Multigen uses an MLP block without dropout so we want to make dropout optional in the current MLP layer when the dropout prob is provided as `0.0`.

Test Plan:
```
(torchmm) langong-mbp:gpt_attention langong$ python -m pytest --cov=torchmultimodal/modules/layers/ test/modules/layers/test_mlp.py -vv
================================================================================ test session starts =================================================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/langong/local/miniconda3/envs/torchmm/bin/python
cachedir: .pytest_cache
rootdir: /Users/langong/gpt_attention
plugins: cov-3.0.0
collected 6 items

test/modules/layers/test_mlp.py::TestMLP::test_activation_and_normalization PASSED                                                                                             [ 16%]
test/modules/layers/test_mlp.py::TestMLP::test_dropout_default PASSED                                                                                                          [ 33%]
test/modules/layers/test_mlp.py::TestMLP::test_no_dropout PASSED                                                                                                               [ 50%]
test/modules/layers/test_mlp.py::TestMLP::test_no_hidden_layers PASSED                                                                                                         [ 66%]
test/modules/layers/test_mlp.py::TestMLP::test_pass_hidden_dims PASSED                                                                                                         [ 83%]
test/modules/layers/test_mlp.py::TestMLP::test_torchscript PASSED                                                                                                              [100%]

---------- coverage: platform darwin, python 3.8.13-final-0 ----------
Name                                                   Stmts   Miss  Cover
--------------------------------------------------------------------------
torchmultimodal/modules/layers/attention.py               97     97     0%
torchmultimodal/modules/layers/codebook.py                81     81     0%
torchmultimodal/modules/layers/conv.py                    74     74     0%
torchmultimodal/modules/layers/mlp.py                     23      1    96%
torchmultimodal/modules/layers/normalizations.py           7      7     0%
torchmultimodal/modules/layers/position_embedding.py      38     38     0%
torchmultimodal/modules/layers/transformer.py            133    133     0%
--------------------------------------------------------------------------
TOTAL                                                    453    431     5%


=========================== 6 passed in 1.82s ====================
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84
* #69
* #68
* #67

Differential Revision: [D37116648](https://our.internmc.facebook.com/intern/diff/D37116648)