### PR TITLE
Add MDETR losses

### DIFF
--- a/test/modules/losses/test_mdetr_losses.py
+++ b/test/modules/losses/test_mdetr_losses.py
@@ -1,0 +1,118 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+
+import pytest
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.losses.mdetr import box_losses, classification_loss
+from torchvision.ops.boxes import box_convert
+
+
+@pytest.fixture(scope="class", autouse=True)
+def rng():
+    set_rng_seed(21)
+
+
+class TestMDETRLosses:
+    @pytest.fixture(scope="class")
+    def batch_size(self):
+        return 2
+
+    @pytest.fixture(scope="class")
+    def num_queries(self):
+        return 10
+
+    @pytest.fixture(scope="class")
+    def num_classes(self):
+        return 15
+
+    @pytest.fixture(scope="class")
+    def n_boxes_per_sample(self, batch_size, num_queries):
+        return [random.randint(1, num_queries) for _ in range(batch_size)]
+
+    @pytest.fixture(scope="class")
+    def total_boxes(self, n_boxes_per_sample):
+        return sum(n_boxes_per_sample)
+
+    @pytest.fixture(scope="class")
+    def pred_logits(self, batch_size, num_queries, num_classes):
+        return torch.randn(batch_size, num_queries, num_classes + 1)
+
+    @pytest.fixture(scope="class")
+    def max_slice_len(self):
+        return 3
+
+    @pytest.fixture(scope="class")
+    def positive_map(self, max_slice_len, total_boxes, num_classes):
+        positive_map = torch.zeros(total_boxes, num_classes + 1)
+        for i in range(total_boxes):
+            start_idx = random.randint(0, num_classes - max_slice_len)
+            increment = random.randint(2, max_slice_len)
+            positive_map[i, start_idx : start_idx + increment] = 1
+        return positive_map
+
+    @pytest.fixture(scope="class")
+    def indices(self, num_queries, n_boxes_per_sample):
+        return [
+            tuple(
+                torch.sort(
+                    torch.multinomial(
+                        torch.arange(num_queries, dtype=torch.float), n_boxes
+                    )
+                )
+            )
+            for n_boxes in n_boxes_per_sample
+        ]
+
+    @pytest.fixture(scope="class")
+    def num_boxes(self, total_boxes):
+        return int(random.uniform(0.5 * total_boxes, 2 * total_boxes))
+
+    @pytest.fixture(scope="class")
+    def construct_valid_boxes(self):
+        def _construct_valid_boxes(n_boxes):
+            boxes = []
+            for _ in range(n_boxes):
+                x1, y1 = torch.rand(2).unbind(-1)
+                x2 = random.uniform(x1.item(), 1)
+                y2 = random.uniform(y1.item(), 1)
+                box = box_convert(
+                    torch.Tensor([x1, y1, x2, y2]), in_fmt="xyxy", out_fmt="cxcywh"
+                )
+                boxes.append(box)
+            return torch.stack(boxes)
+
+        return _construct_valid_boxes
+
+    @pytest.fixture(scope="class")
+    def pred_boxes(self, construct_valid_boxes, batch_size, num_queries):
+        return construct_valid_boxes(batch_size * num_queries).reshape(
+            batch_size, num_queries, -1
+        )
+
+    @pytest.fixture(scope="class")
+    def target_boxes(self, construct_valid_boxes, n_boxes_per_sample):
+        return [construct_valid_boxes(n_boxes) for n_boxes in n_boxes_per_sample]
+
+    def test_classification_loss(
+        self, pred_logits, n_boxes_per_sample, positive_map, indices, num_boxes
+    ):
+        actual = torch.Tensor(
+            classification_loss(
+                pred_logits, n_boxes_per_sample, positive_map, indices, num_boxes
+            )
+        )
+        expected = torch.tensor(4.9197)
+        assert_expected(actual, expected, rtol=0, atol=1e-3)
+
+    def test_box_losses(self, pred_boxes, target_boxes, indices, num_boxes):
+        actual = box_losses(pred_boxes, target_boxes, indices, num_boxes)
+        expected_l1_loss = torch.tensor(0.6080)
+        expected_giou_loss = torch.tensor(0.9898)
+        assert_expected(actual.l1_loss, expected_l1_loss, rtol=0, atol=1e-3)
+        assert_expected(actual.giou_loss, expected_giou_loss, rtol=0, atol=1e-3)

--- a/test/modules/losses/test_mdetr_losses.py
+++ b/test/modules/losses/test_mdetr_losses.py
@@ -13,41 +13,41 @@ from torchmultimodal.modules.losses.mdetr import box_losses, soft_token_predicti
 from torchvision.ops.boxes import box_convert
 
 
-@pytest.fixture(scope="class", autouse=True)
+@pytest.fixture(autouse=True)
 def rng():
-    set_rng_seed(21)
+    set_rng_seed(1)
 
 
 class TestMDETRLosses:
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def batch_size(self):
         return 2
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def num_queries(self):
         return 10
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def num_classes(self):
         return 15
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def n_boxes_per_sample(self, batch_size, num_queries):
         return [random.randint(1, num_queries) for _ in range(batch_size)]
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def total_boxes(self, n_boxes_per_sample):
         return sum(n_boxes_per_sample)
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def pred_logits(self, batch_size, num_queries, num_classes):
         return torch.randn(batch_size, num_queries, num_classes + 1)
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def max_slice_len(self):
         return 3
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def positive_map(self, max_slice_len, total_boxes, num_classes):
         positive_map = torch.zeros(total_boxes, num_classes + 1)
         for i in range(total_boxes):
@@ -56,7 +56,7 @@ class TestMDETRLosses:
             positive_map[i, start_idx : start_idx + increment] = 1
         return positive_map
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def indices(self, num_queries, n_boxes_per_sample):
         return [
             tuple(
@@ -69,11 +69,11 @@ class TestMDETRLosses:
             for n_boxes in n_boxes_per_sample
         ]
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def num_boxes(self, total_boxes):
         return int(random.uniform(0.5 * total_boxes, 2 * total_boxes))
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def construct_valid_boxes(self):
         def _construct_valid_boxes(n_boxes):
             boxes = []
@@ -89,13 +89,13 @@ class TestMDETRLosses:
 
         return _construct_valid_boxes
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def pred_boxes(self, construct_valid_boxes, batch_size, num_queries):
         return construct_valid_boxes(batch_size * num_queries).reshape(
             batch_size, num_queries, -1
         )
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def target_boxes(self, construct_valid_boxes, n_boxes_per_sample):
         return [construct_valid_boxes(n_boxes) for n_boxes in n_boxes_per_sample]
 
@@ -107,12 +107,12 @@ class TestMDETRLosses:
                 pred_logits, n_boxes_per_sample, positive_map, indices, num_boxes
             )
         )
-        expected = torch.tensor(4.9197)
+        expected = torch.tensor(5.0893)
         assert_expected(actual, expected, rtol=0, atol=1e-3)
 
     def test_box_losses(self, pred_boxes, target_boxes, indices, num_boxes):
         actual = box_losses(pred_boxes, target_boxes, indices, num_boxes)
-        expected_l1_loss = torch.tensor(0.6080)
-        expected_giou_loss = torch.tensor(0.9898)
+        expected_l1_loss = torch.tensor(0.7721)
+        expected_giou_loss = torch.tensor(1.1768)
         assert_expected(actual.l1_loss, expected_l1_loss, rtol=0, atol=1e-3)
         assert_expected(actual.giou_loss, expected_giou_loss, rtol=0, atol=1e-3)

--- a/test/modules/losses/test_mdetr_losses.py
+++ b/test/modules/losses/test_mdetr_losses.py
@@ -9,7 +9,7 @@ import random
 import pytest
 import torch
 from test.test_utils import assert_expected, set_rng_seed
-from torchmultimodal.modules.losses.mdetr import box_losses, classification_loss
+from torchmultimodal.modules.losses.mdetr import box_losses, soft_token_prediction_loss
 from torchvision.ops.boxes import box_convert
 
 
@@ -99,11 +99,11 @@ class TestMDETRLosses:
     def target_boxes(self, construct_valid_boxes, n_boxes_per_sample):
         return [construct_valid_boxes(n_boxes) for n_boxes in n_boxes_per_sample]
 
-    def test_classification_loss(
+    def test_soft_token_prediction_loss(
         self, pred_logits, n_boxes_per_sample, positive_map, indices, num_boxes
     ):
         actual = torch.Tensor(
-            classification_loss(
+            soft_token_prediction_loss(
                 pred_logits, n_boxes_per_sample, positive_map, indices, num_boxes
             )
         )

--- a/torchmultimodal/modules/losses/mdetr.py
+++ b/torchmultimodal/modules/losses/mdetr.py
@@ -1,0 +1,119 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, NamedTuple, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torchvision.ops.boxes import box_convert, generalized_box_iou
+
+
+def _get_src_permutation_idx(
+    indices: List[Tuple[Tensor, Tensor]]
+) -> Tuple[Tensor, Tensor]:
+    """Permute predictions following indices"""
+    batch_idx = torch.cat(
+        [torch.full_like(src, i) for i, (src, _) in enumerate(indices)]
+    )
+    src_idx = torch.cat([src for (src, _) in indices])
+    return batch_idx, src_idx
+
+
+# TODO: we can calculate num_boxes in dataloader and add it to targets
+# Note: num_tokens = num_classes + 1. We should make this clear in other docstrings
+def classification_loss(
+    pred_logits: Tensor,
+    n_target_boxes: List[int],
+    positive_map: Tensor,
+    indices: List[Tuple[Tensor, Tensor]],
+    num_boxes: int,
+    eos_coef: float = 0.1,
+) -> Tensor:
+    """Classification loss (NLL)
+
+    Inputs: pred_logits (Tensor): Logits predicted by the model.
+                Shape: (batch_size, num_queries, num_tokens)
+            n_target_boxes (List[int]): Number of boxes in each target
+            positive_map (Tensor): Map from boxes to tokens for the entire batch.
+                positive_map[i,j] = 1 iff box i is associated to token j.
+                Shape: (sum([len(target["boxes"]) for target in batch]), num_tokens)
+            indices (List[Tuple[Tensor, Tensor]]): A list of size batch_size,
+                containing tuples of (index_i, index_j) where:
+                    - index_i is the indices of the selected predictions (in order)
+                    - index_j is the indices of the corresponding selected targets
+                For each batch element, it holds:
+                    len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+            num_boxes (int): Normalization factor. Should equal the average number of
+                boxes per local batch.
+            eos_coef (float): Relative classification weight of the no-object class.
+    Returns: Negative log likelihood for the batch normalized by num_boxes
+    """
+
+    logits = pred_logits.log_softmax(-1)
+
+    src_idx = _get_src_permutation_idx(indices)
+    tgt_idx = []
+    offset = 0
+    for i, (_, tgt) in enumerate(indices):
+        tgt_idx.append(tgt + offset)
+        offset += n_target_boxes[i]
+    tgt_idx = torch.cat(tgt_idx)
+    tgt_pos = positive_map[tgt_idx]
+    target_sim = torch.zeros_like(logits)
+    target_sim[:, :, -1] = 1
+    target_sim[src_idx] = tgt_pos
+    loss_ce = -(logits * target_sim).sum(-1)
+
+    eos_tensor = torch.full(loss_ce.shape, eos_coef, device=target_sim.device)
+    eos_tensor[src_idx] = 1
+
+    loss_ce = loss_ce * eos_tensor
+    loss_ce = loss_ce.sum() / num_boxes
+
+    return loss_ce
+
+
+class BoxLosses(NamedTuple):
+    l1_loss: torch.Tensor
+    giou_loss: torch.Tensor
+
+
+def box_losses(
+    pred_boxes: Tensor,
+    target_boxes: List[Tensor],
+    indices: List[Tuple[Tensor, Tensor]],
+    num_boxes: int,
+) -> BoxLosses:
+    """Box losses: L1 loss and GIoU loss
+
+    Inputs: pred_boxes (Tensor): Bounding boxes predicted by the model.
+                Shape: (batch_size, num_queries, 4)
+            target_boxes (List[Tensor]): List of box coordinates for each sample in batch.
+                Length = batch_size, Tensor size = [len(target["boxes"]), 4]
+            indices (List[Tuple[Tensor, Tensor]]): A list of size batch_size,
+                containing tuples of (index_i, index_j) where:
+                    - index_i is the indices of the selected predictions (in order)
+                    - index_j is the indices of the corresponding selected targets
+                For each batch element, it holds:
+                    len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+            num_boxes (int): Normalization factor. Should equal the average number of
+                boxes per local batch.
+    Returns: BoxLosses NamedTuple with elements l1_loss and giou_loss
+    """
+    idx = _get_src_permutation_idx(indices)
+    src_boxes = pred_boxes[idx]
+    target_boxes = torch.cat([t[i] for t, (_, i) in zip(target_boxes, indices)], dim=0)
+
+    l1_loss = F.l1_loss(src_boxes, target_boxes, reduction="sum") / num_boxes
+    giou_loss = 1 - torch.diag(
+        generalized_box_iou(
+            box_convert(src_boxes, in_fmt="cxcywh", out_fmt="xyxy"),
+            box_convert(target_boxes, in_fmt="cxcywh", out_fmt="xyxy"),
+        )
+    )
+    giou_loss = giou_loss.sum() / num_boxes
+    return BoxLosses(l1_loss=l1_loss, giou_loss=giou_loss)

--- a/torchmultimodal/modules/losses/mdetr.py
+++ b/torchmultimodal/modules/losses/mdetr.py
@@ -15,7 +15,23 @@ from torchvision.ops.boxes import box_convert, generalized_box_iou
 def _get_src_permutation_idx(
     indices: List[Tuple[Tensor, Tensor]]
 ) -> Tuple[Tensor, Tensor]:
-    """Permute predictions following indices"""
+    """
+    Given a list of matched (src, tgt) indices, concatenate the src indices and
+    return along with a tensor identifying which sample they came from.
+
+    Args:
+        indices (List[Tuple[Tensor, Tensor]]): A list of size batch_size, containing
+            tuples of ``(index_i, index_j)`` where:
+            - ``index_i`` is the indices of the selected predictions (i.e. srcs)
+            - ``index_j`` is the indices of the corresponding selected targets
+            For each batch element, it holds:
+                len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+    Returns:
+        A Tuple[Tensor, Tensor] x, where
+        x[0] gives the index of the sample in the batch
+        x[1] gives the src value from indices
+        Both x[0] and x[1] have size = (sum([len(index_i) for index_i in indices]))
+    """
     batch_idx = torch.cat(
         [torch.full_like(src, i) for i, (src, _) in enumerate(indices)]
     )
@@ -25,32 +41,39 @@ def _get_src_permutation_idx(
 
 # TODO: we can calculate num_boxes in dataloader and add it to targets
 # Note: num_tokens = num_classes + 1. We should make this clear in other docstrings
-def classification_loss(
+def soft_token_prediction_loss(
     pred_logits: Tensor,
     n_target_boxes: List[int],
     positive_map: Tensor,
     indices: List[Tuple[Tensor, Tensor]],
     num_boxes: int,
-    eos_coef: float = 0.1,
+    no_object_weight: float = 0.1,
 ) -> Tensor:
-    """Classification loss (NLL)
+    """Classification loss (NLL).
 
-    Inputs: pred_logits (Tensor): Logits predicted by the model.
-                Shape: (batch_size, num_queries, num_tokens)
-            n_target_boxes (List[int]): Number of boxes in each target
-            positive_map (Tensor): Map from boxes to tokens for the entire batch.
-                positive_map[i,j] = 1 iff box i is associated to token j.
-                Shape: (sum([len(target["boxes"]) for target in batch]), num_tokens)
-            indices (List[Tuple[Tensor, Tensor]]): A list of size batch_size,
-                containing tuples of (index_i, index_j) where:
-                    - index_i is the indices of the selected predictions (in order)
-                    - index_j is the indices of the corresponding selected targets
-                For each batch element, it holds:
-                    len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
-            num_boxes (int): Normalization factor. Should equal the average number of
-                boxes per local batch.
-            eos_coef (float): Relative classification weight of the no-object class.
-    Returns: Negative log likelihood for the batch normalized by num_boxes
+    Calculate the negative log-likelihood loss between the predicted logits and the
+    uniform distribution over matched tokens from the ground truth, as in MDETR. The
+    loss for unmatched boxes is downweighted by the value no_object_weight.
+    Ref: https://github.com/ashkamath/mdetr/blob/main/models/mdetr.py#L464
+
+    Args:
+        pred_logits (Tensor): Logits predicted by the model.
+            Shape: (batch_size, num_queries, num_tokens)
+        n_target_boxes (List[int]): Number of boxes in each target
+        positive_map (Tensor): Map from boxes to tokens for the entire batch.
+            positive_map[i,j] = 1 iff box i is associated to token j.
+            Shape: (sum([len(target["boxes"]) for target in batch]), num_tokens)
+        indices (List[Tuple[Tensor, Tensor]]): A list of size batch_size, containing
+            tuples of ``(index_i, index_j)`` where:
+            - ``index_i`` is the indices of the selected predictions (in order)
+            - ``index_j`` is the indices of the corresponding selected targets
+            For each batch element, it holds:
+                len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+        num_boxes (int): Normalization factor. Should equal the average number of
+            boxes per local batch.
+        no_object_weight (float): Relative classification weight of the no-object class.
+    Returns:
+        Negative log likelihood for the batch normalized by num_boxes
     """
 
     logits = pred_logits.log_softmax(-1)
@@ -61,17 +84,30 @@ def classification_loss(
     for i, (_, tgt) in enumerate(indices):
         tgt_idx.append(tgt + offset)
         offset += n_target_boxes[i]
+
+    # tgt_idx concatenates the target indices across samples in the batch,
+    # giving each box a unique value which will be used to permute positive_map
     tgt_idx = torch.cat(tgt_idx)
+
+    # Permute the rows of positive map based on target box indices
     tgt_pos = positive_map[tgt_idx]
+
     target_sim = torch.zeros_like(logits)
+
+    # Default is the no match value
     target_sim[:, :, -1] = 1
+
+    # Fill each of the corresponding rows of target_sim with the ground truth
     target_sim[src_idx] = tgt_pos
+
     loss_ce = -(logits * target_sim).sum(-1)
 
-    eos_tensor = torch.full(loss_ce.shape, eos_coef, device=target_sim.device)
-    eos_tensor[src_idx] = 1
-
-    loss_ce = loss_ce * eos_tensor
+    # Downweight the loss for unmatched boxes by no_object_weight
+    no_object_tensor = torch.full(
+        loss_ce.shape, no_object_weight, device=target_sim.device
+    )
+    no_object_tensor[src_idx] = 1
+    loss_ce = loss_ce * no_object_tensor
     loss_ce = loss_ce.sum() / num_boxes
 
     return loss_ce


### PR DESCRIPTION
Added the classification and box losses (L1 and GIoU) from MDETR.
Still to add the contrastive alignment loss, will update with that later on.

Test plan:
```
$ python -m pytest -v test/modules/losses/test_mdetr_losses.py
=================================================== test session starts ====================================================
platform linux -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /data/home/ebs/miniconda3/envs/torch-multimodal/bin/python
cachedir: .pytest_cache
rootdir: /data/home/ebs/torchmultimodal
collected 2 items

test/modules/losses/test_mdetr_losses.py::TestMDETRLosses::test_classification_loss PASSED                           [ 50%]
test/modules/losses/test_mdetr_losses.py::TestMDETRLosses::test_box_losses PASSED                                    [100%]

==================================================== 2 passed in 3.62s =====================================================
```

Summary:
<!-- Change Summary -->

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
