### PR TITLE
[ALBEF] Text Encoder

### DIFF
--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -8,15 +8,34 @@ import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import Tensor
 from torchmultimodal.modules.encoders.albef_text_encoder import (
+    ALBEFAttention,
     ALBEFOutputLayer,
     ALBEFSelfAttention,
     ALBEFTextEmbeddings,
 )
 
 
-class TestALBEFVisionEncoder:
+class TestALBEFTextEncoder:
+    def test_attention(self):
+        set_rng_seed(0)
+        attention = ALBEFAttention(
+            hidden_size=3,
+            num_attention_heads=1,
+        )
+        input = torch.randn(1, 3, 3)
+        hidden_states = torch.randn(3, 3)
+        (output,) = attention(input, hidden_states)
+        expected = Tensor(
+            [
+                [-0.559244, 1.404537, -0.845293],
+                [-1.367553, 0.995783, 0.371770],
+                [0.154898, -1.294825, 1.139927],
+            ]
+        ).unsqueeze(0)
+        assert_expected(output, expected, rtol=0, atol=1e-4)
+
     def test_self_attention(self):
-        # test the self attention in encoder layers
+        # test the output layer of ALBEFTextEncoder
         set_rng_seed(0)
         self_attention = ALBEFSelfAttention(hidden_size=3, num_attention_heads=1)
         input = torch.randn(1, 2, 3)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -7,10 +7,24 @@
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import Tensor
-from torchmultimodal.modules.encoders.albef_text_encoder import ALBEFTextEmbeddings
+from torchmultimodal.modules.encoders.albef_text_encoder import (
+    ALBEFSelfAttention,
+    ALBEFTextEmbeddings,
+)
 
 
 class TestALBEFVisionEncoder:
+    def test_self_attention(self):
+        # test the self attention in encoder layers
+        torch.manual_seed(0)
+        self_attention = ALBEFSelfAttention(hidden_size=3, num_attention_heads=1)
+        input = torch.randn(1, 2, 3)
+        (output,) = self_attention(input)
+        expected = Tensor(
+            [[0.037105, -1.265525, -0.781167], [-0.033819, -0.167038, -1.050785]]
+        ).unsqueeze(0)
+        assert_expected(output, expected, rtol=0, atol=1e-4)
+
     def test_conv_proj(self):
         # test the embeddings of the ALBEFTextEncoder
         set_rng_seed(0)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -16,7 +16,7 @@ def set_seed():
     set_rng_seed(0)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def text_encoder():
     return ALBEFTextEncoder(hidden_size=3, num_attention_heads=1)
 

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -8,8 +8,8 @@ import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import Tensor
 from torchmultimodal.modules.encoders.albef_text_encoder import (
+    ALBEFOutputLayer,
     ALBEFSelfAttention,
-    ALBEFSelfOutput,
     ALBEFTextEmbeddings,
 )
 
@@ -28,7 +28,7 @@ class TestALBEFVisionEncoder:
 
     def test_attention_output(self):
         set_rng_seed(0)
-        self_output = ALBEFSelfOutput(hidden_size=3)
+        self_output = ALBEFOutputLayer(hidden_size=3)
         input = torch.randn(1, 2, 3)
         hidden_states = torch.randn(2, 3)
         output = self_output(input, hidden_states)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import pytest
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import Tensor
@@ -38,3 +39,15 @@ class TestALBEFTextEncoder:
             ]
         )
         assert_expected(output, expected, rtol=0, atol=1e-4)
+
+    def test_invalid_input_length(self):
+        input_ids = torch.randint(10, (2, 2, 3))
+        text_atts = torch.randn(2, 2, 3)
+        with pytest.raises(RuntimeError):
+            self.text_encoder(input_ids, text_atts)
+
+    def test_not_matching_attenntion_mask_shape(self):
+        input_ids = torch.randint(10, (2, 2))
+        text_atts = torch.randn(2, 3)
+        with pytest.raises(RuntimeError):
+            self.text_encoder(input_ids, text_atts)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -7,98 +7,22 @@
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import Tensor
-from torchmultimodal.modules.encoders.albef_text_encoder import (
-    ALBEFAttention,
-    ALBEFIntermediate,
-    ALBEFLayer,
-    ALBEFOutputLayer,
-    ALBEFSelfAttention,
-    ALBEFTextEmbeddings,
-)
+from torchmultimodal.modules.encoders.albef_text_encoder import ALBEFTextEncoder
 
 
 class TestALBEFTextEncoder:
-    def test_layer(self):
+    set_rng_seed(0)
+    text_encoder = ALBEFTextEncoder(hidden_size=3, num_attention_heads=1)
+
+    def test_text_encoder(self):
         set_rng_seed(0)
-        layer = ALBEFLayer(
-            hidden_size=3,
-            num_attention_heads=1,
-        )
-        input = torch.randn(1, 3, 3)
-        (output,) = layer(input)
+        input_ids = torch.randint(10, (2, 2))
+        text_atts = torch.randn(2, 2)
+        output = self.text_encoder(input_ids, text_atts)
         expected = Tensor(
             [
-                [-1.002000, -0.363290, 1.365290],
-                [-1.288092, 0.138463, 1.149629],
-                [1.380833, -0.425887, -0.954945],
-            ]
-        ).unsqueeze(0)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
-    def test_intermediate(self):
-        set_rng_seed(0)
-        intermediate = ALBEFIntermediate(hidden_size=3)
-        input = torch.randn(1, 3, 3)
-        output = intermediate(input)
-        expected = Tensor(
-            [
-                [0.582390, -0.167281, 0.187117],
-                [-0.052958, 0.088763, -0.136094],
-                [0.848244, -0.091195, 0.307349],
-            ]
-        ).unsqueeze(0)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
-    def test_attention(self):
-        set_rng_seed(0)
-        attention = ALBEFAttention(
-            hidden_size=3,
-            num_attention_heads=1,
-        )
-        input = torch.randn(1, 3, 3)
-        hidden_states = torch.randn(3, 3)
-        (output,) = attention(input, hidden_states)
-        expected = Tensor(
-            [
-                [-0.559244, 1.404537, -0.845293],
-                [-1.367553, 0.995783, 0.371770],
-                [0.154898, -1.294825, 1.139927],
-            ]
-        ).unsqueeze(0)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
-    def test_self_attention(self):
-        # test the output layer of ALBEFTextEncoder
-        set_rng_seed(0)
-        self_attention = ALBEFSelfAttention(hidden_size=3, num_attention_heads=1)
-        input = torch.randn(1, 2, 3)
-        (output,) = self_attention(input)
-        expected = Tensor(
-            [[0.037105, -1.265525, -0.781167], [-0.033819, -0.167038, -1.050785]]
-        ).unsqueeze(0)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
-    def test_attention_output(self):
-        set_rng_seed(0)
-        self_output = ALBEFOutputLayer(hidden_size=3)
-        input = torch.randn(1, 2, 3)
-        hidden_states = torch.randn(2, 3)
-        output = self_output(input, hidden_states)
-        expected = Tensor(
-            [[0.068623, 1.188991, -1.257613], [0.769695, -1.412309, 0.642614]]
-        ).unsqueeze(0)
-        assert_expected(output, expected, rtol=0, atol=1e-4)
-
-    def test_conv_proj(self):
-        # test the embeddings of the ALBEFTextEncoder
-        set_rng_seed(0)
-        text_embeddings = ALBEFTextEmbeddings(hidden_size=3)
-        input = torch.randint(10, (2, 2))
-        output = text_embeddings(input)
-        expected = Tensor(
-            [
-                [[0.306898, -1.349008, 1.042110], [-1.241071, 0.033332, 1.207738]],
-                [[1.097125, -1.321374, 0.224249], [-0.619877, 1.410763, -0.790886]],
+                [[-0.668618, -0.744909, 1.413527], [-0.643172, 1.412341, -0.769169]],
+                [[-1.052131, -0.292326, 1.344457], [0.986411, 0.384430, -1.370841]],
             ]
         )
         assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torch import Tensor
+from torchmultimodal.modules.encoders.albef_text_encoder import ALBEFTextEmbeddings
+
+
+class TestALBEFVisionEncoder:
+    def test_conv_proj(self):
+        # test the embeddings of the ALBEFTextEncoder
+        set_rng_seed(0)
+        text_embeddings = ALBEFTextEmbeddings(hidden_size=3)
+        input = torch.randint(10, (2, 2))
+        output = text_embeddings(input)
+        expected = Tensor(
+            [
+                [[0.306898, -1.349008, 1.042110], [-1.241071, 0.033332, 1.207738]],
+                [[1.097125, -1.321374, 0.224249], [-0.619877, 1.410763, -0.790886]],
+            ]
+        )
+        assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -11,43 +11,50 @@ from torch import Tensor
 from torchmultimodal.modules.encoders.albef_text_encoder import ALBEFTextEncoder
 
 
-class TestALBEFTextEncoder:
+@pytest.fixture(autouse=True)
+def set_seed():
     set_rng_seed(0)
-    text_encoder = ALBEFTextEncoder(hidden_size=3, num_attention_heads=1)
 
-    def test_text_encoder(self):
-        set_rng_seed(42)
-        input_ids = torch.randint(10, (2, 2))
-        text_atts = torch.randint(2, (2, 2))
-        output = self.text_encoder(input_ids, text_atts)
-        expected = Tensor(
-            [
-                [[-0.341512, -1.017742, 1.359254], [-1.302851, 0.175050, 1.127802]],
-                [[-0.381597, -0.988518, 1.370115], [-0.026872, 1.237960, -1.211088]],
-            ]
-        )
-        assert_expected(output, expected, rtol=0, atol=1e-4)
 
-    def test_text_encoder_without_attention_mask(self):
-        set_rng_seed(0)
-        input_ids = torch.randint(10, (2, 2))
-        output = self.text_encoder(input_ids)
-        expected = Tensor(
-            [
-                [[-0.814115, -0.594398, 1.408513], [-0.712880, 1.414198, -0.701317]],
-                [[-0.888834, -0.508200, 1.397035], [1.195881, 0.055820, -1.251700]],
-            ]
-        )
-        assert_expected(output, expected, rtol=0, atol=1e-4)
+@pytest.fixture
+def text_encoder():
+    return ALBEFTextEncoder(hidden_size=3, num_attention_heads=1)
 
-    def test_invalid_input_length(self):
-        input_ids = torch.randint(10, (2, 2, 3))
-        text_atts = torch.randint(2, (2, 2, 3))
-        with pytest.raises(RuntimeError):
-            self.text_encoder(input_ids, text_atts)
 
-    def test_not_matching_attention_mask_shape(self):
-        input_ids = torch.randint(10, (2, 2))
-        text_atts = torch.randint(2, (2, 3))
-        with pytest.raises(RuntimeError):
-            self.text_encoder(input_ids, text_atts)
+def test_text_encoder(text_encoder):
+    input_ids = torch.randint(10, (2, 2))
+    text_atts = Tensor([[1, 1], [1, 0]])
+    output = text_encoder(input_ids, text_atts)
+    expected = Tensor(
+        [
+            [[-0.846098, -0.558322, 1.404420], [-0.337862, 1.358211, -1.020349]],
+            [[-0.911407, -0.480780, 1.392188], [-1.404428, 0.846044, 0.558384]],
+        ]
+    )
+    assert_expected(output, expected, rtol=0, atol=1e-4)
+
+
+def test_text_encoder_without_attention_mask(text_encoder):
+    input_ids = torch.randint(10, (2, 2))
+    output = text_encoder(input_ids)
+    expected = Tensor(
+        [
+            [[-0.846098, -0.558322, 1.404420], [-0.337862, 1.358211, -1.020349]],
+            [[-0.852249, -0.551247, 1.403495], [-0.715966, 1.414176, -0.698211]],
+        ]
+    )
+    assert_expected(output, expected, rtol=0, atol=1e-4)
+
+
+def test_invalid_input_length(text_encoder):
+    input_ids = torch.randint(10, (2, 2, 3))
+    text_atts = torch.randint(2, (2, 2, 3))
+    with pytest.raises(RuntimeError):
+        text_encoder(input_ids, text_atts)
+
+
+def test_not_matching_attention_mask_shape(text_encoder):
+    input_ids = torch.randint(10, (2, 2))
+    text_atts = torch.randint(2, (2, 3))
+    with pytest.raises(RuntimeError):
+        text_encoder(input_ids, text_atts)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -46,7 +46,7 @@ class TestALBEFTextEncoder:
         with pytest.raises(RuntimeError):
             self.text_encoder(input_ids, text_atts)
 
-    def test_not_matching_attenntion_mask_shape(self):
+    def test_not_matching_attention_mask_shape(self):
         input_ids = torch.randint(10, (2, 2))
         text_atts = torch.randn(2, 3)
         with pytest.raises(RuntimeError):

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -10,6 +10,7 @@ from torch import Tensor
 from torchmultimodal.modules.encoders.albef_text_encoder import (
     ALBEFAttention,
     ALBEFIntermediate,
+    ALBEFLayer,
     ALBEFOutputLayer,
     ALBEFSelfAttention,
     ALBEFTextEmbeddings,
@@ -17,6 +18,23 @@ from torchmultimodal.modules.encoders.albef_text_encoder import (
 
 
 class TestALBEFTextEncoder:
+    def test_layer(self):
+        set_rng_seed(0)
+        layer = ALBEFLayer(
+            hidden_size=3,
+            num_attention_heads=1,
+        )
+        input = torch.randn(1, 3, 3)
+        (output,) = layer(input)
+        expected = Tensor(
+            [
+                [-1.002000, -0.363290, 1.365290],
+                [-1.288092, 0.138463, 1.149629],
+                [1.380833, -0.425887, -0.954945],
+            ]
+        ).unsqueeze(0)
+        assert_expected(output, expected, rtol=0, atol=1e-4)
+
     def test_intermediate(self):
         set_rng_seed(0)
         intermediate = ALBEFIntermediate(hidden_size=3)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -16,14 +16,14 @@ class TestALBEFTextEncoder:
     text_encoder = ALBEFTextEncoder(hidden_size=3, num_attention_heads=1)
 
     def test_text_encoder(self):
-        set_rng_seed(0)
+        set_rng_seed(42)
         input_ids = torch.randint(10, (2, 2))
-        text_atts = torch.randn(2, 2)
+        text_atts = torch.randint(2, (2, 2))
         output = self.text_encoder(input_ids, text_atts)
         expected = Tensor(
             [
-                [[-0.668618, -0.744909, 1.413527], [-0.643172, 1.412341, -0.769169]],
-                [[-1.052131, -0.292326, 1.344457], [0.986411, 0.384430, -1.370841]],
+                [[-0.341512, -1.017742, 1.359254], [-1.302851, 0.175050, 1.127802]],
+                [[-0.381597, -0.988518, 1.370115], [-0.026872, 1.237960, -1.211088]],
             ]
         )
         assert_expected(output, expected, rtol=0, atol=1e-4)
@@ -42,12 +42,12 @@ class TestALBEFTextEncoder:
 
     def test_invalid_input_length(self):
         input_ids = torch.randint(10, (2, 2, 3))
-        text_atts = torch.randn(2, 2, 3)
+        text_atts = torch.randint(2, (2, 2, 3))
         with pytest.raises(RuntimeError):
             self.text_encoder(input_ids, text_atts)
 
     def test_not_matching_attention_mask_shape(self):
         input_ids = torch.randint(10, (2, 2))
-        text_atts = torch.randn(2, 3)
+        text_atts = torch.randint(2, (2, 3))
         with pytest.raises(RuntimeError):
             self.text_encoder(input_ids, text_atts)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -34,18 +34,6 @@ def test_text_encoder(text_encoder):
     assert_expected(output, expected, rtol=0, atol=1e-4)
 
 
-def test_text_encoder_without_attention_mask(text_encoder):
-    input_ids = torch.randint(10, (2, 2))
-    output = text_encoder(input_ids)
-    expected = Tensor(
-        [
-            [[-0.846098, -0.558322, 1.404420], [-0.337862, 1.358211, -1.020349]],
-            [[-0.852249, -0.551247, 1.403495], [-0.715966, 1.414176, -0.698211]],
-        ]
-    )
-    assert_expected(output, expected, rtol=0, atol=1e-4)
-
-
 def test_invalid_input_length(text_encoder):
     input_ids = torch.randint(10, (2, 2, 3))
     text_atts = torch.randint(2, (2, 2, 3))

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -9,6 +9,7 @@ from test.test_utils import assert_expected, set_rng_seed
 from torch import Tensor
 from torchmultimodal.modules.encoders.albef_text_encoder import (
     ALBEFAttention,
+    ALBEFIntermediate,
     ALBEFOutputLayer,
     ALBEFSelfAttention,
     ALBEFTextEmbeddings,
@@ -16,6 +17,20 @@ from torchmultimodal.modules.encoders.albef_text_encoder import (
 
 
 class TestALBEFTextEncoder:
+    def test_intermediate(self):
+        set_rng_seed(0)
+        intermediate = ALBEFIntermediate(hidden_size=3)
+        input = torch.randn(1, 3, 3)
+        output = intermediate(input)
+        expected = Tensor(
+            [
+                [0.582390, -0.167281, 0.187117],
+                [-0.052958, 0.088763, -0.136094],
+                [0.848244, -0.091195, 0.307349],
+            ]
+        ).unsqueeze(0)
+        assert_expected(output, expected, rtol=0, atol=1e-4)
+
     def test_attention(self):
         set_rng_seed(0)
         attention = ALBEFAttention(

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -26,3 +26,15 @@ class TestALBEFTextEncoder:
             ]
         )
         assert_expected(output, expected, rtol=0, atol=1e-4)
+
+    def test_text_encoder_without_attention_mask(self):
+        set_rng_seed(0)
+        input_ids = torch.randint(10, (2, 2))
+        output = self.text_encoder(input_ids)
+        expected = Tensor(
+            [
+                [[-0.814115, -0.594398, 1.408513], [-0.712880, 1.414198, -0.701317]],
+                [[-0.888834, -0.508200, 1.397035], [1.195881, 0.055820, -1.251700]],
+            ]
+        )
+        assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_albef_text_encoder.py
+++ b/test/modules/encoders/test_albef_text_encoder.py
@@ -9,6 +9,7 @@ from test.test_utils import assert_expected, set_rng_seed
 from torch import Tensor
 from torchmultimodal.modules.encoders.albef_text_encoder import (
     ALBEFSelfAttention,
+    ALBEFSelfOutput,
     ALBEFTextEmbeddings,
 )
 
@@ -16,12 +17,23 @@ from torchmultimodal.modules.encoders.albef_text_encoder import (
 class TestALBEFVisionEncoder:
     def test_self_attention(self):
         # test the self attention in encoder layers
-        torch.manual_seed(0)
+        set_rng_seed(0)
         self_attention = ALBEFSelfAttention(hidden_size=3, num_attention_heads=1)
         input = torch.randn(1, 2, 3)
         (output,) = self_attention(input)
         expected = Tensor(
             [[0.037105, -1.265525, -0.781167], [-0.033819, -0.167038, -1.050785]]
+        ).unsqueeze(0)
+        assert_expected(output, expected, rtol=0, atol=1e-4)
+
+    def test_attention_output(self):
+        set_rng_seed(0)
+        self_output = ALBEFSelfOutput(hidden_size=3)
+        input = torch.randn(1, 2, 3)
+        hidden_states = torch.randn(2, 3)
+        output = self_output(input, hidden_states)
+        expected = Tensor(
+            [[0.068623, 1.188991, -1.257613], [0.769695, -1.412309, 0.642614]]
         ).unsqueeze(0)
         assert_expected(output, expected, rtol=0, atol=1e-4)
 

--- a/torchmultimodal/models/flava.py
+++ b/torchmultimodal/models/flava.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 
 import torch
 from packaging import version
-from torch import device, nn, Tensor
+from torch import nn, Tensor
 from torchmultimodal.modules.layers.mlp import MLP
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
 from torchmultimodal.modules.layers.transformer import (
@@ -31,7 +31,11 @@ from torchmultimodal.modules.losses.flava import (
     FLAVAPretrainingLossOutput,
     Pooler,
 )
-from torchmultimodal.utils.common import ModelOutput, PretrainedMixin
+from torchmultimodal.utils.common import (
+    get_extended_attention_mask,
+    ModelOutput,
+    PretrainedMixin,
+)
 
 
 EMBEDDING_OPTIONS = Literal["image", "text", "mm"]
@@ -937,45 +941,6 @@ class TextTransformer(nn.Module):
 
         self.apply(weight_init_fn)
 
-    def get_extended_attention_mask(
-        self, attention_mask: Tensor, input_shape: Tuple[int], device: device
-    ) -> Tensor:
-        """
-        Makes broadcastable attention and causal masks so that future and masked tokens are ignored.
-        Arguments:
-            attention_mask (`torch.Tensor`):
-                Mask with ones indicating tokens to attend to, zeros for tokens to ignore.
-            input_shape (`Tuple[int]`):
-                The shape of the input to the model.
-            device: (`torch.device`):
-                The device of the input to the model.
-        Returns:
-            `torch.Tensor` The extended attention mask, with a the same dtype as `attention_mask.dtype`.
-        """
-        # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
-        # ourselves in which case we just need to make it broadcastable to all heads.
-        if attention_mask.dim() == 3:
-            extended_attention_mask = attention_mask[:, None, :, :]
-        elif attention_mask.dim() == 2:
-            # Provided a padding mask of dimensions [batch_size, seq_length]
-            # - if the model is an encoder, make the mask broadcastable to [batch_size, num_heads, seq_length, seq_length]
-            extended_attention_mask = attention_mask[:, None, None, :]
-        else:
-            raise ValueError(
-                f"Wrong shape for input_ids (shape {input_shape}) or attention_mask (shape {attention_mask.shape})"
-            )
-
-        # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
-        # masked positions, this operation will create a tensor which is 0.0 for
-        # positions we want to attend and -10000.0 for masked positions.
-        # Since we are adding it to the raw scores before the softmax, this is
-        # effectively the same as removing these entirely.
-        extended_attention_mask = extended_attention_mask.to(
-            dtype=attention_mask.dtype
-        )  # fp16 compatibility
-        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
-        return extended_attention_mask
-
     def forward(
         self,
         input_ids: Optional[Tensor] = None,
@@ -997,8 +962,8 @@ class TextTransformer(nn.Module):
         # We can provide a self-attention mask of dimensions
         # [batch_size, from_seq_length, to_seq_length]
         # ourselves in which case we just need to make it broadcastable to all heads.
-        extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(
-            attention_mask, input_shape, device
+        extended_attention_mask: torch.Tensor = get_extended_attention_mask(
+            attention_mask
         )
 
         embedding_output = self.embeddings(

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -10,6 +10,45 @@ import torch
 from torch import nn, Tensor
 
 
+class ALBEFAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int = 768,
+        num_attention_heads: int = 12,
+        attention_probs_dropout_prob: float = 0.0,
+        layer_norm_eps: float = 1e-12,
+        hidden_dropout_prob: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.self = ALBEFSelfAttention(
+            hidden_size, num_attention_heads, attention_probs_dropout_prob
+        )
+        self.output = ALBEFOutputLayer(hidden_size, layer_norm_eps, hidden_dropout_prob)
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        head_mask=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        output_attentions=False,
+    ):
+        self_outputs = self.self(
+            hidden_states,
+            attention_mask,
+            head_mask,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            output_attentions,
+        )
+        attention_output = self.output(self_outputs[0], hidden_states)
+        outputs = (attention_output,) + self_outputs[
+            1:
+        ]  # add attentions if we output them
+        return outputs
+
+
 class ALBEFSelfAttention(nn.Module):
     def __init__(
         self,

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -143,7 +143,7 @@ class ALBEFEncoder(nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: Optional[torch.FloatTensor] = None,
     ) -> Tensor:
-        for _, layer_module in enumerate(self.layer):
+        for layer_module in self.layer:
             hidden_states = layer_module(hidden_states, attention_mask)
         return hidden_states
 

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -7,8 +7,98 @@
 # This code is based on https://github.com/openai/CLIP/blob/main/clip/model.py
 
 
+import math
+
 import torch
 from torch import nn, Tensor
+
+
+class ALBEFSelfAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int = 768,
+        num_attention_heads: int = 12,
+        attention_probs_dropout_prob: float = 0.0,
+    ) -> None:
+        super().__init__()
+        if hidden_size % num_attention_heads != 0:
+            raise ValueError(
+                "The hidden size (%d) is not a multiple of the number of attention "
+                "heads (%d)" % (hidden_size, num_attention_heads)
+            )
+
+        self.num_attention_heads = num_attention_heads
+        self.attention_head_size = int(hidden_size / num_attention_heads)
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.query = nn.Linear(hidden_size, self.all_head_size)
+        self.key = nn.Linear(hidden_size, self.all_head_size)
+        self.value = nn.Linear(hidden_size, self.all_head_size)
+
+        self.dropout = nn.Dropout(attention_probs_dropout_prob)
+
+    def transpose_for_scores(self, x: Tensor) -> Tensor:
+        new_x_shape = x.size()[:-1] + (
+            self.num_attention_heads,
+            self.attention_head_size,
+        )
+        x = x.view(*new_x_shape)
+        return x.permute(0, 2, 1, 3)
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        head_mask=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        output_attentions=False,
+    ):
+        mixed_query_layer = self.query(hidden_states)
+
+        # If this is instantiated as a cross-attention module, the keys
+        # and values come from an encoder; the attention mask needs to be
+        # such that the encoder's padding tokens are not attended to.
+        if encoder_hidden_states is not None:
+            mixed_key_layer = self.key(encoder_hidden_states)
+            mixed_value_layer = self.value(encoder_hidden_states)
+            attention_mask = encoder_attention_mask
+        else:
+            mixed_key_layer = self.key(hidden_states)
+            mixed_value_layer = self.value(hidden_states)
+
+        query_layer = self.transpose_for_scores(mixed_query_layer)
+        key_layer = self.transpose_for_scores(mixed_key_layer)
+        value_layer = self.transpose_for_scores(mixed_value_layer)
+
+        # Take the dot product between "query" and "key" to get the raw attention scores.
+        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+        if attention_mask is not None:
+            # Apply the attention mask is (precomputed for all layers in BertModel forward() function)
+            attention_scores = attention_scores + attention_mask
+
+        # Normalize the attention scores to probabilities.
+        attention_probs = nn.Softmax(dim=-1)(attention_scores)
+
+        # This is actually dropping out entire tokens to attend to, which might
+        # seem a bit unusual, but is taken from the original Transformer paper.
+        attention_probs = self.dropout(attention_probs)
+
+        # Mask heads if we want to
+        if head_mask is not None:
+            attention_probs = attention_probs * head_mask
+
+        context_layer = torch.matmul(attention_probs, value_layer)
+
+        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
+        context_layer = context_layer.view(*new_context_layer_shape)
+
+        outputs = (
+            (context_layer, attention_probs) if output_attentions else (context_layer,)
+        )
+        return outputs
 
 
 class ALBEFTextEmbeddings(nn.Module):

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -89,7 +89,7 @@ class ALBEFTextEmbeddings(nn.Module):
         self.word_embeddings = nn.Embedding(vocab_size, hidden_size, padding_idx)
         self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
         self.token_type_embeddings = nn.Embedding(type_vocab_size, hidden_size)
-        self.LayerNorm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.Layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
     def forward(self, input_ids: Tensor) -> Tensor:
         input_shape = input_ids.size()
@@ -105,7 +105,7 @@ class ALBEFTextEmbeddings(nn.Module):
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
 
         embeddings = inputs_embeds + position_embeddings + token_type_embeddings
-        embeddings = self.LayerNorm(embeddings)
+        embeddings = self.Layer_norm(embeddings)
         return embeddings
 
 
@@ -156,7 +156,7 @@ class ALBEFTransformerLayer(nn.Module):
         self.dense1 = nn.Linear(hidden_size, intermediate_size)
         self.transform_act_fn = nn.GELU()
         self.dense2 = nn.Linear(intermediate_size, hidden_size)
-        self.LayerNorm = torch.nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.Layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
     def forward(
         self,
@@ -167,7 +167,7 @@ class ALBEFTransformerLayer(nn.Module):
         dense1_output = self.dense1(attention_output)
         act_output = self.transform_act_fn(dense1_output)
         dense2_output = self.dense2(act_output)
-        norm_output = self.LayerNorm(dense2_output + attention_output)
+        norm_output = self.Layer_norm(dense2_output + attention_output)
         return norm_output
 
 
@@ -183,7 +183,7 @@ class ALBEFTransformerAttention(nn.Module):
             hidden_size, num_attention_heads
         )
         self.dense = nn.Linear(hidden_size, hidden_size)
-        self.LayerNorm = torch.nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.Layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
     def forward(
         self,
@@ -192,7 +192,7 @@ class ALBEFTransformerAttention(nn.Module):
     ) -> Tensor:
         self_output = self.self_attention(hidden_states, attention_mask)
         dense_output = self.dense(self_output)
-        attention_output = self.LayerNorm(dense_output + hidden_states)
+        attention_output = self.Layer_norm(dense_output + hidden_states)
         return attention_output
 
 

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -111,25 +111,6 @@ class ALBEFAttention(nn.Module):
         return outputs
 
 
-class ALBEFOutputLayer(nn.Module):
-    def __init__(
-        self,
-        hidden_size: int = 768,
-        layer_norm_eps: float = 1e-12,
-        hidden_dropout_prob: float = 0.0,
-    ) -> None:
-        super().__init__()
-        self.dense = nn.Linear(hidden_size, hidden_size)
-        self.LayerNorm = torch.nn.LayerNorm(hidden_size, eps=layer_norm_eps)
-        self.dropout = nn.Dropout(hidden_dropout_prob)
-
-    def forward(self, hidden_states, input_tensor):
-        hidden_states = self.dense(hidden_states)
-        hidden_states = self.dropout(hidden_states)
-        hidden_states = self.LayerNorm(hidden_states + input_tensor)
-        return hidden_states
-
-
 class ALBEFTextEmbeddings(nn.Module):
     def __init__(
         self,
@@ -222,3 +203,24 @@ class ALBEFSelfAttention(nn.Module):
         context_layer = context_layer.view(*new_context_layer_shape)
 
         return context_layer
+
+
+class ALBEFOutput(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        layer_norm_eps: float,
+    ) -> None:
+        super().__init__()
+        self.dense = nn.Linear(intermediate_size, hidden_size)
+        self.LayerNorm = torch.nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        input_tensor: Tensor,
+    ) -> Tensor:
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -94,7 +94,7 @@ class ALBEFTextEmbeddings(nn.Module):
         self.word_embeddings = nn.Embedding(vocab_size, hidden_size, padding_idx)
         self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
         self.token_type_embeddings = nn.Embedding(type_vocab_size, hidden_size)
-        self.Layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
     def forward(self, input_ids: Tensor) -> Tensor:
         input_shape = input_ids.size()
@@ -110,7 +110,7 @@ class ALBEFTextEmbeddings(nn.Module):
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
 
         embeddings = inputs_embeds + position_embeddings + token_type_embeddings
-        embeddings = self.Layer_norm(embeddings)
+        embeddings = self.layer_norm(embeddings)
         return embeddings
 
 
@@ -161,7 +161,7 @@ class ALBEFTransformerLayer(nn.Module):
         self.dense1 = nn.Linear(hidden_size, intermediate_size)
         self.transform_act_fn = nn.GELU()
         self.dense2 = nn.Linear(intermediate_size, hidden_size)
-        self.Layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
     def forward(
         self,
@@ -172,7 +172,7 @@ class ALBEFTransformerLayer(nn.Module):
         dense1_output = self.dense1(attention_output)
         act_output = self.transform_act_fn(dense1_output)
         dense2_output = self.dense2(act_output)
-        norm_output = self.Layer_norm(dense2_output + attention_output)
+        norm_output = self.layer_norm(dense2_output + attention_output)
         return norm_output
 
 
@@ -188,7 +188,7 @@ class ALBEFTransformerAttention(nn.Module):
             hidden_size, num_attention_heads
         )
         self.dense = nn.Linear(hidden_size, hidden_size)
-        self.Layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
     def forward(
         self,
@@ -197,7 +197,7 @@ class ALBEFTransformerAttention(nn.Module):
     ) -> Tensor:
         self_output = self.self_attention(hidden_states, attention_mask)
         dense_output = self.dense(self_output)
-        attention_output = self.Layer_norm(dense_output + hidden_states)
+        attention_output = self.layer_norm(dense_output + hidden_states)
         return attention_output
 
 

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -22,14 +22,16 @@ class ALBEFTextEncoder(nn.Module):
 
     Args:
         vocab_size (int): Vocabulary size of the model. Defines the different tokens that can be represented by the inputs_ids.
-        hidden_size (int): Dimensionality of the encoder layers.
-        num_hidden_layers (int): Number of hidden layers in the Transformer encoder.
-        num_attention_heads (int): Number of attention heads for each attention layer in the Transformer encoder.
+            Default is 30522.
+        hidden_size (int): Dimensionality of the encoder layers. Default is 768.
+        num_hidden_layers (int): Number of hidden layers in the Transformer encoder. Default is 6.
+        num_attention_heads (int): Number of attention heads for each attention layer in the Transformer encoder. Default is 12.
         intermediate_size (int): Dimensionality of the “intermediate” (i.e., feed-forward) layer in the Transformer encoder.
-        max_position_embeddings (int): The maximum sequence length that this model might ever be used with.
-        type_vocab_size (int): The vocabulary size of the token_type_ids.
-        pad_token_id (int): The embedding for pad_token_id is not updated during training.
-        layer_norm_eps (float): The epsilon used by the layer normalization layers.
+            Default is 3072.
+        max_position_embeddings (int): The maximum sequence length that this model might ever be used with. Default is 512.
+        type_vocab_size (int): The vocabulary size of the token_type_ids. Default is 2.
+        pad_token_id (int): The embedding for pad_token_id is not updated during training. Default is 0.
+        layer_norm_eps (float): The epsilon used by the layer normalization layers. Default is 1e-12.
     Inputs:
         input_ids (Tensor of size (batch_size, sequence_length)): Indices of input sequence tokens in the vocabulary.
         attention_mask (Tensor of shape (batch_size, sequence_length)): Mask to avoid performing attention on padding token indices.

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This code is based on https://github.com/openai/CLIP/blob/main/clip/model.py
+
+
+import torch
+from torch import nn, Tensor
+
+
+class ALBEFTextEmbeddings(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int = 30522,
+        hidden_size: int = 768,
+        padding_idx: int = 0,
+        max_position_embeddings: int = 512,
+        type_vocab_size: int = 2,
+        layer_norm_eps: float = 1e-12,
+        hidden_dropout_prob: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.word_embeddings = nn.Embedding(vocab_size, hidden_size, padding_idx)
+        self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
+        self.token_type_embeddings = nn.Embedding(type_vocab_size, hidden_size)
+        self.LayerNorm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.dropout = nn.Dropout(hidden_dropout_prob)
+
+    def forward(
+        self, input_ids=None, token_type_ids=None, position_ids=None, inputs_embeds=None
+    ) -> Tensor:
+        input_shape = input_ids.size()
+        seq_length = input_shape[1]
+        device = input_ids.device if input_ids is not None else inputs_embeds.device
+        if position_ids is None:
+            position_ids = torch.arange(seq_length, dtype=torch.long, device=device)
+            position_ids = position_ids.unsqueeze(0).expand(input_shape)
+        if token_type_ids is None:
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+        if inputs_embeds is None:
+            inputs_embeds = self.word_embeddings(input_ids)
+        position_embeddings = self.position_embeddings(position_ids)
+        token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        embeddings = inputs_embeds + position_embeddings + token_type_embeddings
+        embeddings = self.LayerNorm(embeddings)
+        embeddings = self.dropout(embeddings)
+        return embeddings

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from typing import Optional
 
 import torch
 from torch import nn, Tensor
@@ -110,94 +111,6 @@ class ALBEFAttention(nn.Module):
         return outputs
 
 
-class ALBEFSelfAttention(nn.Module):
-    def __init__(
-        self,
-        hidden_size: int = 768,
-        num_attention_heads: int = 12,
-        attention_probs_dropout_prob: float = 0.0,
-    ) -> None:
-        super().__init__()
-        if hidden_size % num_attention_heads != 0:
-            raise ValueError(
-                "The hidden size (%d) is not a multiple of the number of attention "
-                "heads (%d)" % (hidden_size, num_attention_heads)
-            )
-
-        self.num_attention_heads = num_attention_heads
-        self.attention_head_size = int(hidden_size / num_attention_heads)
-        self.all_head_size = self.num_attention_heads * self.attention_head_size
-
-        self.query = nn.Linear(hidden_size, self.all_head_size)
-        self.key = nn.Linear(hidden_size, self.all_head_size)
-        self.value = nn.Linear(hidden_size, self.all_head_size)
-
-        self.dropout = nn.Dropout(attention_probs_dropout_prob)
-
-    def transpose_for_scores(self, x: Tensor) -> Tensor:
-        new_x_shape = x.size()[:-1] + (
-            self.num_attention_heads,
-            self.attention_head_size,
-        )
-        x = x.view(*new_x_shape)
-        return x.permute(0, 2, 1, 3)
-
-    def forward(
-        self,
-        hidden_states,
-        attention_mask=None,
-        head_mask=None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
-        output_attentions=False,
-    ):
-        mixed_query_layer = self.query(hidden_states)
-
-        # If this is instantiated as a cross-attention module, the keys
-        # and values come from an encoder; the attention mask needs to be
-        # such that the encoder's padding tokens are not attended to.
-        if encoder_hidden_states is not None:
-            mixed_key_layer = self.key(encoder_hidden_states)
-            mixed_value_layer = self.value(encoder_hidden_states)
-            attention_mask = encoder_attention_mask
-        else:
-            mixed_key_layer = self.key(hidden_states)
-            mixed_value_layer = self.value(hidden_states)
-
-        query_layer = self.transpose_for_scores(mixed_query_layer)
-        key_layer = self.transpose_for_scores(mixed_key_layer)
-        value_layer = self.transpose_for_scores(mixed_value_layer)
-
-        # Take the dot product between "query" and "key" to get the raw attention scores.
-        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
-        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
-        if attention_mask is not None:
-            # Apply the attention mask is (precomputed for all layers in BertModel forward() function)
-            attention_scores = attention_scores + attention_mask
-
-        # Normalize the attention scores to probabilities.
-        attention_probs = nn.Softmax(dim=-1)(attention_scores)
-
-        # This is actually dropping out entire tokens to attend to, which might
-        # seem a bit unusual, but is taken from the original Transformer paper.
-        attention_probs = self.dropout(attention_probs)
-
-        # Mask heads if we want to
-        if head_mask is not None:
-            attention_probs = attention_probs * head_mask
-
-        context_layer = torch.matmul(attention_probs, value_layer)
-
-        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
-        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
-        context_layer = context_layer.view(*new_context_layer_shape)
-
-        outputs = (
-            (context_layer, attention_probs) if output_attentions else (context_layer,)
-        )
-        return outputs
-
-
 class ALBEFOutputLayer(nn.Module):
     def __init__(
         self,
@@ -249,3 +162,63 @@ class ALBEFTextEmbeddings(nn.Module):
         embeddings = inputs_embeds + position_embeddings + token_type_embeddings
         embeddings = self.LayerNorm(embeddings)
         return embeddings
+
+
+class ALBEFSelfAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+    ) -> None:
+        super().__init__()
+        if hidden_size % num_attention_heads != 0:
+            raise ValueError(
+                "The hidden size (%d) is not a multiple of the number of attention "
+                "heads (%d)" % (hidden_size, num_attention_heads)
+            )
+
+        self.num_attention_heads = num_attention_heads
+        self.attention_head_size = int(hidden_size / num_attention_heads)
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.query = nn.Linear(hidden_size, self.all_head_size)
+        self.key = nn.Linear(hidden_size, self.all_head_size)
+        self.value = nn.Linear(hidden_size, self.all_head_size)
+
+    def transpose_for_scores(self, x: Tensor) -> Tensor:
+        new_x_shape = x.size()[:-1] + (
+            self.num_attention_heads,
+            self.attention_head_size,
+        )
+        x = x.view(*new_x_shape)
+        return x.permute(0, 2, 1, 3)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Optional[Tensor] = None,
+    ) -> Tensor:
+        mixed_query_layer = self.query(hidden_states)
+        mixed_key_layer = self.key(hidden_states)
+        mixed_value_layer = self.value(hidden_states)
+
+        query_layer = self.transpose_for_scores(mixed_query_layer)
+        key_layer = self.transpose_for_scores(mixed_key_layer)
+        value_layer = self.transpose_for_scores(mixed_value_layer)
+
+        # Take the dot product between "query" and "key" to get the raw attention scores.
+        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+        if attention_mask is not None:
+            attention_scores = attention_scores + attention_mask
+
+        # Normalize the attention scores to probabilities.
+        attention_probs = nn.Softmax(dim=-1)(attention_scores)
+
+        context_layer = torch.matmul(attention_probs, value_layer)
+
+        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
+        context_layer = context_layer.view(*new_context_layer_shape)
+
+        return context_layer

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -4,9 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# This code is based on https://github.com/openai/CLIP/blob/main/clip/model.py
-
-
 import math
 
 import torch
@@ -101,7 +98,7 @@ class ALBEFSelfAttention(nn.Module):
         return outputs
 
 
-class ALBEFSelfOutput(nn.Module):
+class ALBEFOutputLayer(nn.Module):
     def __init__(
         self,
         hidden_size: int = 768,

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import Optional
 
 import torch
 from torch import nn, Tensor
@@ -66,16 +65,10 @@ class ALBEFTextEncoder(nn.Module):
 
     def forward(
         self,
-        input_ids: Tensor = None,
-        attention_mask: Optional[Tensor] = None,
+        input_ids: Tensor,
+        attention_mask: Tensor,
     ) -> Tensor:
-        input_shape = input_ids.size()
-        device = input_ids.device
-        if attention_mask is None:
-            attention_mask = torch.ones(input_shape, device=device)
-
         extended_attention_mask = get_extended_attention_mask(attention_mask)
-
         embedding_output = self.embeddings(input_ids)
         encoder_outputs = self.encoder(embedding_output, extended_attention_mask)
 
@@ -140,8 +133,8 @@ class ALBEFTransformerEncoder(nn.Module):
 
     def forward(
         self,
-        hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.FloatTensor] = None,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
     ) -> Tensor:
         for layer_module in self.layer:
             hidden_states = layer_module(hidden_states, attention_mask)
@@ -168,7 +161,7 @@ class ALBEFTransformerLayer(nn.Module):
     def forward(
         self,
         hidden_states: Tensor,
-        attention_mask: Optional[Tensor] = None,
+        attention_mask: Tensor,
     ) -> Tensor:
         attention_output = self.attention(hidden_states, attention_mask)
         dense1_output = self.dense1(attention_output)
@@ -195,7 +188,7 @@ class ALBEFTransformerAttention(nn.Module):
     def forward(
         self,
         hidden_states: Tensor,
-        attention_mask: Optional[Tensor] = None,
+        attention_mask: Tensor,
     ) -> Tensor:
         self_output = self.self_attention(hidden_states, attention_mask)
         dense_output = self.dense(self_output)
@@ -235,7 +228,7 @@ class ALBEFTransformerSelfAttention(nn.Module):
     def forward(
         self,
         hidden_states: Tensor,
-        attention_mask: Optional[Tensor] = None,
+        attention_mask: Tensor,
     ) -> Tensor:
         mixed_query_layer = self.query(hidden_states)
         mixed_key_layer = self.key(hidden_states)

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -72,45 +72,6 @@ class ALBEFIntermediate(nn.Module):
         return hidden_states
 
 
-class ALBEFAttention(nn.Module):
-    def __init__(
-        self,
-        hidden_size: int = 768,
-        num_attention_heads: int = 12,
-        attention_probs_dropout_prob: float = 0.0,
-        layer_norm_eps: float = 1e-12,
-        hidden_dropout_prob: float = 0.0,
-    ) -> None:
-        super().__init__()
-        self.self = ALBEFSelfAttention(
-            hidden_size, num_attention_heads, attention_probs_dropout_prob
-        )
-        self.output = ALBEFOutputLayer(hidden_size, layer_norm_eps, hidden_dropout_prob)
-
-    def forward(
-        self,
-        hidden_states,
-        attention_mask=None,
-        head_mask=None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
-        output_attentions=False,
-    ):
-        self_outputs = self.self(
-            hidden_states,
-            attention_mask,
-            head_mask,
-            encoder_hidden_states,
-            encoder_attention_mask,
-            output_attentions,
-        )
-        attention_output = self.output(self_outputs[0], hidden_states)
-        outputs = (attention_output,) + self_outputs[
-            1:
-        ]  # add attentions if we output them
-        return outputs
-
-
 class ALBEFTextEmbeddings(nn.Module):
     def __init__(
         self,
@@ -143,6 +104,27 @@ class ALBEFTextEmbeddings(nn.Module):
         embeddings = inputs_embeds + position_embeddings + token_type_embeddings
         embeddings = self.LayerNorm(embeddings)
         return embeddings
+
+
+class ALBEFAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        layer_norm_eps: float,
+    ) -> None:
+        super().__init__()
+        self.self_attention = ALBEFSelfAttention(hidden_size, num_attention_heads)
+        self.output = ALBEFOutput(hidden_size, hidden_size, layer_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Optional[Tensor] = None,
+    ) -> Tensor:
+        self_output = self.self_attention(hidden_states, attention_mask)
+        attention_output = self.output(self_output, hidden_states)
+        return attention_output
 
 
 class ALBEFSelfAttention(nn.Module):

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -10,6 +10,24 @@ import torch
 from torch import nn, Tensor
 
 
+class ALBEFIntermediate(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int = 768,
+    ) -> None:
+        super().__init__()
+        self.dense = nn.Linear(hidden_size, hidden_size)
+        self.transform_act_fn = nn.GELU()
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+    ) -> Tensor:
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.transform_act_fn(hidden_states)
+        return hidden_states
+
+
 class ALBEFAttention(nn.Module):
     def __init__(
         self,

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -54,24 +54,6 @@ class ALBEFLayer(nn.Module):
         return outputs
 
 
-class ALBEFIntermediate(nn.Module):
-    def __init__(
-        self,
-        hidden_size: int = 768,
-    ) -> None:
-        super().__init__()
-        self.dense = nn.Linear(hidden_size, hidden_size)
-        self.transform_act_fn = nn.GELU()
-
-    def forward(
-        self,
-        hidden_states: Tensor,
-    ) -> Tensor:
-        hidden_states = self.dense(hidden_states)
-        hidden_states = self.transform_act_fn(hidden_states)
-        return hidden_states
-
-
 class ALBEFTextEmbeddings(nn.Module):
     def __init__(
         self,
@@ -205,4 +187,23 @@ class ALBEFOutput(nn.Module):
     ) -> Tensor:
         hidden_states = self.dense(hidden_states)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
+class ALBEFIntermediate(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+    ) -> None:
+        super().__init__()
+        self.dense = nn.Linear(hidden_size, intermediate_size)
+        self.transform_act_fn = nn.GELU()
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+    ) -> Tensor:
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.transform_act_fn(hidden_states)
         return hidden_states

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -45,6 +45,38 @@ class ALBEFTextEmbeddings(nn.Module):
         return embeddings
 
 
+class ALBEFEncoder(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_attention_heads: int,
+        num_hidden_layers: int,
+        layer_norm_eps: float,
+    ) -> None:
+        super().__init__()
+        self.layer = nn.ModuleList(
+            [
+                ALBEFLayer(
+                    hidden_size,
+                    intermediate_size,
+                    num_attention_heads,
+                    layer_norm_eps,
+                )
+                for _ in range(num_hidden_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.FloatTensor] = None,
+    ) -> Tensor:
+        for _, layer_module in enumerate(self.layer):
+            hidden_states = layer_module(hidden_states, attention_mask)
+        return hidden_states
+
+
 class ALBEFLayer(nn.Module):
     def __init__(
         self,

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -56,7 +56,7 @@ class ALBEFTextEncoder(nn.Module):
             type_vocab_size,
             layer_norm_eps,
         )
-        self.encoder = ALBEFEncoder(
+        self.encoder = ALBEFTransformerEncoder(
             hidden_size,
             intermediate_size,
             num_attention_heads,
@@ -116,7 +116,7 @@ class ALBEFTextEmbeddings(nn.Module):
         return embeddings
 
 
-class ALBEFEncoder(nn.Module):
+class ALBEFTransformerEncoder(nn.Module):
     def __init__(
         self,
         hidden_size: int,
@@ -128,7 +128,7 @@ class ALBEFEncoder(nn.Module):
         super().__init__()
         self.layer = nn.ModuleList(
             [
-                ALBEFLayer(
+                ALBEFTransformerLayer(
                     hidden_size,
                     intermediate_size,
                     num_attention_heads,
@@ -148,7 +148,7 @@ class ALBEFEncoder(nn.Module):
         return hidden_states
 
 
-class ALBEFLayer(nn.Module):
+class ALBEFTransformerLayer(nn.Module):
     def __init__(
         self,
         hidden_size: int,
@@ -157,7 +157,7 @@ class ALBEFLayer(nn.Module):
         layer_norm_eps: float,
     ) -> None:
         super().__init__()
-        self.attention = ALBEFAttention(
+        self.attention = ALBEFTransformerAttention(
             hidden_size, num_attention_heads, layer_norm_eps
         )
         self.dense1 = nn.Linear(hidden_size, intermediate_size)
@@ -178,7 +178,7 @@ class ALBEFLayer(nn.Module):
         return norm_output
 
 
-class ALBEFAttention(nn.Module):
+class ALBEFTransformerAttention(nn.Module):
     def __init__(
         self,
         hidden_size: int,
@@ -186,7 +186,9 @@ class ALBEFAttention(nn.Module):
         layer_norm_eps: float,
     ) -> None:
         super().__init__()
-        self.self_attention = ALBEFSelfAttention(hidden_size, num_attention_heads)
+        self.self_attention = ALBEFTransformerSelfAttention(
+            hidden_size, num_attention_heads
+        )
         self.dense = nn.Linear(hidden_size, hidden_size)
         self.LayerNorm = torch.nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
@@ -201,7 +203,7 @@ class ALBEFAttention(nn.Module):
         return attention_output
 
 
-class ALBEFSelfAttention(nn.Module):
+class ALBEFTransformerSelfAttention(nn.Module):
     def __init__(
         self,
         hidden_size: int,

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -101,6 +101,25 @@ class ALBEFSelfAttention(nn.Module):
         return outputs
 
 
+class ALBEFSelfOutput(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int = 768,
+        layer_norm_eps: float = 1e-12,
+        hidden_dropout_prob: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.dense = nn.Linear(hidden_size, hidden_size)
+        self.LayerNorm = torch.nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.dropout = nn.Dropout(hidden_dropout_prob)
+
+    def forward(self, hidden_states, input_tensor):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
 class ALBEFTextEmbeddings(nn.Module):
     def __init__(
         self,

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -220,38 +220,32 @@ class ALBEFOutputLayer(nn.Module):
 class ALBEFTextEmbeddings(nn.Module):
     def __init__(
         self,
-        vocab_size: int = 30522,
-        hidden_size: int = 768,
-        padding_idx: int = 0,
-        max_position_embeddings: int = 512,
-        type_vocab_size: int = 2,
-        layer_norm_eps: float = 1e-12,
-        hidden_dropout_prob: float = 0.0,
+        vocab_size: int,
+        hidden_size: int,
+        padding_idx: int,
+        max_position_embeddings: int,
+        type_vocab_size: int,
+        layer_norm_eps: float,
     ) -> None:
         super().__init__()
         self.word_embeddings = nn.Embedding(vocab_size, hidden_size, padding_idx)
         self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
         self.token_type_embeddings = nn.Embedding(type_vocab_size, hidden_size)
         self.LayerNorm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
-        self.dropout = nn.Dropout(hidden_dropout_prob)
 
-    def forward(
-        self, input_ids=None, token_type_ids=None, position_ids=None, inputs_embeds=None
-    ) -> Tensor:
+    def forward(self, input_ids: Tensor) -> Tensor:
         input_shape = input_ids.size()
         seq_length = input_shape[1]
-        device = input_ids.device if input_ids is not None else inputs_embeds.device
-        if position_ids is None:
-            position_ids = torch.arange(seq_length, dtype=torch.long, device=device)
-            position_ids = position_ids.unsqueeze(0).expand(input_shape)
-        if token_type_ids is None:
-            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
-        if inputs_embeds is None:
-            inputs_embeds = self.word_embeddings(input_ids)
+        device = input_ids.device
+
+        position_ids = torch.arange(seq_length, dtype=torch.long, device=device)
+        position_ids = position_ids.unsqueeze(0).expand(input_shape)
+        token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+
+        inputs_embeds = self.word_embeddings(input_ids)
         position_embeddings = self.position_embeddings(position_ids)
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
 
         embeddings = inputs_embeds + position_embeddings + token_type_embeddings
         embeddings = self.LayerNorm(embeddings)
-        embeddings = self.dropout(embeddings)
         return embeddings

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -126,6 +126,17 @@ def tensor_slice(x: Tensor, begin: List[int], size: List[int]) -> Tensor:
     return x[slices]
 
 
+def transpose_for_scores(
+    num_attention_heads: int, attention_head_size: int, x: Tensor
+) -> Tensor:
+    new_x_shape = x.size()[:-1] + (
+        num_attention_heads,
+        attention_head_size,
+    )
+    x = x.view(*new_x_shape)
+    return x.permute(0, 2, 1, 3)
+
+
 class PretrainedMixin:
     def get_model_dir(self, url):
         return os.path.join(

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -129,11 +129,7 @@ def tensor_slice(x: Tensor, begin: List[int], size: List[int]) -> Tensor:
 def transpose_for_scores(
     num_attention_heads: int, attention_head_size: int, x: Tensor
 ) -> Tensor:
-    new_x_shape = x.size()[:-1] + (
-        num_attention_heads,
-        attention_head_size,
-    )
-    x = x.view(*new_x_shape)
+    x = x.unflatten(-1, (num_attention_heads, attention_head_size))
     return x.permute(0, 2, 1, 3)
 
 


### PR DESCRIPTION
Summary:
<!-- Change Summary -->
This PR implements the text encoder used in the ALBEF model. 

The text encoder is based off of the [bert implementation](https://github.com/salesforce/ALBEF/blob/6224e78e5292757ca9c7d5add3e415010955a58b/models/xbert.py) in the ALBEF repo. Only classes and operations that affect the final output are kept in this PR. 

TODO: All of the text encoder's components are in the same file as the text encoder, but will refactor once the multimodal encoder is finished. 

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
Initiated the text encoder and loaded the pre-trained bert `state_dict` from the ALBEF repo, and checked that the outputs match. 

Wrote unit tests with small inputs and invalid inputs to check for expected outputs/errors. 

