### PR TITLE
[ALBEF] multimodal encoder

### DIFF
--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -145,13 +145,15 @@ def test_dequeue_and_enqueue(dummy_albef_model):
 def test_momentum_update(dummy_albef_model):
     init_weight = Tensor([[1, 2, 3], [4, 5, 6]])
     init_weight_m = Tensor([[6, 5, 4], [3, 2, 1]])
-    dummy_albef_model.models[0].weight = nn.Parameter(init_weight)
-    dummy_albef_model.models_m[0].weight = nn.Parameter(init_weight_m)
+    dummy_albef_model.vision_encoder.weight = nn.Parameter(init_weight)
+    dummy_albef_model.vision_encoder_m.weight = nn.Parameter(init_weight_m)
     dummy_albef_model._momentum_update()
     expected_weight_m = Tensor([[4.75, 4.25, 3.75], [3.25, 2.75, 2.25]])
-    assert_expected(dummy_albef_model.models[0].weight, init_weight, rtol=0, atol=1e-4)
     assert_expected(
-        dummy_albef_model.models_m[0].weight, expected_weight_m, rtol=0, atol=1e-4
+        dummy_albef_model.vision_encoder.weight, init_weight, rtol=0, atol=1e-4
+    )
+    assert_expected(
+        dummy_albef_model.vision_encoder_m.weight, expected_weight_m, rtol=0, atol=1e-4
     )
 
 

--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -52,6 +52,7 @@ def dummy_albef_model():
         nn.Linear(3, 2),
         embed_dim=2,
         queue_size=4,
+        momentum=0.75,
     )
 
 
@@ -147,7 +148,7 @@ def test_momentum_update(dummy_albef_model):
     dummy_albef_model.models[0].weight = nn.Parameter(init_weight)
     dummy_albef_model.models_m[0].weight = nn.Parameter(init_weight_m)
     dummy_albef_model._momentum_update()
-    expected_weight_m = Tensor([[5.9750, 4.9850, 3.9950], [3.0050, 2.0150, 1.0250]])
+    expected_weight_m = Tensor([[4.75, 4.25, 3.75], [3.25, 2.75, 2.25]])
     assert_expected(dummy_albef_model.models[0].weight, init_weight, rtol=0, atol=1e-4)
     assert_expected(
         dummy_albef_model.models_m[0].weight, expected_weight_m, rtol=0, atol=1e-4

--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -4,14 +4,47 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from functools import partial
+
+import pytest
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import nn, Tensor
 from torchmultimodal.models.albef import ALBEFModel, ALBEFSimilarity
+from torchmultimodal.modules.encoders.albef_multimodal_encoder import (
+    ALBEFMultimodalEncoder,
+)
+from torchmultimodal.modules.encoders.albef_text_encoder import ALBEFTextEncoder
+from torchmultimodal.modules.encoders.albef_vision_encoder import ALBEFVisionEncoder
 
 
-class TestALBEFModel:
-    albef = ALBEFModel(
+@pytest.fixture(autouse=True)
+def vision_encoder():
+    set_rng_seed(0)
+    return ALBEFVisionEncoder(
+        image_size=4,
+        patch_size=4,
+        num_layers=2,
+        num_heads=1,
+        hidden_dim=3,
+        mlp_dim=6,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6),
+    )
+
+
+@pytest.fixture(autouse=True)
+def text_encoder():
+    return ALBEFTextEncoder(hidden_size=3, num_attention_heads=1)
+
+
+@pytest.fixture(autouse=True)
+def multimodal_encoder():
+    return ALBEFMultimodalEncoder(hidden_size=3, num_attention_heads=1)
+
+
+@pytest.fixture(autouse=True)
+def dummy_albef_model():
+    return ALBEFModel(
         nn.Linear(3, 2),
         nn.Linear(3, 2),
         nn.Linear(3, 2),
@@ -21,96 +54,170 @@ class TestALBEFModel:
         queue_size=4,
     )
 
-    def test_copy_params_momentum_models(self):
-        self.albef.models_m = [nn.Linear(3, 2) for _ in range(5)]
-        self.albef._copy_params_momentum_models()
-        for model, model_m in zip(self.albef.models, self.albef.models_m):
-            for param, param_m in zip(model.parameters(), model_m.parameters()):
-                assert_expected(param, param_m, rtol=0, atol=1e-4)
-                assert not param_m.requires_grad
 
-    def test_dequeue_and_enqueue(self):
-        image_feat_m = torch.randn(2, 2)
-        text_feat_m = torch.randn(2, 2)
-        self.albef._dequeue_and_enqueue(image_feat_m, text_feat_m)
-        assert_expected(
-            self.albef.image_queue[:, 0:2], image_feat_m.T, rtol=0, atol=1e-4
-        )
-        assert_expected(self.albef.text_queue[:, 0:2], text_feat_m.T, rtol=0, atol=1e-4)
+@pytest.fixture(autouse=True)
+def albef_model(vision_encoder, text_encoder, multimodal_encoder):
+    return ALBEFModel(
+        vision_encoder,
+        text_encoder,
+        multimodal_encoder,
+        nn.Linear(3, 2),
+        nn.Linear(3, 2),
+        embed_dim=2,
+        queue_size=4,
+    )
 
-    def test_momentum_update(self):
-        init_weight = Tensor([[1, 2, 3], [4, 5, 6]])
-        init_weight_m = Tensor([[6, 5, 4], [3, 2, 1]])
-        self.albef.models[0].weight = nn.Parameter(init_weight)
-        self.albef.models_m[0].weight = nn.Parameter(init_weight_m)
-        self.albef._momentum_update()
-        expected_weight_m = Tensor([[5.9750, 4.9850, 3.9950], [3.0050, 2.0150, 1.0250]])
-        assert_expected(self.albef.models[0].weight, init_weight, rtol=0, atol=1e-4)
-        assert_expected(
-            self.albef.models_m[0].weight, expected_weight_m, rtol=0, atol=1e-4
-        )
 
-    def test_similarity(self):
-        set_rng_seed(0)
-        self.albef.image_queue = torch.randn(2, 4)
-        self.albef.text_queue = torch.randn(2, 4)
-        image_feat = torch.randn(2, 2)
-        text_feat = torch.randn(2, 2)
-        image_feat_m = torch.randn(2, 2)
-        text_feat_m = torch.randn(2, 2)
-        output = self.albef._similarity(
-            image_feat, text_feat, image_feat_m, text_feat_m
-        )
-        expected_sim_i2t = Tensor(
-            [
-                [-3.660729, -11.191917, 1.252719, 9.129601, -0.882724, -0.818697],
-                [15.755546, 21.687363, 27.634123, -18.587852, 30.696188, -4.964930],
-            ]
-        )
-        expected_sim_t2i = Tensor(
-            [
-                [27.311251, -23.288742, -14.411922, -30.653456, -3.136197, 20.444725],
-                [16.565296, -26.082125, 8.684321, -19.420963, -24.787359, 16.908016],
-            ]
-        )
-        expected_sim_i2t_m = Tensor(
-            [
-                [-13.028821, -22.274969, -17.438065, 18.764980, -20.974815, 2.714235],
-                [8.504787, 5.272466, 22.941040, -5.002890, 23.104834, -4.742508],
-            ]
-        )
-        expected_sim_t2i_m = Tensor(
-            [
-                [-13.028821, 8.504787, 10.671893, 14.442708, -3.490067, -8.771053],
-                [-22.274969, 5.272466, 31.752522, 24.050060, -23.705740, -11.501695],
-            ]
-        )
-        assert_expected(output.sim_i2t, expected_sim_i2t, rtol=0, atol=1e-4)
-        assert_expected(output.sim_t2i, expected_sim_t2i, rtol=0, atol=1e-4)
-        assert_expected(output.sim_i2t_m, expected_sim_i2t_m, rtol=0, atol=1e-4)
-        assert_expected(output.sim_t2i_m, expected_sim_t2i_m, rtol=0, atol=1e-4)
+@pytest.fixture(autouse=True)
+def albef_model_output(albef_model):
+    image = torch.randn(2, 3, 4, 4)
+    text = torch.randint(10, (2, 2))
+    text_atts = Tensor([[1, 1], [1, 0]])
+    return albef_model(image, text, text_atts)
 
-    def test_neg_embeddings(self):
-        set_rng_seed(0)
-        image_embeds = torch.randn(2, 1, 3)
-        text_embeds = torch.randn(2, 1, 3)
-        text_atts = torch.randn(2, 1)
-        similarity = ALBEFSimilarity(
-            sim_i2t=torch.randn(2, 5),
-            sim_t2i=torch.randn(2, 5),
-            sim_i2t_m=torch.randn(2, 5),
-            sim_t2i_m=torch.randn(2, 5),
-        )
-        image_embeds_neg, text_embeds_neg, text_atts_neg = self.albef._neg_embeddings(
-            image_embeds, text_embeds, text_atts, similarity
-        )
-        expected_image_embeds_neg = Tensor(
-            [[0.568431, -1.084522, -1.398595], [1.540996, -0.293429, -2.178789]]
-        ).unsqueeze(1)
-        expected_text_embeds_neg = Tensor(
-            [[-0.403344, -0.596635, 0.182036], [0.403347, 0.838026, -0.719258]]
-        ).unsqueeze(1)
-        expected_text_atts_neg = Tensor([1.100604, -0.856675]).unsqueeze(1)
-        assert_expected(image_embeds_neg, expected_image_embeds_neg, rtol=0, atol=1e-4)
-        assert_expected(text_embeds_neg, expected_text_embeds_neg, rtol=0, atol=1e-4)
-        assert_expected(text_atts_neg, expected_text_atts_neg, rtol=0, atol=1e-4)
+
+def test_albef_image_embeddings(albef_model_output):
+    expected = Tensor(
+        [
+            [[1.401580, -0.537510, -0.864071], [1.378901, -0.417473, -0.961429]],
+            [[1.413948, -0.729806, -0.684143], [-1.313033, 1.111438, 0.201595]],
+        ]
+    )
+    assert_expected(albef_model_output.image_embeddings, expected, rtol=0, atol=1e-4)
+
+
+def test_albef_image_embeddings_momentum(albef_model_output):
+    expected = Tensor(
+        [
+            [[1.401580, -0.537510, -0.864070], [1.378902, -0.417473, -0.961429]],
+            [[1.413949, -0.729807, -0.684141], [-1.313033, 1.111438, 0.201595]],
+        ]
+    )
+    assert_expected(albef_model_output.image_embeddings_m, expected, rtol=0, atol=1e-4)
+
+
+def test_albef_text_embeddings(albef_model_output):
+    expected = Tensor(
+        [
+            [[-1.372420, 0.981756, 0.390664], [1.305102, -1.124284, -0.180818]],
+            [[-1.320019, 0.220507, 1.099512], [1.366452, -0.998831, -0.367621]],
+        ]
+    )
+    assert_expected(albef_model_output.text_embeddings, expected, rtol=0, atol=1e-4)
+
+
+def test_albef_vl_embeddings(albef_model_output):
+    expected = Tensor(
+        [
+            [-1.398094, 0.883438, 0.514656],
+            [-1.115577, 1.310528, -0.194951],
+            [-0.706023, 1.414213, -0.708190],
+            [-1.402520, 0.544084, 0.858435],
+            [-1.402520, 0.544084, 0.858435],
+            [-0.706023, 1.414213, -0.708190],
+        ]
+    )
+    assert_expected(albef_model_output.vl_embeddings, expected, rtol=0, atol=1e-4)
+
+
+def test_copy_params_momentum_models(dummy_albef_model):
+    dummy_albef_model.models_m = [nn.Linear(3, 2) for _ in range(5)]
+    dummy_albef_model._copy_params_momentum_models()
+    for model, model_m in zip(dummy_albef_model.models, dummy_albef_model.models_m):
+        for param, param_m in zip(model.parameters(), model_m.parameters()):
+            assert_expected(param, param_m, rtol=0, atol=1e-4)
+            assert not param_m.requires_grad
+
+
+def test_dequeue_and_enqueue(dummy_albef_model):
+    image_feat_m = torch.randn(2, 2)
+    text_feat_m = torch.randn(2, 2)
+    dummy_albef_model._dequeue_and_enqueue(image_feat_m, text_feat_m)
+    assert_expected(
+        dummy_albef_model.image_queue[:, 0:2], image_feat_m.T, rtol=0, atol=1e-4
+    )
+    assert_expected(
+        dummy_albef_model.text_queue[:, 0:2], text_feat_m.T, rtol=0, atol=1e-4
+    )
+
+
+def test_momentum_update(dummy_albef_model):
+    init_weight = Tensor([[1, 2, 3], [4, 5, 6]])
+    init_weight_m = Tensor([[6, 5, 4], [3, 2, 1]])
+    dummy_albef_model.models[0].weight = nn.Parameter(init_weight)
+    dummy_albef_model.models_m[0].weight = nn.Parameter(init_weight_m)
+    dummy_albef_model._momentum_update()
+    expected_weight_m = Tensor([[5.9750, 4.9850, 3.9950], [3.0050, 2.0150, 1.0250]])
+    assert_expected(dummy_albef_model.models[0].weight, init_weight, rtol=0, atol=1e-4)
+    assert_expected(
+        dummy_albef_model.models_m[0].weight, expected_weight_m, rtol=0, atol=1e-4
+    )
+
+
+def test_similarity(dummy_albef_model):
+    dummy_albef_model.image_queue = torch.randn(2, 4)
+    dummy_albef_model.text_queue = torch.randn(2, 4)
+    image_feat = torch.randn(2, 2)
+    text_feat = torch.randn(2, 2)
+    image_feat_m = torch.randn(2, 2)
+    text_feat_m = torch.randn(2, 2)
+    output = dummy_albef_model._similarity(
+        image_feat, text_feat, image_feat_m, text_feat_m
+    )
+    expected_sim_i2t = Tensor(
+        [
+            [6.502346, -7.115936, -2.145788, -6.376165, -24.799065, 9.196653],
+            [6.027566, 0.114348, 1.448457, -1.095767, -9.806778, 4.751029],
+        ]
+    )
+    expected_sim_t2i = Tensor(
+        [
+            [1.810656, 7.657638, 3.690561, -3.923022, -0.312378, -1.590274],
+            [-8.485663, -23.672398, -12.058897, 11.247606, 3.449185, 0.094083],
+        ]
+    )
+    expected_sim_i2t_m = Tensor(
+        [
+            [10.874029, -5.082995, -0.096355, -5.771802, -28.081427, 11.545799],
+            [-28.726080, -29.685524, -21.830336, -15.685751, -10.502577, -6.253645],
+        ]
+    )
+    expected_sim_t2i_m = Tensor(
+        [
+            [10.874029, -28.726080, -9.868037, 20.097771, -14.018656, 35.459442],
+            [-5.082995, -29.685524, -13.870997, 15.797729, -0.453870, 9.397278],
+        ]
+    )
+    assert_expected(output.sim_i2t, expected_sim_i2t, rtol=0, atol=1e-4)
+    assert_expected(output.sim_t2i, expected_sim_t2i, rtol=0, atol=1e-4)
+    assert_expected(output.sim_i2t_m, expected_sim_i2t_m, rtol=0, atol=1e-4)
+    assert_expected(output.sim_t2i_m, expected_sim_t2i_m, rtol=0, atol=1e-4)
+
+
+def test_neg_embeddings(dummy_albef_model):
+    image_embeds = torch.randn(2, 1, 3)
+    text_embeds = torch.randn(2, 1, 3)
+    text_atts = torch.randn(2, 1)
+    similarity = ALBEFSimilarity(
+        sim_i2t=torch.randn(2, 5),
+        sim_t2i=torch.randn(2, 5),
+        sim_i2t_m=torch.randn(2, 5),
+        sim_t2i_m=torch.randn(2, 5),
+    )
+    (
+        image_embeds_neg,
+        text_embeds_neg,
+        text_atts_neg,
+    ) = dummy_albef_model._neg_embeddings(
+        image_embeds, text_embeds, text_atts, similarity
+    )
+    expected_image_embeds_neg = Tensor(
+        [[0.360331, 0.022756, -0.614475], [-1.006015, 1.046856, 0.119976]]
+    ).unsqueeze(1)
+    expected_text_embeds_neg = Tensor(
+        [[0.560847, 0.789766, -0.013260], [0.910636, -1.927051, 0.644789]]
+    ).unsqueeze(1)
+    expected_text_atts_neg = Tensor([0.111645, -0.351305]).unsqueeze(1)
+    assert_expected(image_embeds_neg, expected_image_embeds_neg, rtol=0, atol=1e-4)
+    assert_expected(text_embeds_neg, expected_text_embeds_neg, rtol=0, atol=1e-4)
+    assert_expected(text_atts_neg, expected_text_atts_neg, rtol=0, atol=1e-4)

--- a/test/modules/encoders/test_albef_multimodal_encoder.py
+++ b/test/modules/encoders/test_albef_multimodal_encoder.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torch import Tensor
+from torchmultimodal.modules.encoders.albef_multimodal_encoder import (
+    ALBEFMultimodalEncoder,
+)
+
+
+@pytest.fixture(autouse=True)
+def multimodal_encoder():
+    set_rng_seed(0)
+    return ALBEFMultimodalEncoder(hidden_size=3, num_attention_heads=1)
+
+
+def test_multimodal_encoder(multimodal_encoder):
+    image_embeds = torch.randn(2, 2, 3)
+    text_embeds = torch.randn(2, 2, 3)
+    text_atts = torch.Tensor([[1, 1], [1, 0]])
+    output = multimodal_encoder(image_embeds, text_embeds, text_atts)
+    expected = Tensor(
+        [
+            [[0.794870, 0.615549, -1.410419], [1.314163, -1.109555, -0.204607]],
+            [[-0.862034, -0.539896, 1.401930], [-1.176761, -0.090902, 1.267663]],
+        ]
+    )
+    assert_expected(output, expected, rtol=0, atol=1e-4)
+
+
+def test_invalid_image_hidden_size(multimodal_encoder):
+    image_embeds = torch.randn(2, 2, 4)
+    text_embeds = torch.randn(2, 2, 3)
+    text_atts = torch.Tensor([[1, 1], [1, 0]])
+    with pytest.raises(RuntimeError):
+        multimodal_encoder(image_embeds, text_embeds, text_atts)
+
+
+def test_invalid_text_hidden_size(multimodal_encoder):
+    image_embeds = torch.randn(2, 2, 3)
+    text_embeds = torch.randn(2, 2, 4)
+    text_atts = torch.Tensor([[1, 1], [1, 0]])
+    with pytest.raises(RuntimeError):
+        multimodal_encoder(image_embeds, text_embeds, text_atts)
+
+
+def test_not_matching_input_batch_size(multimodal_encoder):
+    image_embeds = torch.randn(2, 2, 3)
+    text_embeds = torch.randn(3, 2, 3)
+    text_atts = torch.Tensor([[1, 1], [1, 0], [1, 1]])
+    with pytest.raises(RuntimeError):
+        multimodal_encoder(image_embeds, text_embeds, text_atts)

--- a/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
@@ -58,9 +58,7 @@ class ALBEFMultimodalEncoder(nn.Module):
         text_embeds: Tensor,
         text_atts: Tensor,
     ) -> Tensor:
-        if text_atts.size() == text_embeds.size()[:-1]:
-            text_atts = get_extended_attention_mask(text_atts)
-
+        text_atts = get_extended_attention_mask(text_atts)
         hidden_states = text_embeds
         for layer_module in self.layer:
             hidden_states = layer_module(

--- a/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
@@ -18,6 +18,8 @@ class ALBEFMultimodalEncoder(nn.Module):
     """
     Construct multimodal embeddings from image embeddings, text embeddings, and text attention mask.
 
+    The ALBEFMultimodalEncoder is similar to ALBEFTextEncoder, with the addition of image-text cross attention in encoder layers.
+
     Args:
         hidden_size (int): Dimensionality of the encoder layers. Default is 768.
         num_hidden_layers (int): Number of hidden layers in the Transformer encoder. Default is 6.
@@ -84,9 +86,11 @@ class ALBEFTransformerLayerWithCrossAttention(nn.Module):
         transform_act_fn: Callable[[Tensor], Tensor],
     ) -> None:
         super().__init__()
+        # the attention block computes the self attention on text embeddings
         self.attention = ALBEFTransformerAttention(
             hidden_size, num_attention_heads, layer_norm_eps
         )
+        # the cross_attention block computes the cross attention on image and text embeddings
         self.cross_attention = ALBEFTransformerAttention(
             hidden_size, num_attention_heads, layer_norm_eps
         )

--- a/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
@@ -27,7 +27,7 @@ class ALBEFMultimodalEncoder(nn.Module):
         intermediate_size (int): Dimensionality of the “intermediate” (i.e., feed-forward) layer in the Transformer encoder.
             Default is 3072.
         layer_norm_eps (float): The epsilon used by the layer normalization layers. Default is 1e-12.
-        transform_act_fn (Callable[[Tensor], Tensor]): The activation function for the Transformer encoder layer. Defualt is GELU.
+        transform_act_fn (Callable[[Tensor], Tensor]): The activation function for the Transformer encoder layer. Default is GELU.
 
     Inputs:
         image_embeds (Tensor of size (batch_size, image_seq_length, hidden_size)): Image embeddings from a vision encoder.

--- a/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
@@ -13,12 +13,30 @@ from torchmultimodal.utils.common import get_extended_attention_mask
 
 
 class ALBEFMultimodalEncoder(nn.Module):
+    """
+    Construct multimodal embeddings from image embeddings, text embeddings, and text attention mask.
+
+    Args:
+        hidden_size (int): Dimensionality of the encoder layers. Default is 768.
+        num_hidden_layers (int): Number of hidden layers in the Transformer encoder. Default is 6.
+        num_attention_heads (int): Number of attention heads for each attention layer in the Transformer encoder. Default is 12.
+        intermediate_size (int): Dimensionality of the “intermediate” (i.e., feed-forward) layer in the Transformer encoder.
+            Default is 3072.
+        layer_norm_eps (float): The epsilon used by the layer normalization layers. Default is 1e-12.
+
+    Inputs:
+        image_embeds (Tensor of size (batch_size, image_seq_length, hidden_size)): Image embeddings from a vision encoder.
+        text_embeds (Tensor of size (batch_size, text_seq_length, hidden_size)): Text embeddings from a text encoder.
+        text_atts (Tensor of size (batch_size, text_seq_length)): Mask to avoid performing attention on padding token indices.
+            Mask values selected in [0, 1]: 1 for tokens that are NOT MASKED, 0 for MASKED tokens.
+    """
+
     def __init__(
         self,
         hidden_size: int = 768,
-        intermediate_size: int = 3072,
-        num_attention_heads: int = 12,
         num_hidden_layers: int = 6,
+        num_attention_heads: int = 12,
+        intermediate_size: int = 3072,
         layer_norm_eps: float = 1e-12,
     ) -> None:
         super().__init__()

--- a/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from torch import nn, Tensor
+from torchmultimodal.modules.encoders.albef_text_encoder import (
+    ALBEFTransformerAttention,
+)
+from torchmultimodal.utils.common import get_extended_attention_mask
+
+
+class ALBEFMultimodalEncoder(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int = 768,
+        intermediate_size: int = 3072,
+        num_attention_heads: int = 12,
+        num_hidden_layers: int = 6,
+        layer_norm_eps: float = 1e-12,
+    ) -> None:
+        super().__init__()
+        self.layer = nn.ModuleList(
+            [
+                ALBEFTransformerLayerWithCrossAttention(
+                    hidden_size,
+                    intermediate_size,
+                    num_attention_heads,
+                    layer_norm_eps,
+                )
+                for _ in range(num_hidden_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        image_embeds: Tensor,
+        text_embeds: Tensor,
+        text_atts: Tensor,
+    ) -> Tensor:
+        if text_atts.size() == text_embeds.size()[:-1]:
+            text_atts = get_extended_attention_mask(text_atts)
+
+        hidden_states = text_embeds
+        for layer_module in self.layer:
+            hidden_states = layer_module(
+                hidden_states,
+                attention_mask=text_atts,
+                encoder_hidden_states=image_embeds,
+            )
+        return hidden_states
+
+
+class ALBEFTransformerLayerWithCrossAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_attention_heads: int,
+        layer_norm_eps: float,
+    ) -> None:
+        super().__init__()
+        self.attention = ALBEFTransformerAttention(
+            hidden_size, num_attention_heads, layer_norm_eps
+        )
+        self.cross_attention = ALBEFTransformerAttention(
+            hidden_size, num_attention_heads, layer_norm_eps
+        )
+        self.dense1 = nn.Linear(hidden_size, intermediate_size)
+        self.transform_act_fn = nn.GELU()
+        self.dense2 = nn.Linear(intermediate_size, hidden_size)
+        self.layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        encoder_hidden_states: Tensor,
+    ) -> Tensor:
+        attention_output = self.attention(hidden_states, attention_mask)
+        attention_output = self.cross_attention(
+            attention_output, attention_mask, encoder_hidden_states
+        )
+        dense1_output = self.dense1(attention_output)
+        act_output = self.transform_act_fn(dense1_output)
+        dense2_output = self.dense2(act_output)
+        norm_output = self.layer_norm(dense2_output + attention_output)
+        return norm_output

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -33,7 +33,7 @@ class ALBEFTextEncoder(nn.Module):
         type_vocab_size (int): The vocabulary size of the token_type_ids. Default is 2.
         pad_token_id (int): The embedding for pad_token_id is not updated during training. Default is 0.
         layer_norm_eps (float): The epsilon used by the layer normalization layers. Default is 1e-12.
-        ransform_act_fn (Callable[[Tensor], Tensor]): The activation function for the Transformer encoder layer. Defualt is GELU.
+        transform_act_fn (Callable[[Tensor], Tensor]): The activation function for the Transformer encoder layer. Default is GELU.
     Inputs:
         input_ids (Tensor of size (batch_size, sequence_length)): Indices of input sequence tokens in the vocabulary.
         attention_mask (Tensor of shape (batch_size, sequence_length)): Mask to avoid performing attention on padding token indices.

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -240,6 +240,8 @@ class ALBEFTransformerSelfAttention(nn.Module):
     ) -> Tensor:
         mixed_query_layer = self.query(hidden_states)
 
+        # If encoder_hidden_states is not passed, then compute the self attention on hidden_states
+        # Otherwise, compute the cross attention on hidden_states and encoder_hidden_states
         if encoder_hidden_states is None:
             mixed_key_layer = self.key(hidden_states)
             mixed_value_layer = self.value(hidden_states)

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import Optional
+from typing import Callable, Optional
 
 import torch
 from torch import nn, Tensor
@@ -33,6 +33,7 @@ class ALBEFTextEncoder(nn.Module):
         type_vocab_size (int): The vocabulary size of the token_type_ids. Default is 2.
         pad_token_id (int): The embedding for pad_token_id is not updated during training. Default is 0.
         layer_norm_eps (float): The epsilon used by the layer normalization layers. Default is 1e-12.
+        ransform_act_fn (Callable[[Tensor], Tensor]): The activation function for the Transformer encoder layer. Defualt is GELU.
     Inputs:
         input_ids (Tensor of size (batch_size, sequence_length)): Indices of input sequence tokens in the vocabulary.
         attention_mask (Tensor of shape (batch_size, sequence_length)): Mask to avoid performing attention on padding token indices.
@@ -50,6 +51,7 @@ class ALBEFTextEncoder(nn.Module):
         type_vocab_size: int = 2,
         pad_token_id: int = 0,
         layer_norm_eps: float = 1e-12,
+        transform_act_fn: Callable[[Tensor], Tensor] = nn.functional.gelu,
     ) -> None:
         super().__init__()
 
@@ -67,6 +69,7 @@ class ALBEFTextEncoder(nn.Module):
             num_attention_heads,
             num_hidden_layers,
             layer_norm_eps,
+            transform_act_fn,
         )
 
     def forward(
@@ -123,6 +126,7 @@ class ALBEFTransformerEncoder(nn.Module):
         num_attention_heads: int,
         num_hidden_layers: int,
         layer_norm_eps: float,
+        transform_act_fn: Callable[[Tensor], Tensor],
     ) -> None:
         super().__init__()
         self.layer = nn.ModuleList(
@@ -132,6 +136,7 @@ class ALBEFTransformerEncoder(nn.Module):
                     intermediate_size,
                     num_attention_heads,
                     layer_norm_eps,
+                    transform_act_fn,
                 )
                 for _ in range(num_hidden_layers)
             ]
@@ -154,13 +159,14 @@ class ALBEFTransformerLayer(nn.Module):
         intermediate_size: int,
         num_attention_heads: int,
         layer_norm_eps: float,
+        transform_act_fn: Callable[[Tensor], Tensor],
     ) -> None:
         super().__init__()
         self.attention = ALBEFTransformerAttention(
             hidden_size, num_attention_heads, layer_norm_eps
         )
         self.dense1 = nn.Linear(hidden_size, intermediate_size)
-        self.transform_act_fn = nn.GELU()
+        self.transform_act_fn = transform_act_fn
         self.dense2 = nn.Linear(intermediate_size, hidden_size)
         self.layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 


### PR DESCRIPTION
Summary:
<!-- Change Summary -->
This PR implements the multimodal encoder for the ALBEF model. 
* Modifies the `ALBEFTransformerAttention` class in [albef_text_encoder.py](https://github.com/facebookresearch/multimodal/compare/albef-multimodal-encoder?expand=1#diff-3932bbbc9188801f7a2310b6c7d9461bf744f9ac5be55ab613ded71f83a062d6) to include an optional `encoder_hidden_states` input. When this input is passed in, cross attention is computed. Otherwise self attention is computed. 
* The multimodal encoder is similar to the text encoder, with the cross attention added to each of the encoder layers. 
* Fixed some bugs in `ALBEFModel` found when adding embedding tests to the [test_albef.py](https://github.com/facebookresearch/multimodal/compare/albef-multimodal-encoder?expand=1#diff-d5a1ba66dc8cd1d757cd40b8676f6c2a07866a432fae6f94f5f61a12561a1e8f) (removed `text_atts` from `ALBEFOutput` because it's not used, buffer queues were updated in the wrong place, and `vl_embeddings` only needed the cls tokens. 

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
* Wrote unit tests for the multimodal encoder. 
* Added more tests for the ALBEFModel to test for expected encoder embeddings

