### PR TITLE
[ALBEF] vision encoder

### DIFF
--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import OrderedDict
+
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torch import Tensor
+from torchmultimodal.modules.encoders.albef_vision_encoder import PatchEmbed
+
+
+class TestALBEFVisionEncoder:
+    def test_conv_proj(self):
+        set_rng_seed(0)
+        state_dict = OrderedDict(
+            [("proj.weight", torch.randn(3, 3, 4, 4)), ("proj.bias", torch.randn(3))]
+        )
+        conv_proj = PatchEmbed(
+            img_size=4,
+            patch_size=4,
+            in_chans=3,
+            embed_dim=3,
+        )
+        conv_proj.load_state_dict(state_dict)
+        input = torch.randn(1, 3, 4, 4)
+        output = conv_proj(input)
+        expected = Tensor([14.094812, 13.545728, 14.223189]).reshape(1, 1, 3)
+        assert_expected(output, expected)

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -6,6 +6,7 @@
 
 from functools import partial
 
+import pytest
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import nn, Tensor
@@ -68,3 +69,23 @@ class TestALBEFVisionEncoder:
             ]
         ).unsqueeze(0)
         assert_expected(output, expected, rtol=0, atol=1e-4)
+
+    def test_invalid_input_length(self):
+        input = torch.randn(3, 4, 4)
+        with pytest.raises(ValueError, match="not enough values to unpack"):
+            self.vision_encoder(input)
+
+    def test_invalid_image_channel_dim(self):
+        input = torch.rand(1, 1, 4, 4)
+        with pytest.raises(RuntimeError, match="channels"):
+            self.vision_encoder(input)
+
+    def test_invalid_image_height(self):
+        input = torch.rand(1, 3, 5, 4)
+        with pytest.raises(AssertionError, match="Wrong image height!"):
+            self.vision_encoder(input)
+
+    def test_invalid_image_width(self):
+        input = torch.rand(1, 3, 4, 3)
+        with pytest.raises(AssertionError, match="Wrong image width!"):
+            self.vision_encoder(input)

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -9,12 +9,13 @@ from typing import OrderedDict
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import Tensor
-from torchmultimodal.modules.encoders.albef_vision_encoder import PatchEmbed
+from torchmultimodal.modules.encoders.albef_vision_encoder import Attention, PatchEmbed
 
 
 class TestALBEFVisionEncoder:
     def test_conv_proj(self):
         set_rng_seed(0)
+        input = torch.randn(1, 3, 4, 4)
         state_dict = OrderedDict(
             [("proj.weight", torch.randn(3, 3, 4, 4)), ("proj.bias", torch.randn(3))]
         )
@@ -25,7 +26,27 @@ class TestALBEFVisionEncoder:
             embed_dim=3,
         )
         conv_proj.load_state_dict(state_dict)
-        input = torch.randn(1, 3, 4, 4)
         output = conv_proj(input)
-        expected = Tensor([14.094812, 13.545728, 14.223189]).reshape(1, 1, 3)
-        assert_expected(output, expected)
+        expected = Tensor([-3.718719, 2.117420, 6.098923]).reshape(1, 1, 3)
+        assert_expected(output, expected, rtol=0, atol=1e-4)
+
+    def test_attention(self):
+        set_rng_seed(0)
+        input = torch.randn(1, 1, 3)
+        state_dict = OrderedDict(
+            [
+                ("qkv.weight", torch.randn(9, 3)),
+                ("qkv.bias", torch.randn(9)),
+                ("proj.weight", torch.randn(3, 3)),
+                ("proj.bias", torch.randn(3)),
+            ]
+        )
+        attention = Attention(
+            3,
+            num_heads=1,
+            qkv_bias=True,
+        )
+        attention.load_state_dict(state_dict)
+        output = attention(input)
+        expected = Tensor([-12.703959, -9.637766, 7.394966]).reshape(1, 1, 3)
+        assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -8,8 +8,12 @@ from typing import OrderedDict
 
 import torch
 from test.test_utils import assert_expected, set_rng_seed
-from torch import Tensor
-from torchmultimodal.modules.encoders.albef_vision_encoder import Attention, PatchEmbed
+from torch import nn, Tensor
+from torchmultimodal.modules.encoders.albef_vision_encoder import (
+    Attention,
+    Mlp,
+    PatchEmbed,
+)
 
 
 class TestALBEFVisionEncoder:
@@ -49,4 +53,21 @@ class TestALBEFVisionEncoder:
         attention.load_state_dict(state_dict)
         output = attention(input)
         expected = Tensor([-12.703959, -9.637766, 7.394966]).reshape(1, 1, 3)
+        assert_expected(output, expected, rtol=0, atol=1e-4)
+
+    def test_mlp_block(self):
+        set_rng_seed(0)
+        input = torch.randn(1, 1, 3)
+        state_dict = OrderedDict(
+            [
+                ("fc1.weight", torch.randn(6, 3)),
+                ("fc1.bias", torch.randn(6)),
+                ("fc2.weight", torch.randn(3, 6)),
+                ("fc2.bias", torch.randn(3)),
+            ]
+        )
+        mlp = Mlp(3, hidden_features=6, act_layer=nn.GELU)
+        mlp.load_state_dict(state_dict)
+        output = mlp(input)
+        expected = Tensor([4.896436, -0.737119, 1.037403]).reshape(1, 1, 3)
         assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -17,57 +17,55 @@ from torchmultimodal.modules.encoders.albef_vision_encoder import (
 
 
 class TestALBEFVisionEncoder:
+    set_rng_seed(0)
+    input = torch.randn(1, 3, 4, 4)
+    proj_input = torch.randn(1, 1, 3)
+    proj_state_dict = OrderedDict(
+        [("proj.weight", torch.randn(3, 3, 4, 4)), ("proj.bias", torch.randn(3))]
+    )
+    attention_state_dict = OrderedDict(
+        [
+            ("qkv.weight", torch.randn(9, 3)),
+            ("qkv.bias", torch.randn(9)),
+            ("proj.weight", torch.randn(3, 3)),
+            ("proj.bias", torch.randn(3)),
+        ]
+    )
+    mlp_state_dict = OrderedDict(
+        [
+            ("fc1.weight", torch.randn(6, 3)),
+            ("fc1.bias", torch.randn(6)),
+            ("fc2.weight", torch.randn(3, 6)),
+            ("fc2.bias", torch.randn(3)),
+        ]
+    )
+
     def test_conv_proj(self):
-        set_rng_seed(0)
-        input = torch.randn(1, 3, 4, 4)
-        state_dict = OrderedDict(
-            [("proj.weight", torch.randn(3, 3, 4, 4)), ("proj.bias", torch.randn(3))]
-        )
         conv_proj = PatchEmbed(
             img_size=4,
             patch_size=4,
             in_chans=3,
             embed_dim=3,
         )
-        conv_proj.load_state_dict(state_dict)
-        output = conv_proj(input)
-        expected = Tensor([-3.718719, 2.117420, 6.098923]).reshape(1, 1, 3)
+        conv_proj.load_state_dict(self.proj_state_dict)
+        output = conv_proj(self.input)
+        expected = Tensor([-5.115712, 3.110137, -2.686451]).reshape(1, 1, 3)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_attention(self):
-        set_rng_seed(0)
-        input = torch.randn(1, 1, 3)
-        state_dict = OrderedDict(
-            [
-                ("qkv.weight", torch.randn(9, 3)),
-                ("qkv.bias", torch.randn(9)),
-                ("proj.weight", torch.randn(3, 3)),
-                ("proj.bias", torch.randn(3)),
-            ]
-        )
         attention = Attention(
             3,
             num_heads=1,
             qkv_bias=True,
         )
-        attention.load_state_dict(state_dict)
-        output = attention(input)
-        expected = Tensor([-12.703959, -9.637766, 7.394966]).reshape(1, 1, 3)
+        attention.load_state_dict(self.attention_state_dict)
+        output = attention(self.proj_input)
+        expected = Tensor([0.799757, 0.632195, 2.890842]).reshape(1, 1, 3)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_mlp_block(self):
-        set_rng_seed(0)
-        input = torch.randn(1, 1, 3)
-        state_dict = OrderedDict(
-            [
-                ("fc1.weight", torch.randn(6, 3)),
-                ("fc1.bias", torch.randn(6)),
-                ("fc2.weight", torch.randn(3, 6)),
-                ("fc2.bias", torch.randn(3)),
-            ]
-        )
         mlp = Mlp(3, hidden_features=6, act_layer=nn.GELU)
-        mlp.load_state_dict(state_dict)
-        output = mlp(input)
-        expected = Tensor([4.896436, -0.737119, 1.037403]).reshape(1, 1, 3)
+        mlp.load_state_dict(self.mlp_state_dict)
+        output = mlp(self.proj_input)
+        expected = Tensor([14.869835, 3.666760, 0.993663]).reshape(1, 1, 3)
         assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -15,6 +15,7 @@ from torchmultimodal.modules.encoders.albef_vision_encoder import ALBEFVisionEnc
 
 class TestALBEFVisionEncoder:
     set_rng_seed(0)
+    torch.set_printoptions(precision=6)
     vision_encoder = ALBEFVisionEncoder(
         image_size=4,
         patch_size=4,
@@ -25,42 +26,6 @@ class TestALBEFVisionEncoder:
         norm_layer=partial(nn.LayerNorm, eps=1e-6),
     )
 
-    def test_conv_proj(self):
-        # test the conv_proj of the ALBEFVisionEncoder
-        set_rng_seed(0)
-        conv_proj = self.vision_encoder.conv_proj
-        input = torch.randn(1, 3, 4, 4)
-        output = conv_proj(input)
-        expected = Tensor([-0.792905, -0.971702, -0.393140]).reshape(1, 3, 1, 1)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
-    def test_attention(self):
-        # test the attention in an encoder layer
-        set_rng_seed(0)
-        attention = self.vision_encoder.encoder.layers[0].self_attention
-        input = torch.randn(1, 1, 3)
-        output, _ = attention(query=input, key=input, value=input)
-        expected = Tensor([0.226826, 0.262802, -0.304190]).reshape(1, 1, 3)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
-    def test_mlp_block(self):
-        # test the MLP block in an encoder layer
-        set_rng_seed(0)
-        mlp = self.vision_encoder.encoder.layers[0].mlp
-        input = torch.randn(1, 1, 3)
-        output = mlp(input)
-        expected = Tensor([1.498866, -1.010315, 0.139188]).reshape(1, 1, 3)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
-    def test_encoder_block(self):
-        # test an encoder layer of ALBEFVisionEncoder
-        set_rng_seed(0)
-        encoder_block = self.vision_encoder.encoder.layers[0]
-        input = torch.randn(1, 1, 3)
-        output = encoder_block(input)
-        expected = Tensor([2.685928, -0.826006, -2.173242]).reshape(1, 1, 3)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
     def test_vision_transformer(self):
         set_rng_seed(0)
         vit = self.vision_encoder
@@ -68,15 +33,15 @@ class TestALBEFVisionEncoder:
         output = vit(input)
         expected = Tensor(
             [
-                [1.268159, -0.092086, -1.176073],
-                [-0.988629, 1.370074, -0.381445],
+                [1.399478, -0.875986, -0.523492],
+                [-0.869867, 1.400589, -0.530722],
             ]
         ).unsqueeze(0)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_invalid_input_length(self):
         input = torch.randn(3, 4, 4)
-        with pytest.raises(ValueError, match="not enough values to unpack"):
+        with pytest.raises(IndexError, match="index out of range"):
             self.vision_encoder(input)
 
     def test_invalid_image_channel_dim(self):

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -78,7 +78,7 @@ class TestALBEFVisionEncoder:
         conv_proj = self.vision_encoder.conv_proj
         conv_proj.load_state_dict(self.proj_state_dict)
         output = conv_proj(self.input)
-        expected = Tensor([-5.115712, 3.110137, -2.686451]).reshape(1, 1, 3)
+        expected = Tensor([-5.115712, 3.110137, -2.686451]).reshape(1, 3, 1, 1)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_attention(self):

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from functools import partial
-from typing import OrderedDict
 
 import torch
 from test.test_utils import assert_expected, set_rng_seed
@@ -15,54 +14,6 @@ from torchmultimodal.modules.encoders.albef_vision_encoder import ALBEFVisionEnc
 
 class TestALBEFVisionEncoder:
     set_rng_seed(0)
-    input = torch.randn(1, 3, 4, 4)
-    proj_input = torch.randn(1, 1, 3)
-    proj_state_dict = OrderedDict(
-        [("weight", torch.randn(3, 3, 4, 4)), ("bias", torch.randn(3))]
-    )
-    attention_state_dict = OrderedDict(
-        [
-            ("in_proj_weight", torch.randn(9, 3)),
-            ("in_proj_bias", torch.randn(9)),
-            ("out_proj.weight", torch.randn(3, 3)),
-            ("out_proj.bias", torch.randn(3)),
-        ]
-    )
-    mlp_state_dict = OrderedDict(
-        [
-            ("0.weight", torch.randn(6, 3)),
-            ("0.bias", torch.randn(6)),
-            ("3.weight", torch.randn(3, 6)),
-            ("3.bias", torch.randn(3)),
-        ]
-    )
-    encoder_block_state_dict = OrderedDict(
-        [
-            ("ln_1.weight", torch.randn(3)),
-            ("ln_1.bias", torch.randn(3)),
-            ("ln_2.weight", torch.randn(3)),
-            ("ln_2.bias", torch.randn(3)),
-        ]
-        + [("self_attention." + key, val) for key, val in attention_state_dict.items()]
-        + [("mlp." + key, val) for key, val in mlp_state_dict.items()]
-    )
-    vit_state_dict = OrderedDict(
-        [
-            ("class_token", torch.randn(1, 1, 3)),
-            ("encoder.pos_embedding", torch.randn(1, 2, 3)),
-            ("encoder.ln.weight", torch.randn(3)),
-            ("encoder.ln.bias", torch.randn(3)),
-        ]
-        + [("conv_proj." + key, val) for key, val in proj_state_dict.items()]
-        + [
-            ("encoder.layers.encoder_layer_0." + key, val)
-            for key, val in encoder_block_state_dict.items()
-        ]
-        + [
-            ("encoder.layers.encoder_layer_1." + key, val)
-            for key, val in encoder_block_state_dict.items()
-        ]
-    )
     vision_encoder = ALBEFVisionEncoder(
         image_size=4,
         patch_size=4,
@@ -74,43 +25,46 @@ class TestALBEFVisionEncoder:
     )
 
     def test_conv_proj(self):
+        set_rng_seed(0)
         conv_proj = self.vision_encoder.conv_proj
-        conv_proj.load_state_dict(self.proj_state_dict)
-        output = conv_proj(self.input)
-        expected = Tensor([-5.115712, 3.110137, -2.686451]).reshape(1, 3, 1, 1)
+        input = torch.randn(1, 3, 4, 4)
+        output = conv_proj(input)
+        expected = Tensor([-0.792905, -0.971702, -0.393140]).reshape(1, 3, 1, 1)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_attention(self):
+        set_rng_seed(0)
         attention = self.vision_encoder.encoder.layers[0].self_attention
-        attention.load_state_dict(self.attention_state_dict)
-        output, _ = attention(
-            query=self.proj_input, key=self.proj_input, value=self.proj_input
-        )
-        expected = Tensor([0.799757, 0.632195, 2.890842]).reshape(1, 1, 3)
+        input = torch.randn(1, 1, 3)
+        output, _ = attention(query=input, key=input, value=input)
+        expected = Tensor([0.226826, 0.262802, -0.304190]).reshape(1, 1, 3)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_mlp_block(self):
+        set_rng_seed(0)
         mlp = self.vision_encoder.encoder.layers[0].mlp
-        mlp.load_state_dict(self.mlp_state_dict)
-        output = mlp(self.proj_input)
-        expected = Tensor([14.869835, 3.666760, 0.993663]).reshape(1, 1, 3)
+        input = torch.randn(1, 1, 3)
+        output = mlp(input)
+        expected = Tensor([1.498866, -1.010315, 0.139188]).reshape(1, 1, 3)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_encoder_block(self):
+        set_rng_seed(0)
         encoder_block = self.vision_encoder.encoder.layers[0]
-        encoder_block.load_state_dict(self.encoder_block_state_dict)
-        output = encoder_block(self.proj_input)
-        expected = Tensor([41.667698, 15.369812, 1.672322]).reshape(1, 1, 3)
+        input = torch.randn(1, 1, 3)
+        output = encoder_block(input)
+        expected = Tensor([2.685928, -0.826006, -2.173242]).reshape(1, 1, 3)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_vision_transformer(self):
+        set_rng_seed(0)
         vit = self.vision_encoder
-        vit.load_state_dict(self.vit_state_dict)
-        output = vit(self.input)
+        input = torch.randn(1, 3, 4, 4)
+        output = vit(input)
         expected = Tensor(
             [
-                [-2.992489e-02, -3.361803e-01, 2.282364e00],
-                [-1.769625e-03, -3.862467e-01, 2.380805e00],
+                [1.268159, -0.092086, -1.176073],
+                [-0.988629, 1.370074, -0.381445],
             ]
         ).unsqueeze(0)
         assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -84,7 +84,9 @@ class TestALBEFVisionEncoder:
     def test_attention(self):
         attention = self.vision_encoder.encoder.layers[0].self_attention
         attention.load_state_dict(self.attention_state_dict)
-        output = attention(self.proj_input)
+        output, _ = attention(
+            query=self.proj_input, key=self.proj_input, value=self.proj_input
+        )
         expected = Tensor([0.799757, 0.632195, 2.890842]).reshape(1, 1, 3)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -18,44 +18,50 @@ class TestALBEFVisionEncoder:
     input = torch.randn(1, 3, 4, 4)
     proj_input = torch.randn(1, 1, 3)
     proj_state_dict = OrderedDict(
-        [("proj.weight", torch.randn(3, 3, 4, 4)), ("proj.bias", torch.randn(3))]
+        [("weight", torch.randn(3, 3, 4, 4)), ("bias", torch.randn(3))]
     )
     attention_state_dict = OrderedDict(
         [
-            ("qkv.weight", torch.randn(9, 3)),
-            ("qkv.bias", torch.randn(9)),
-            ("proj.weight", torch.randn(3, 3)),
-            ("proj.bias", torch.randn(3)),
+            ("in_proj_weight", torch.randn(9, 3)),
+            ("in_proj_bias", torch.randn(9)),
+            ("out_proj.weight", torch.randn(3, 3)),
+            ("out_proj.bias", torch.randn(3)),
         ]
     )
     mlp_state_dict = OrderedDict(
         [
-            ("fc1.weight", torch.randn(6, 3)),
-            ("fc1.bias", torch.randn(6)),
-            ("fc2.weight", torch.randn(3, 6)),
-            ("fc2.bias", torch.randn(3)),
+            ("0.weight", torch.randn(6, 3)),
+            ("0.bias", torch.randn(6)),
+            ("3.weight", torch.randn(3, 6)),
+            ("3.bias", torch.randn(3)),
         ]
     )
     encoder_block_state_dict = OrderedDict(
         [
-            ("norm1.weight", torch.randn(3)),
-            ("norm1.bias", torch.randn(3)),
-            ("norm2.weight", torch.randn(3)),
-            ("norm2.bias", torch.randn(3)),
+            ("ln_1.weight", torch.randn(3)),
+            ("ln_1.bias", torch.randn(3)),
+            ("ln_2.weight", torch.randn(3)),
+            ("ln_2.bias", torch.randn(3)),
         ]
-        + [("attn." + key, val) for key, val in attention_state_dict.items()]
+        + [("self_attention." + key, val) for key, val in attention_state_dict.items()]
         + [("mlp." + key, val) for key, val in mlp_state_dict.items()]
     )
     vit_state_dict = OrderedDict(
         [
-            ("cls_token", torch.randn(1, 1, 3)),
-            ("pos_embed", torch.randn(1, 2, 3)),
-            ("norm.weight", torch.randn(3)),
-            ("norm.bias", torch.randn(3)),
+            ("class_token", torch.randn(1, 1, 3)),
+            ("encoder.pos_embedding", torch.randn(1, 2, 3)),
+            ("encoder.ln.weight", torch.randn(3)),
+            ("encoder.ln.bias", torch.randn(3)),
         ]
-        + [("patch_embed." + key, val) for key, val in proj_state_dict.items()]
-        + [("blocks.0." + key, val) for key, val in encoder_block_state_dict.items()]
-        + [("blocks.1." + key, val) for key, val in encoder_block_state_dict.items()]
+        + [("conv_proj." + key, val) for key, val in proj_state_dict.items()]
+        + [
+            ("encoder.layers.encoder_layer_0." + key, val)
+            for key, val in encoder_block_state_dict.items()
+        ]
+        + [
+            ("encoder.layers.encoder_layer_1." + key, val)
+            for key, val in encoder_block_state_dict.items()
+        ]
     )
     vision_encoder = ALBEFVisionEncoder(
         image_size=4,

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -26,6 +26,7 @@ class TestALBEFVisionEncoder:
     )
 
     def test_conv_proj(self):
+        # test the conv_proj of the ALBEFVisionEncoder
         set_rng_seed(0)
         conv_proj = self.vision_encoder.conv_proj
         input = torch.randn(1, 3, 4, 4)
@@ -34,6 +35,7 @@ class TestALBEFVisionEncoder:
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_attention(self):
+        # test the attention in an encoder layer
         set_rng_seed(0)
         attention = self.vision_encoder.encoder.layers[0].self_attention
         input = torch.randn(1, 1, 3)
@@ -42,6 +44,7 @@ class TestALBEFVisionEncoder:
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_mlp_block(self):
+        # test the MLP block in an encoder layer
         set_rng_seed(0)
         mlp = self.vision_encoder.encoder.layers[0].mlp
         input = torch.randn(1, 1, 3)
@@ -50,6 +53,7 @@ class TestALBEFVisionEncoder:
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
     def test_encoder_block(self):
+        # test an encoder layer of ALBEFVisionEncoder
         set_rng_seed(0)
         encoder_block = self.vision_encoder.encoder.layers[0]
         input = torch.randn(1, 1, 3)

--- a/test/modules/encoders/test_albef_vision_encoder.py
+++ b/test/modules/encoders/test_albef_vision_encoder.py
@@ -71,7 +71,6 @@ class TestALBEFVisionEncoder:
         hidden_dim=3,
         mlp_dim=6,
         norm_layer=partial(nn.LayerNorm, eps=1e-6),
-        num_classes=3,
     )
 
     def test_conv_proj(self):

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -36,6 +36,18 @@ class ALBEFVisionEncoder(VisionTransformer):
         )
         self.heads = None
 
+    def forward(self, x: torch.Tensor):
+        # Reshape and permute the input tensor
+        x = self._process_input(x)
+        n = x.shape[0]
+
+        # Expand the class token to the full batch
+        batch_class_token = self.class_token.expand(n, -1, -1)
+        x = torch.cat([batch_class_token, x], dim=1)
+
+        x = self.encoder(x)
+        return x
+
 
 def interpolate_pos_embed(pos_embed_checkpoint, visual_encoder):
     # interpolate position embedding

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -45,8 +45,8 @@ class ALBEFVisionEncoder(nn.Module):
         mlp_dim: int = 3072,
         dropout: float = 0.0,
         attention_dropout: float = 0.0,
-        norm_layer: Callable[..., torch.nn.Module] = partial(nn.LayerNorm, eps=1e-6),
-    ):
+        norm_layer: Callable[..., nn.Module] = partial(nn.LayerNorm, eps=1e-6),
+    ) -> None:
         super().__init__()
         torch._assert(
             image_size % patch_size == 0, "Input shape indivisible by patch size!"

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -29,7 +29,6 @@ class ALBEFVisionEncoder(nn.Module):
         mlp_dim (int): Dimensionality of the MLP Block in the encoder layers
         dropout (float): The dropout ratio for the encoder probabilities
         attention_dropout (float): The dropout ratio for the attention probabilities
-        num_classes (int) The number of output classes
         norm_layer (Callable[..., torch.nn.Module]): The normalization layer in the encoder layers
 
     Inputs:
@@ -46,7 +45,6 @@ class ALBEFVisionEncoder(nn.Module):
         mlp_dim: int = 3072,
         dropout: float = 0.0,
         attention_dropout: float = 0.0,
-        num_classes: int = 768,
         norm_layer: Callable[..., torch.nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ):
         super().__init__()
@@ -59,7 +57,6 @@ class ALBEFVisionEncoder(nn.Module):
         self.mlp_dim = mlp_dim
         self.attention_dropout = attention_dropout
         self.dropout = dropout
-        self.num_classes = num_classes
         self.norm_layer = norm_layer
         self.conv_proj = nn.Conv2d(
             in_channels=3,

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -14,6 +14,28 @@ from torchvision.models.vision_transformer import Encoder
 
 
 class ALBEFVisionEncoder(nn.Module):
+    """
+    Modified VisionTransformer used by ALBEF.
+
+    Based on https://github.com/pytorch/vision/blob/main/torchvision/models/vision_transformer.py#L160.
+    This class removes the heads from VisionTransformer.
+
+    Args:
+        image_size (int): The size (resolution) of each image
+        patch_size (int) The size (resolution) of each patch
+        num_layers (int): Number of hidden layers in the Transformer encoder
+        num_heads (int): Number of attention heads for each attention layer in the Transformer encoder
+        hidden_dim (int): Dimensionality of the encoder layers and the pooler layer
+        mlp_dim (int): Dimensionality of the MLP Block in the encoder layers
+        dropout (float): The dropout ratio for the encoder probabilities
+        attention_dropout (float): The dropout ratio for the attention probabilities
+        num_classes (int) The number of output classes
+        norm_layer (Callable[..., torch.nn.Module]): The normalization layer in the encoder layers
+
+    Inputs:
+        x (Tensor): Tensor of size (n, c, image_size, image_size) containing image features
+    """
+
     def __init__(
         self,
         image_size: int = 256,

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -4,13 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
 from functools import partial
 from typing import Callable
 
-import torch
 from torch import nn, Tensor
-from torchvision.models.vision_transformer import Encoder
+from torchvision.models.feature_extraction import create_feature_extractor
+from torchvision.models.vision_transformer import VisionTransformer
 
 
 class ALBEFVisionEncoder(nn.Module):
@@ -48,81 +47,18 @@ class ALBEFVisionEncoder(nn.Module):
         norm_layer: Callable[..., nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ) -> None:
         super().__init__()
-        torch._assert(
-            image_size % patch_size == 0, "Input shape indivisible by patch size!"
-        )
-        self.image_size = image_size
-        self.patch_size = patch_size
-        self.hidden_dim = hidden_dim
-        self.mlp_dim = mlp_dim
-        self.attention_dropout = attention_dropout
-        self.dropout = dropout
-        self.norm_layer = norm_layer
-        self.conv_proj = nn.Conv2d(
-            in_channels=3,
-            out_channels=hidden_dim,
-            kernel_size=patch_size,
-            stride=patch_size,
-        )
-
-        seq_length = (image_size // patch_size) ** 2
-
-        # Add a class token
-        self.class_token = nn.Parameter(torch.zeros(1, 1, hidden_dim))
-        seq_length += 1
-
-        self.encoder = Encoder(
-            seq_length,
+        vision_transformer = VisionTransformer(
+            image_size,
+            patch_size,
             num_layers,
             num_heads,
             hidden_dim,
             mlp_dim,
             dropout,
             attention_dropout,
-            norm_layer,
+            norm_layer=norm_layer,
         )
-        self.seq_length = seq_length
-
-        # Init the patchify stem
-        fan_in = (
-            self.conv_proj.in_channels
-            * self.conv_proj.kernel_size[0]
-            * self.conv_proj.kernel_size[1]
-        )
-        nn.init.trunc_normal_(self.conv_proj.weight, std=math.sqrt(1 / fan_in))
-        if self.conv_proj.bias is not None:
-            nn.init.zeros_(self.conv_proj.bias)
-
-    def _process_input(self, x: Tensor) -> Tensor:
-        n, c, h, w = x.shape
-        p = self.patch_size
-        torch._assert(h == self.image_size, "Wrong image height!")
-        torch._assert(w == self.image_size, "Wrong image width!")
-        n_h = h // p
-        n_w = w // p
-
-        # (n, c, h, w) -> (n, hidden_dim, n_h, n_w)
-        x = self.conv_proj(x)
-        # (n, hidden_dim, n_h, n_w) -> (n, hidden_dim, (n_h * n_w))
-        x = x.reshape(n, self.hidden_dim, n_h * n_w)
-
-        # (n, hidden_dim, (n_h * n_w)) -> (n, (n_h * n_w), hidden_dim)
-        # The self attention layer expects inputs in the format (N, S, E)
-        # where S is the source sequence length, N is the batch size, E is the
-        # embedding dimension
-        x = x.permute(0, 2, 1)
-
-        return x
+        self.encoder = create_feature_extractor(vision_transformer, ["encoder.ln"])
 
     def forward(self, x: Tensor) -> Tensor:
-        # Reshape and permute the input tensor
-        x = self._process_input(x)
-        n = x.shape[0]
-
-        # Expand the class token to the full batch
-        batch_class_token = self.class_token.expand(n, -1, -1)
-        x = torch.cat([batch_class_token, x], dim=1)
-
-        x = self.encoder(x)
-
-        return x
+        return self.encoder(x)["encoder.ln"]

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -9,7 +9,7 @@ from functools import partial
 from typing import Callable
 
 import torch
-from torch import nn
+from torch import nn, Tensor
 from torchvision.models.vision_transformer import Encoder
 
 
@@ -74,7 +74,7 @@ class ALBEFVisionEncoder(nn.Module):
         if self.conv_proj.bias is not None:
             nn.init.zeros_(self.conv_proj.bias)
 
-    def _process_input(self, x: torch.Tensor) -> torch.Tensor:
+    def _process_input(self, x: Tensor) -> Tensor:
         n, c, h, w = x.shape
         p = self.patch_size
         torch._assert(h == self.image_size, "Wrong image height!")
@@ -95,7 +95,7 @@ class ALBEFVisionEncoder(nn.Module):
 
         return x
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: Tensor) -> Tensor:
         # Reshape and permute the input tensor
         x = self._process_input(x)
         n = x.shape[0]

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -1,0 +1,334 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+import torch
+from torch import nn
+from torch.nn.init import trunc_normal_
+from torch.nn.modules.utils import _pair as to_2tuple
+
+
+class PatchEmbed(nn.Module):
+    """2D Image to Patch Embedding"""
+
+    def __init__(
+        self,
+        img_size=224,
+        patch_size=16,
+        in_chans=3,
+        embed_dim=768,
+        norm_layer=None,
+        flatten=True,
+    ):
+        super().__init__()
+        img_size = to_2tuple(img_size)
+        patch_size = to_2tuple(patch_size)
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.grid_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
+        self.num_patches = self.grid_size[0] * self.grid_size[1]
+        self.flatten = flatten
+
+        self.proj = nn.Conv2d(
+            in_chans, embed_dim, kernel_size=patch_size, stride=patch_size
+        )
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    def forward(self, x):
+        b, c, h, w = x.shape
+        torch._assert(
+            h == self.img_size[0],
+            f"Input image height ({h}) doesn't match model ({self.img_size[0]}).",
+        )
+        torch._assert(
+            w == self.img_size[1],
+            f"Input image width ({w}) doesn't match model ({self.img_size[1]}).",
+        )
+        x = self.proj(x)
+        if self.flatten:
+            x = x.flatten(2).transpose(1, 2)  # BCHW -> BNC
+        x = self.norm(x)
+        return x
+
+
+class Mlp(nn.Module):
+    """MLP as used in Vision Transformer, MLP-Mixer and related networks"""
+
+    def __init__(
+        self,
+        in_features,
+        hidden_features=None,
+        out_features=None,
+        act_layer=nn.GELU,
+        drop=0.0,
+    ):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads=8,
+        qkv_bias=False,
+        qk_scale=None,
+        attn_drop=0.0,
+        proj_drop=0.0,
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        # NOTE scale factor was wrong in my original version, can set manually to be compat with prev weights
+        self.scale = qk_scale or head_dim**-0.5
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.attn_gradients = None
+        self.attention_map = None
+
+    def save_attn_gradients(self, attn_gradients):
+        self.attn_gradients = attn_gradients
+
+    def get_attn_gradients(self):
+        return self.attn_gradients
+
+    def save_attention_map(self, attention_map):
+        self.attention_map = attention_map
+
+    def get_attention_map(self):
+        return self.attention_map
+
+    def forward(self, x, register_hook=False):
+        b, n, c = x.shape
+        qkv = (
+            self.qkv(x)
+            .reshape(b, n, 3, self.num_heads, c // self.num_heads)
+            .permute(2, 0, 3, 1, 4)
+        )
+        q, k, v = (
+            qkv[0],
+            qkv[1],
+            qkv[2],
+        )  # make torchscript happy (cannot use tensor as tuple)
+
+        attn = (q @ k.transpose(-2, -1)) * self.scale
+        attn = attn.softmax(dim=-1)
+        attn = self.attn_drop(attn)
+
+        if register_hook:
+            self.save_attention_map(attn)
+            attn.register_hook(self.save_attn_gradients)
+
+        x = (attn @ v).transpose(1, 2).reshape(b, n, c)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        mlp_ratio=4.0,
+        qkv_bias=False,
+        qk_scale=None,
+        drop=0.0,
+        attn_drop=0.0,
+        drop_path=0.0,
+        act_layer=nn.GELU,
+        norm_layer=nn.LayerNorm,
+    ):
+        super().__init__()
+        self.norm1 = norm_layer(dim)
+        self.attn = Attention(
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+            attn_drop=attn_drop,
+            proj_drop=drop,
+        )
+        # NOTE: drop path for stochastic depth, we shall see if this is better than dropout here
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.norm2 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=drop,
+        )
+
+    def forward(self, x, register_hook=False):
+        x = x + self.drop_path(self.attn(self.norm1(x), register_hook=register_hook))
+        x = x + self.drop_path(self.mlp(self.norm2(x)))
+        return x
+
+
+class VisionTransformer(nn.Module):
+    """Vision Transformer
+    A PyTorch impl of : `An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale`  -
+        https://arxiv.org/abs/2010.11929
+    """
+
+    def __init__(
+        self,
+        img_size=224,
+        patch_size=16,
+        in_chans=3,
+        num_classes=1000,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        mlp_ratio=4.0,
+        qkv_bias=True,
+        qk_scale=None,
+        representation_size=None,
+        drop_rate=0.0,
+        attn_drop_rate=0.0,
+        drop_path_rate=0.0,
+        norm_layer=None,
+    ):
+        """
+        Args:
+            img_size (int, tuple): input image size
+            patch_size (int, tuple): patch size
+            in_chans (int): number of input channels
+            num_classes (int): number of classes for classification head
+            embed_dim (int): embedding dimension
+            depth (int): depth of transformer
+            num_heads (int): number of attention heads
+            mlp_ratio (int): ratio of mlp hidden dim to embedding dim
+            qkv_bias (bool): enable bias for qkv if True
+            qk_scale (float): override default qk scale of head_dim ** -0.5 if set
+            representation_size (Optional[int]): enable and set representation layer (pre-logits) to this value if set
+            drop_rate (float): dropout rate
+            attn_drop_rate (float): attention dropout rate
+            drop_path_rate (float): stochastic depth rate
+            norm_layer: (nn.Module): normalization layer
+        """
+        super().__init__()
+        self.num_features = (
+            self.embed_dim
+        ) = embed_dim  # num_features for consistency with other models
+        norm_layer = norm_layer or partial(nn.LayerNorm, eps=1e-6)
+
+        self.patch_embed = PatchEmbed(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+        )
+        num_patches = self.patch_embed.num_patches
+
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
+        self.pos_drop = nn.Dropout(p=drop_rate)
+
+        dpr = [
+            x.item() for x in torch.linspace(0, drop_path_rate, depth)
+        ]  # stochastic depth decay rule
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    dim=embed_dim,
+                    num_heads=num_heads,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=qkv_bias,
+                    qk_scale=qk_scale,
+                    drop=drop_rate,
+                    attn_drop=attn_drop_rate,
+                    drop_path=dpr[i],
+                    norm_layer=norm_layer,
+                )
+                for i in range(depth)
+            ]
+        )
+        self.norm = norm_layer(embed_dim)
+
+        trunc_normal_(self.pos_embed, std=0.02)
+        trunc_normal_(self.cls_token, std=0.02)
+        self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, nn.Linear):
+            trunc_normal_(m.weight, std=0.02)
+            if isinstance(m, nn.Linear) and m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+        elif isinstance(m, nn.LayerNorm):
+            nn.init.constant_(m.bias, 0)
+            nn.init.constant_(m.weight, 1.0)
+
+    @torch.jit.ignore
+    def no_weight_decay(self):
+        return {"pos_embed", "cls_token"}
+
+    def forward(self, x, register_blk=-1):
+        b = x.shape[0]
+        x = self.patch_embed(x)
+
+        cls_tokens = self.cls_token.expand(
+            b, -1, -1
+        )  # stole cls_tokens impl from Phil Wang, thanks
+        x = torch.cat((cls_tokens, x), dim=1)
+
+        x = x + self.pos_embed[:, : x.size(1), :]
+        x = self.pos_drop(x)
+
+        for i, blk in enumerate(self.blocks):
+            x = blk(x, register_blk == i)
+        x = self.norm(x)
+
+        return x
+
+
+def interpolate_pos_embed(pos_embed_checkpoint, visual_encoder):
+    # interpolate position embedding
+    embedding_size = pos_embed_checkpoint.shape[-1]
+    num_patches = visual_encoder.patch_embed.num_patches
+    num_extra_tokens = visual_encoder.pos_embed.shape[-2] - num_patches
+    # height (== width) for the checkpoint position embedding
+    orig_size = int((pos_embed_checkpoint.shape[-2] - num_extra_tokens) ** 0.5)
+    # height (== width) for the new position embedding
+    new_size = int(num_patches**0.5)
+
+    if orig_size != new_size:
+        # class_token and dist_token are kept unchanged
+        extra_tokens = pos_embed_checkpoint[:, :num_extra_tokens]
+        # only the position tokens are interpolated
+        pos_tokens = pos_embed_checkpoint[:, num_extra_tokens:]
+        pos_tokens = pos_tokens.reshape(
+            -1, orig_size, orig_size, embedding_size
+        ).permute(0, 3, 1, 2)
+        pos_tokens = torch.nn.functional.interpolate(
+            pos_tokens, size=(new_size, new_size), mode="bicubic", align_corners=False
+        )
+        pos_tokens = pos_tokens.permute(0, 2, 3, 1).flatten(1, 2)
+        new_pos_embed = torch.cat((extra_tokens, pos_tokens), dim=1)
+        print(
+            "reshape position embedding from %d to %d" % (orig_size**2, new_size**2)
+        )
+
+        return new_pos_embed
+    else:
+        return pos_embed_checkpoint

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -16,8 +16,7 @@ class ALBEFVisionEncoder(nn.Module):
     """
     Modified VisionTransformer used by ALBEF.
 
-    Based on https://github.com/pytorch/vision/blob/main/torchvision/models/vision_transformer.py#L160.
-    This class removes the heads from VisionTransformer.
+    This class returns the output of the encoder ('encoder.ln'), without passing it to the heads.
 
     Args:
         image_size (int): The size (resolution) of each image
@@ -58,7 +57,10 @@ class ALBEFVisionEncoder(nn.Module):
             attention_dropout,
             norm_layer=norm_layer,
         )
-        self.encoder = create_feature_extractor(vision_transformer, ["encoder.ln"])
+        self.encoder_layer_name = "encoder.ln"
+        self.encoder = create_feature_extractor(
+            vision_transformer, [self.encoder_layer_name]
+        )
 
     def forward(self, x: Tensor) -> Tensor:
-        return self.encoder(x)["encoder.ln"]
+        return self.encoder(x)[self.encoder_layer_name]

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -5,301 +5,35 @@
 # LICENSE file in the root directory of this source tree.
 
 from functools import partial
+from typing import Callable
 
 import torch
 from torch import nn
-from torch.nn.init import trunc_normal_
-from torch.nn.modules.utils import _pair as to_2tuple
+from torchvision.models.vision_transformer import VisionTransformer
 
 
-class PatchEmbed(nn.Module):
-    """2D Image to Patch Embedding"""
-
+class ALBEFVisionEncoder(VisionTransformer):
     def __init__(
         self,
-        img_size=224,
-        patch_size=16,
-        in_chans=3,
-        embed_dim=768,
-        norm_layer=None,
-        flatten=True,
+        image_size: int = 256,
+        patch_size: int = 16,
+        num_layers: int = 12,
+        num_heads: int = 12,
+        hidden_dim: int = 768,
+        mlp_dim: int = 3072,
+        num_classes: int = 768,
+        norm_layer: Callable[..., torch.nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ):
-        super().__init__()
-        img_size = to_2tuple(img_size)
-        patch_size = to_2tuple(patch_size)
-        self.img_size = img_size
-        self.patch_size = patch_size
-        self.grid_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
-        self.num_patches = self.grid_size[0] * self.grid_size[1]
-        self.flatten = flatten
-
-        self.proj = nn.Conv2d(
-            in_chans, embed_dim, kernel_size=patch_size, stride=patch_size
-        )
-        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
-
-    def forward(self, x):
-        b, c, h, w = x.shape
-        torch._assert(
-            h == self.img_size[0],
-            f"Input image height ({h}) doesn't match model ({self.img_size[0]}).",
-        )
-        torch._assert(
-            w == self.img_size[1],
-            f"Input image width ({w}) doesn't match model ({self.img_size[1]}).",
-        )
-        x = self.proj(x)
-        if self.flatten:
-            x = x.flatten(2).transpose(1, 2)  # BCHW -> BNC
-        x = self.norm(x)
-        return x
-
-
-class Mlp(nn.Module):
-    """MLP as used in Vision Transformer, MLP-Mixer and related networks"""
-
-    def __init__(
-        self,
-        in_features,
-        hidden_features=None,
-        out_features=None,
-        act_layer=nn.GELU,
-        drop=0.0,
-    ):
-        super().__init__()
-        out_features = out_features or in_features
-        hidden_features = hidden_features or in_features
-        self.fc1 = nn.Linear(in_features, hidden_features)
-        self.act = act_layer()
-        self.fc2 = nn.Linear(hidden_features, out_features)
-        self.drop = nn.Dropout(drop)
-
-    def forward(self, x):
-        x = self.fc1(x)
-        x = self.act(x)
-        x = self.drop(x)
-        x = self.fc2(x)
-        x = self.drop(x)
-        return x
-
-
-class Attention(nn.Module):
-    def __init__(
-        self,
-        dim,
-        num_heads=8,
-        qkv_bias=False,
-        qk_scale=None,
-        attn_drop=0.0,
-        proj_drop=0.0,
-    ):
-        super().__init__()
-        self.num_heads = num_heads
-        head_dim = dim // num_heads
-        # NOTE scale factor was wrong in my original version, can set manually to be compat with prev weights
-        self.scale = qk_scale or head_dim**-0.5
-        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
-        self.attn_drop = nn.Dropout(attn_drop)
-        self.proj = nn.Linear(dim, dim)
-        self.proj_drop = nn.Dropout(proj_drop)
-        self.attn_gradients = None
-        self.attention_map = None
-
-    def save_attn_gradients(self, attn_gradients):
-        self.attn_gradients = attn_gradients
-
-    def get_attn_gradients(self):
-        return self.attn_gradients
-
-    def save_attention_map(self, attention_map):
-        self.attention_map = attention_map
-
-    def get_attention_map(self):
-        return self.attention_map
-
-    def forward(self, x, register_hook=False):
-        b, n, c = x.shape
-        qkv = (
-            self.qkv(x)
-            .reshape(b, n, 3, self.num_heads, c // self.num_heads)
-            .permute(2, 0, 3, 1, 4)
-        )
-        q, k, v = (
-            qkv[0],
-            qkv[1],
-            qkv[2],
-        )  # make torchscript happy (cannot use tensor as tuple)
-
-        attn = (q @ k.transpose(-2, -1)) * self.scale
-        attn = attn.softmax(dim=-1)
-        attn = self.attn_drop(attn)
-
-        if register_hook:
-            self.save_attention_map(attn)
-            attn.register_hook(self.save_attn_gradients)
-
-        x = (attn @ v).transpose(1, 2).reshape(b, n, c)
-        x = self.proj(x)
-        x = self.proj_drop(x)
-        return x
-
-
-class Block(nn.Module):
-    def __init__(
-        self,
-        dim,
-        num_heads,
-        mlp_ratio=4.0,
-        qkv_bias=False,
-        qk_scale=None,
-        drop=0.0,
-        attn_drop=0.0,
-        drop_path=0.0,
-        act_layer=nn.GELU,
-        norm_layer=nn.LayerNorm,
-    ):
-        super().__init__()
-        self.norm1 = norm_layer(dim)
-        self.attn = Attention(
-            dim,
-            num_heads=num_heads,
-            qkv_bias=qkv_bias,
-            qk_scale=qk_scale,
-            attn_drop=attn_drop,
-            proj_drop=drop,
-        )
-        # NOTE: drop path for stochastic depth, we shall see if this is better than dropout here
-        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
-        self.norm2 = norm_layer(dim)
-        mlp_hidden_dim = int(dim * mlp_ratio)
-        self.mlp = Mlp(
-            in_features=dim,
-            hidden_features=mlp_hidden_dim,
-            act_layer=act_layer,
-            drop=drop,
-        )
-
-    def forward(self, x, register_hook=False):
-        x = x + self.drop_path(self.attn(self.norm1(x), register_hook=register_hook))
-        x = x + self.drop_path(self.mlp(self.norm2(x)))
-        return x
-
-
-class VisionTransformer(nn.Module):
-    """Vision Transformer
-    A PyTorch impl of : `An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale`  -
-        https://arxiv.org/abs/2010.11929
-    """
-
-    def __init__(
-        self,
-        img_size=224,
-        patch_size=16,
-        in_chans=3,
-        num_classes=1000,
-        embed_dim=768,
-        depth=12,
-        num_heads=12,
-        mlp_ratio=4.0,
-        qkv_bias=True,
-        qk_scale=None,
-        representation_size=None,
-        drop_rate=0.0,
-        attn_drop_rate=0.0,
-        drop_path_rate=0.0,
-        norm_layer=None,
-    ):
-        """
-        Args:
-            img_size (int, tuple): input image size
-            patch_size (int, tuple): patch size
-            in_chans (int): number of input channels
-            num_classes (int): number of classes for classification head
-            embed_dim (int): embedding dimension
-            depth (int): depth of transformer
-            num_heads (int): number of attention heads
-            mlp_ratio (int): ratio of mlp hidden dim to embedding dim
-            qkv_bias (bool): enable bias for qkv if True
-            qk_scale (float): override default qk scale of head_dim ** -0.5 if set
-            representation_size (Optional[int]): enable and set representation layer (pre-logits) to this value if set
-            drop_rate (float): dropout rate
-            attn_drop_rate (float): attention dropout rate
-            drop_path_rate (float): stochastic depth rate
-            norm_layer: (nn.Module): normalization layer
-        """
-        super().__init__()
-        self.num_features = (
-            self.embed_dim
-        ) = embed_dim  # num_features for consistency with other models
-        norm_layer = norm_layer or partial(nn.LayerNorm, eps=1e-6)
-
-        self.patch_embed = PatchEmbed(
-            img_size=img_size,
+        super().__init__(
+            image_size=image_size,
             patch_size=patch_size,
-            in_chans=in_chans,
-            embed_dim=embed_dim,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            hidden_dim=hidden_dim,
+            mlp_dim=mlp_dim,
+            num_classes=num_classes,
+            norm_layer=norm_layer,
         )
-        num_patches = self.patch_embed.num_patches
-
-        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
-        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
-        self.pos_drop = nn.Dropout(p=drop_rate)
-
-        dpr = [
-            x.item() for x in torch.linspace(0, drop_path_rate, depth)
-        ]  # stochastic depth decay rule
-        self.blocks = nn.ModuleList(
-            [
-                Block(
-                    dim=embed_dim,
-                    num_heads=num_heads,
-                    mlp_ratio=mlp_ratio,
-                    qkv_bias=qkv_bias,
-                    qk_scale=qk_scale,
-                    drop=drop_rate,
-                    attn_drop=attn_drop_rate,
-                    drop_path=dpr[i],
-                    norm_layer=norm_layer,
-                )
-                for i in range(depth)
-            ]
-        )
-        self.norm = norm_layer(embed_dim)
-
-        trunc_normal_(self.pos_embed, std=0.02)
-        trunc_normal_(self.cls_token, std=0.02)
-        self.apply(self._init_weights)
-
-    def _init_weights(self, m):
-        if isinstance(m, nn.Linear):
-            trunc_normal_(m.weight, std=0.02)
-            if isinstance(m, nn.Linear) and m.bias is not None:
-                nn.init.constant_(m.bias, 0)
-        elif isinstance(m, nn.LayerNorm):
-            nn.init.constant_(m.bias, 0)
-            nn.init.constant_(m.weight, 1.0)
-
-    @torch.jit.ignore
-    def no_weight_decay(self):
-        return {"pos_embed", "cls_token"}
-
-    def forward(self, x, register_blk=-1):
-        b = x.shape[0]
-        x = self.patch_embed(x)
-
-        cls_tokens = self.cls_token.expand(
-            b, -1, -1
-        )  # stole cls_tokens impl from Phil Wang, thanks
-        x = torch.cat((cls_tokens, x), dim=1)
-
-        x = x + self.pos_embed[:, : x.size(1), :]
-        x = self.pos_drop(x)
-
-        for i, blk in enumerate(self.blocks):
-            x = blk(x, register_blk == i)
-        x = self.norm(x)
-
-        return x
 
 
 def interpolate_pos_embed(pos_embed_checkpoint, visual_encoder):

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -47,35 +47,3 @@ class ALBEFVisionEncoder(VisionTransformer):
 
         x = self.encoder(x)
         return x
-
-
-def interpolate_pos_embed(pos_embed_checkpoint, visual_encoder):
-    # interpolate position embedding
-    embedding_size = pos_embed_checkpoint.shape[-1]
-    num_patches = visual_encoder.patch_embed.num_patches
-    num_extra_tokens = visual_encoder.pos_embed.shape[-2] - num_patches
-    # height (== width) for the checkpoint position embedding
-    orig_size = int((pos_embed_checkpoint.shape[-2] - num_extra_tokens) ** 0.5)
-    # height (== width) for the new position embedding
-    new_size = int(num_patches**0.5)
-
-    if orig_size != new_size:
-        # class_token and dist_token are kept unchanged
-        extra_tokens = pos_embed_checkpoint[:, :num_extra_tokens]
-        # only the position tokens are interpolated
-        pos_tokens = pos_embed_checkpoint[:, num_extra_tokens:]
-        pos_tokens = pos_tokens.reshape(
-            -1, orig_size, orig_size, embedding_size
-        ).permute(0, 3, 1, 2)
-        pos_tokens = torch.nn.functional.interpolate(
-            pos_tokens, size=(new_size, new_size), mode="bicubic", align_corners=False
-        )
-        pos_tokens = pos_tokens.permute(0, 2, 3, 1).flatten(1, 2)
-        new_pos_embed = torch.cat((extra_tokens, pos_tokens), dim=1)
-        print(
-            "reshape position embedding from %d to %d" % (orig_size**2, new_size**2)
-        )
-
-        return new_pos_embed
-    else:
-        return pos_embed_checkpoint

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -4,15 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
 from functools import partial
 from typing import Callable
 
 import torch
 from torch import nn
-from torchvision.models.vision_transformer import VisionTransformer
+from torchvision.models.vision_transformer import Encoder
 
 
-class ALBEFVisionEncoder(VisionTransformer):
+class ALBEFVisionEncoder(nn.Module):
     def __init__(
         self,
         image_size: int = 256,
@@ -21,20 +22,78 @@ class ALBEFVisionEncoder(VisionTransformer):
         num_heads: int = 12,
         hidden_dim: int = 768,
         mlp_dim: int = 3072,
+        dropout: float = 0.0,
+        attention_dropout: float = 0.0,
         num_classes: int = 768,
         norm_layer: Callable[..., torch.nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ):
-        super().__init__(
-            image_size=image_size,
-            patch_size=patch_size,
-            num_layers=num_layers,
-            num_heads=num_heads,
-            hidden_dim=hidden_dim,
-            mlp_dim=mlp_dim,
-            num_classes=num_classes,
-            norm_layer=norm_layer,
+        super().__init__()
+        torch._assert(
+            image_size % patch_size == 0, "Input shape indivisible by patch size!"
         )
-        self.heads = None
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.hidden_dim = hidden_dim
+        self.mlp_dim = mlp_dim
+        self.attention_dropout = attention_dropout
+        self.dropout = dropout
+        self.num_classes = num_classes
+        self.norm_layer = norm_layer
+        self.conv_proj = nn.Conv2d(
+            in_channels=3,
+            out_channels=hidden_dim,
+            kernel_size=patch_size,
+            stride=patch_size,
+        )
+
+        seq_length = (image_size // patch_size) ** 2
+
+        # Add a class token
+        self.class_token = nn.Parameter(torch.zeros(1, 1, hidden_dim))
+        seq_length += 1
+
+        self.encoder = Encoder(
+            seq_length,
+            num_layers,
+            num_heads,
+            hidden_dim,
+            mlp_dim,
+            dropout,
+            attention_dropout,
+            norm_layer,
+        )
+        self.seq_length = seq_length
+
+        # Init the patchify stem
+        fan_in = (
+            self.conv_proj.in_channels
+            * self.conv_proj.kernel_size[0]
+            * self.conv_proj.kernel_size[1]
+        )
+        nn.init.trunc_normal_(self.conv_proj.weight, std=math.sqrt(1 / fan_in))
+        if self.conv_proj.bias is not None:
+            nn.init.zeros_(self.conv_proj.bias)
+
+    def _process_input(self, x: torch.Tensor) -> torch.Tensor:
+        n, c, h, w = x.shape
+        p = self.patch_size
+        torch._assert(h == self.image_size, "Wrong image height!")
+        torch._assert(w == self.image_size, "Wrong image width!")
+        n_h = h // p
+        n_w = w // p
+
+        # (n, c, h, w) -> (n, hidden_dim, n_h, n_w)
+        x = self.conv_proj(x)
+        # (n, hidden_dim, n_h, n_w) -> (n, hidden_dim, (n_h * n_w))
+        x = x.reshape(n, self.hidden_dim, n_h * n_w)
+
+        # (n, hidden_dim, (n_h * n_w)) -> (n, (n_h * n_w), hidden_dim)
+        # The self attention layer expects inputs in the format (N, S, E)
+        # where S is the source sequence length, N is the batch size, E is the
+        # embedding dimension
+        x = x.permute(0, 2, 1)
+
+        return x
 
     def forward(self, x: torch.Tensor):
         # Reshape and permute the input tensor
@@ -46,4 +105,5 @@ class ALBEFVisionEncoder(VisionTransformer):
         x = torch.cat([batch_class_token, x], dim=1)
 
         x = self.encoder(x)
+
         return x

--- a/torchmultimodal/modules/encoders/albef_vision_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_vision_encoder.py
@@ -34,6 +34,7 @@ class ALBEFVisionEncoder(VisionTransformer):
             num_classes=num_classes,
             norm_layer=norm_layer,
         )
+        self.heads = None
 
 
 def interpolate_pos_embed(pos_embed_checkpoint, visual_encoder):


### PR DESCRIPTION
Summary:
<!-- Change Summary -->
Implemented `ALBEFVisionEncoder`, which is a wrapper of `torchvision`'s  `VisionTransformer` implementation. The only change is removed the `heads` from the `VisionTransformer`. 

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
* Started by copying the entire [`vit.py`](https://github.com/salesforce/ALBEF/blob/6224e78e5292757ca9c7d5add3e415010955a58b/models/vit.py) from ALBEF repo, and its import from timm ([PatchEmbed](https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/patch_embed.py))
* Wrote tests for ALBEF's `VisionTransformer`, as well as its building blocks (with assigned `state_dict` so can regenerate the models later)
* Wrote the wrapper class `ALBEFVisionEncoder`, and replaced the testing components with the new implementation (loaded with the same `state_dict` from before)
* Checked that the outputs remained the same
