### PR TITLE
add support for loading pretrained weights to S3D encoder

### DIFF
--- a/examples/mugen/test/retrieval/test_video_clip.py
+++ b/examples/mugen/test/retrieval/test_video_clip.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 from examples.mugen.retrieval.video_clip import TextEncoder, VideoEncoder
 
-from test.test_utils import assert_expected, set_rng_seed
+from test.test_utils import assert_expected, get_asset_path, set_rng_seed
 
 
 class TestTextEncoder:
@@ -70,10 +70,25 @@ class TestVideoEncoder:
 
         return make_input_video
 
-    def test_forward(self, start):
+    def test_forward_pretrained(self, start):
         make_input_video = start
         input_video = make_input_video()
-        encoder = VideoEncoder()
+        pretrain_weights_filename = "S3D_kinetics400.pt"
+        encoder = VideoEncoder(pretrain_file=get_asset_path(pretrain_weights_filename))
+
+        out = encoder(input_video)
+        expected_sum = 1587.7263
+        assert_expected(
+            actual=out.shape, expected=torch.Size([2, 1024])
+        )  # batch x embedding
+        assert_expected(
+            actual=out.sum(), expected=torch.as_tensor(expected_sum), rtol=0, atol=1e-3
+        )
+
+    def test_forward_untrained(self, start):
+        make_input_video = start
+        input_video = make_input_video()
+        encoder = VideoEncoder(pretrained=False)
         out = encoder(input_video)
         expected_sum = 846.3781
         assert_expected(


### PR DESCRIPTION
Summary:
Add support for loading pretrained weights to S3D encoder. MUGEN used S3D pretrained on the Kinetics 400 dataset.

Test plan:
`python -m pytest examples/mugen/test/retrieval/test_video_clip.py::TestVideoEncoder -rP`