### PR TITLE
Add sanity tests to wheel building workflow

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -26,3 +26,6 @@ jobs:
       - name: Test import
         run: |
           python -c "import torchmultimodal"
+      - name: Install pytorch dependencies
+        run: |
+          pip3 install --pre torch torchvision torchtext --extra-index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -16,6 +16,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Check out repository
         uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          pip3 install --pre torch torchvision torchtext --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+          pip3 install -r dev-requirements.txt
       - name: Build wheel
         run: |
           pip3 install wheel
@@ -26,10 +30,6 @@ jobs:
       - name: Test import
         run: |
           python -c "import torchmultimodal"
-      - name: Install dependencies
-        run: |
-          pip3 install --pre torch torchvision torchtext --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-          pip3 install -r dev-requirements.txt
       - name: Run unit tests for sanity
         run: |
-          pytest -vv
+          pytest test -vv

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,6 +1,5 @@
 name: Test build workflow
 on:
-  pull_request:
   workflow_dispatch:
 jobs:
   build_wheel:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run unit tests for sanity
         run: |
           pip3 install pytest
-          pytest torchmultimodal
+          pytest -vv

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,5 +1,6 @@
 name: Test build workflow
 on:
+  pull_request:
   workflow_dispatch:
 jobs:
   build_wheel:
@@ -22,3 +23,6 @@ jobs:
       - name: Install wheel
         run: |
           pip3 install dist/torchmultimodal*.whl
+      - name: Test import
+        run: |
+          python -c "import torchmultimodal"

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,7 +1,6 @@
 name: Test build workflow
 on:
   workflow_dispatch:
-  pull_request:
 jobs:
   build_wheel:
     strategy:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,6 +1,7 @@
 name: Test build workflow
 on:
   workflow_dispatch:
+  pull_request:
 jobs:
   build_wheel:
     strategy:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -29,3 +29,7 @@ jobs:
       - name: Install pytorch dependencies
         run: |
           pip3 install --pre torch torchvision torchtext --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+      - name: Run unit tests for sanity
+        run: |
+          pip3 install pytest
+          pytest torchmultimodal

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Test import
         run: |
           python -c "import torchmultimodal"
-      - name: Install pytorch dependencies
+      - name: Install dependencies
         run: |
           pip3 install --pre torch torchvision torchtext --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+          pip3 install -r dev-requirements.txt
       - name: Run unit tests for sanity
         run: |
-          pip3 install pytest
           pytest -vv


### PR DESCRIPTION
Summary:
Run sanity tests after building the wheel. next step would be to publish to pypi (test one till we go under pytorch?)

Test plan:
CI on the PR itself (I added trigger as pull request temporarily to see successful flow and then removed it)
https://github.com/facebookresearch/multimodal/runs/7117869297?check_suite_focus=true