### PR TITLE
[FLAVA] Fix flava training and finetuning

### DIFF
--- a/examples/flava/data/utils.py
+++ b/examples/flava/data/utils.py
@@ -26,6 +26,7 @@ def build_datasets_from_info(dataset_infos: List[HFDatasetInfo], split: str = "t
             dataset_info.key,
             dataset_info.subset,
             split=dataset_info.split_key_mapping[split],
+            use_auth_token=True,
             **dataset_info.extra_kwargs,
         )
         if dataset_info.remove_columns is not None:

--- a/examples/flava/finetune.py
+++ b/examples/flava/finetune.py
@@ -60,7 +60,6 @@ def main():
         callbacks=[
             LearningRateMonitor(logging_interval="step"),
         ],
-        strategy="ddp",
     )
     trainer.fit(model, datamodule=datamodule)
     trainer.validate(model, datamodule=datamodule)


### PR DESCRIPTION
Summary:
Fix the scripts which broke
- removing duplicate strategy from finetuning from https://github.com/facebookresearch/multimodal/pull/66
- adding auth token for reading imagenet (not sure how this broke randomly)

Test plan:
python train.py config=configs/pretraining/debug.yaml
python finetune.py config=configs/finetuning/qnli.yaml

