### PR TITLE
[ALBEF] Losses

### DIFF
--- a/test/modules/losses/test_albef.py
+++ b/test/modules/losses/test_albef.py
@@ -132,5 +132,5 @@ class TestMaskedLanguageModelingLoss:
         embeddings_m = torch.randn(2, 5, 3)
         weights = torch.randn(2)
         output = self.loss(labels, embeddings, embeddings_m, weights).item()
-        expected = -12.189002
+        expected = -24.951170
         assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/losses/test_albef.py
+++ b/test/modules/losses/test_albef.py
@@ -1,0 +1,147 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.losses.albef import (
+    ImageTextContrastiveLoss,
+    ImageTextMatchingLoss,
+    MaskedLanguageModelingLoss,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(0)
+
+
+@pytest.fixture(autouse=True)
+def itc_loss_module():
+    return ImageTextContrastiveLoss()
+
+
+@pytest.fixture(autouse=True)
+def itm_loss_module():
+    return ImageTextMatchingLoss(hidden_size=3)
+
+
+@pytest.fixture(autouse=True)
+def mlm_loss_module():
+    return MaskedLanguageModelingLoss(hidden_size=3)
+
+
+def test_itc_loss_invalid_sim(itc_loss_module):
+    sim_i2t = torch.randn(2, 4)  # all inputs should be the same size
+    sim_t2i = torch.randn(2, 3)
+    sim_i2t_m = torch.randn(2, 3)
+    sim_t2i_m = torch.randn(2, 3)
+    with pytest.raises(RuntimeError):
+        itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
+
+
+def test_itc_loss_invalid_sim_m(itc_loss_module):
+    sim_i2t = torch.randn(2, 3)
+    sim_t2i = torch.randn(2, 3)
+    sim_i2t_m = torch.randn(2, 4)  # all inputs should be the same size
+    sim_t2i_m = torch.randn(2, 3)
+    with pytest.raises(RuntimeError):
+        itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
+
+
+def test_itc_loss_invalid_sim_target(itc_loss_module):
+    sim_i2t = torch.randn(2, 3)
+    sim_t2i = torch.randn(2, 3)
+    sim_i2t_m = torch.randn(2, 3)
+    sim_t2i_m = torch.randn(2, 3)
+    sim_targets = torch.randn(2, 4)  # all inputs should be the same size
+    with pytest.raises(RuntimeError):
+        itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m, sim_targets).item()
+
+
+def test_itc_loss_without_sim_targets(itc_loss_module):
+    sim_i2t = torch.randn(2, 3)
+    sim_t2i = torch.randn(2, 3)
+    sim_i2t_m = torch.randn(2, 3)
+    sim_t2i_m = torch.randn(2, 3)
+    output = itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
+    expected = 1.160506
+    assert_expected(output, expected, rtol=0, atol=1e-4)
+
+
+def test_itc_loss_with_sim_targets(itc_loss_module):
+    sim_i2t = torch.randn(2, 3)
+    sim_t2i = torch.randn(2, 3)
+    sim_i2t_m = torch.randn(2, 3)
+    sim_t2i_m = torch.randn(2, 3)
+    sim_targets = torch.randn(2, 3)
+    output = itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m, sim_targets).item()
+    expected = -1.928954
+    assert_expected(output, expected, rtol=0, atol=1e-4)
+
+
+def test_itm_loss_invalid_input_batch_size(itm_loss_module):
+    # embeddings_neg's batch size (dim 0) should be double of embeddings_pos's batch size
+    embeddings_pos = torch.randn(2, 5, 3)
+    embeddings_neg = torch.randn(2, 5, 3)
+    with pytest.raises(ValueError):
+        itm_loss_module(embeddings_pos, embeddings_neg)
+
+
+def test_itm_loss_invalid_input_hidden_size(itm_loss_module):
+    # embeddings hidden size (dim 2) should match the hidden size of itm_loss_module
+    embeddings_pos = torch.randn(2, 5, 4)
+    embeddings_neg = torch.randn(4, 5, 4)
+    with pytest.raises(RuntimeError):
+        itm_loss_module(embeddings_pos, embeddings_neg)
+
+
+def test_itm_loss(itm_loss_module):
+    embeddings_pos = torch.randn(2, 5, 3)
+    embeddings_neg = torch.randn(4, 5, 3)
+    output = itm_loss_module(embeddings_pos, embeddings_neg).item()
+    expected = 0.813487
+    assert_expected(output, expected, rtol=0, atol=1e-4)
+
+
+def test_mlm_loss_invalid_labels(mlm_loss_module):
+    # labels dimensions should match the first two dimensions of the embeddings
+    labels = torch.randint(10, (2, 6))
+    embeddings = torch.randn(2, 5, 3)
+    embeddings_m = torch.randn(2, 5, 3)
+    weights = torch.randn(2)
+    with pytest.raises(RuntimeError):
+        mlm_loss_module(labels, embeddings, embeddings_m, weights)
+
+
+def test_mlm_loss_invalid_embeddings(mlm_loss_module):
+    labels = torch.randint(10, (2, 5))
+    # embeddings hidden size (dim 2) should match the hidden size of mlm_loss_module
+    embeddings = torch.randn(2, 5, 4)
+    embeddings_m = torch.randn(2, 5, 4)
+    weights = torch.randn(2)
+    with pytest.raises(RuntimeError):
+        mlm_loss_module(labels, embeddings, embeddings_m, weights)
+
+
+def test_mlm_loss_invalid_weights(mlm_loss_module):
+    labels = torch.randint(10, (2, 5))
+    embeddings = torch.randn(2, 5, 3)
+    embeddings_m = torch.randn(2, 5, 3)
+    weights = torch.randn(3)  # all inputs should have the same batch size (dim 0)
+    with pytest.raises(RuntimeError):
+        mlm_loss_module(labels, embeddings, embeddings_m, weights)
+
+
+def test_mlm_loss(mlm_loss_module):
+    labels = torch.randint(10, (2, 5))
+    embeddings = torch.randn(2, 5, 3)
+    embeddings_m = torch.randn(2, 5, 3)
+    weights = torch.randn(2)
+    output = mlm_loss_module(labels, embeddings, embeddings_m, weights).item()
+    expected = 13.533014
+    assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/test/modules/losses/test_albef.py
+++ b/test/modules/losses/test_albef.py
@@ -73,32 +73,24 @@ class TestImageTextMatchingLoss:
         set_rng_seed(0)
         self.loss = ImageTextMatchingLoss(hidden_size=3)
 
-    def test_itm_loss_invalid_input_batch_size(self):
-        # embeddings_neg's batch size (dim 0) should be double of embeddings_pos's batch size
-        embeddings_pos = torch.randn(2, 5, 3)
-        embeddings_neg = torch.randn(2, 5, 3)
-        with pytest.raises(ValueError):
-            self.loss(embeddings_pos, embeddings_neg)
-
     def test_itm_loss_invalid_input_hidden_size(self):
         # embeddings hidden size (dim 2) should match the hidden size of ImageTextMatchingLoss
-        embeddings_pos = torch.randn(2, 5, 4)
-        embeddings_neg = torch.randn(4, 5, 4)
+        embeddings_pos = torch.randn(2, 4)
+        embeddings_neg = torch.randn(4, 4)
         with pytest.raises(RuntimeError):
             self.loss(embeddings_pos, embeddings_neg)
 
     def test_itm_loss(self):
-        embeddings_pos = torch.randn(2, 5, 3)
-        embeddings_neg = torch.randn(4, 5, 3)
+        embeddings_pos = torch.randn(2, 3)
+        embeddings_neg = torch.randn(4, 3)
         output = self.loss(embeddings_pos, embeddings_neg).item()
-        expected = 0.974678
+        expected = 0.860578
         assert_expected(output, expected, rtol=0, atol=1e-4)
 
 
 class TestMaskedLanguageModelingLoss:
     @pytest.fixture(autouse=True)
     def setup(self):
-        torch.set_printoptions(precision=6)
         set_rng_seed(0)
         self.loss = MaskedLanguageModelingLoss(hidden_size=3)
         self.loss_with_distillation = MaskedLanguageModelingLoss(

--- a/test/modules/losses/test_albef.py
+++ b/test/modules/losses/test_albef.py
@@ -15,133 +15,122 @@ from torchmultimodal.modules.losses.albef import (
 )
 
 
-@pytest.fixture(autouse=True)
-def set_seed():
-    set_rng_seed(0)
+class TestImageTextContrastiveLoss:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        set_rng_seed(0)
+        self.loss = ImageTextContrastiveLoss()
+
+    def test_itc_loss_invalid_sim(self):
+        sim_i2t = torch.randn(2, 4)  # all inputs should be the same size
+        sim_t2i = torch.randn(2, 3)
+        sim_i2t_m = torch.randn(2, 3)
+        sim_t2i_m = torch.randn(2, 3)
+        with pytest.raises(RuntimeError):
+            self.loss(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
+
+    def test_itc_loss_invalid_sim_m(self):
+        sim_i2t = torch.randn(2, 3)
+        sim_t2i = torch.randn(2, 3)
+        sim_i2t_m = torch.randn(2, 4)  # all inputs should be the same size
+        sim_t2i_m = torch.randn(2, 3)
+        with pytest.raises(RuntimeError):
+            self.loss(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
+
+    def test_itc_loss_invalid_sim_target(self):
+        sim_i2t = torch.randn(2, 3)
+        sim_t2i = torch.randn(2, 3)
+        sim_i2t_m = torch.randn(2, 3)
+        sim_t2i_m = torch.randn(2, 3)
+        sim_targets = torch.randn(2, 4)  # all inputs should be the same size
+        with pytest.raises(RuntimeError):
+            self.loss(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m, sim_targets).item()
+
+    def test_itc_loss_without_sim_targets(self):
+        sim_i2t = torch.randn(2, 3)
+        sim_t2i = torch.randn(2, 3)
+        sim_i2t_m = torch.randn(2, 3)
+        sim_t2i_m = torch.randn(2, 3)
+        output = self.loss(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
+        expected = 1.160506
+        assert_expected(output, expected, rtol=0, atol=1e-4)
+
+    def test_itc_loss_with_sim_targets(self):
+        sim_i2t = torch.randn(2, 3)
+        sim_t2i = torch.randn(2, 3)
+        sim_i2t_m = torch.randn(2, 3)
+        sim_t2i_m = torch.randn(2, 3)
+        sim_targets = torch.randn(2, 3)
+        output = self.loss(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m, sim_targets).item()
+        expected = -1.928954
+        assert_expected(output, expected, rtol=0, atol=1e-4)
 
 
-@pytest.fixture(autouse=True)
-def itc_loss_module():
-    return ImageTextContrastiveLoss()
+class TestImageTextMatchingLoss:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        set_rng_seed(0)
+        self.loss = ImageTextMatchingLoss(hidden_size=3)
+
+    def test_itm_loss_invalid_input_batch_size(self):
+        # embeddings_neg's batch size (dim 0) should be double of embeddings_pos's batch size
+        embeddings_pos = torch.randn(2, 5, 3)
+        embeddings_neg = torch.randn(2, 5, 3)
+        with pytest.raises(ValueError):
+            self.loss(embeddings_pos, embeddings_neg)
+
+    def test_itm_loss_invalid_input_hidden_size(self):
+        # embeddings hidden size (dim 2) should match the hidden size of itm_loss_module
+        embeddings_pos = torch.randn(2, 5, 4)
+        embeddings_neg = torch.randn(4, 5, 4)
+        with pytest.raises(RuntimeError):
+            self.loss(embeddings_pos, embeddings_neg)
+
+    def test_itm_loss(self):
+        embeddings_pos = torch.randn(2, 5, 3)
+        embeddings_neg = torch.randn(4, 5, 3)
+        output = self.loss(embeddings_pos, embeddings_neg).item()
+        expected = 0.974678
+        assert_expected(output, expected, rtol=0, atol=1e-4)
 
 
-@pytest.fixture(autouse=True)
-def itm_loss_module():
-    return ImageTextMatchingLoss(hidden_size=3)
+class TestMaskedLanguageModelingLoss:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        set_rng_seed(0)
+        self.loss = MaskedLanguageModelingLoss(hidden_size=3)
 
+    def test_mlm_loss_invalid_labels(self):
+        # labels dimensions should match the first two dimensions of the embeddings
+        labels = torch.randint(10, (2, 6))
+        embeddings = torch.randn(2, 5, 3)
+        embeddings_m = torch.randn(2, 5, 3)
+        weights = torch.randn(2)
+        with pytest.raises(RuntimeError):
+            self.loss(labels, embeddings, embeddings_m, weights)
 
-@pytest.fixture(autouse=True)
-def mlm_loss_module():
-    return MaskedLanguageModelingLoss(hidden_size=3)
+    def test_mlm_loss_invalid_embeddings(self):
+        labels = torch.randint(10, (2, 5))
+        # embeddings hidden size (dim 2) should match the hidden size of mlm_loss_module
+        embeddings = torch.randn(2, 5, 4)
+        embeddings_m = torch.randn(2, 5, 4)
+        weights = torch.randn(2)
+        with pytest.raises(RuntimeError):
+            self.loss(labels, embeddings, embeddings_m, weights)
 
+    def test_mlm_loss_invalid_weights(self):
+        labels = torch.randint(10, (2, 5))
+        embeddings = torch.randn(2, 5, 3)
+        embeddings_m = torch.randn(2, 5, 3)
+        weights = torch.randn(3)  # all inputs should have the same batch size (dim 0)
+        with pytest.raises(RuntimeError):
+            self.loss(labels, embeddings, embeddings_m, weights)
 
-def test_itc_loss_invalid_sim(itc_loss_module):
-    sim_i2t = torch.randn(2, 4)  # all inputs should be the same size
-    sim_t2i = torch.randn(2, 3)
-    sim_i2t_m = torch.randn(2, 3)
-    sim_t2i_m = torch.randn(2, 3)
-    with pytest.raises(RuntimeError):
-        itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
-
-
-def test_itc_loss_invalid_sim_m(itc_loss_module):
-    sim_i2t = torch.randn(2, 3)
-    sim_t2i = torch.randn(2, 3)
-    sim_i2t_m = torch.randn(2, 4)  # all inputs should be the same size
-    sim_t2i_m = torch.randn(2, 3)
-    with pytest.raises(RuntimeError):
-        itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
-
-
-def test_itc_loss_invalid_sim_target(itc_loss_module):
-    sim_i2t = torch.randn(2, 3)
-    sim_t2i = torch.randn(2, 3)
-    sim_i2t_m = torch.randn(2, 3)
-    sim_t2i_m = torch.randn(2, 3)
-    sim_targets = torch.randn(2, 4)  # all inputs should be the same size
-    with pytest.raises(RuntimeError):
-        itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m, sim_targets).item()
-
-
-def test_itc_loss_without_sim_targets(itc_loss_module):
-    sim_i2t = torch.randn(2, 3)
-    sim_t2i = torch.randn(2, 3)
-    sim_i2t_m = torch.randn(2, 3)
-    sim_t2i_m = torch.randn(2, 3)
-    output = itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m).item()
-    expected = 1.160506
-    assert_expected(output, expected, rtol=0, atol=1e-4)
-
-
-def test_itc_loss_with_sim_targets(itc_loss_module):
-    sim_i2t = torch.randn(2, 3)
-    sim_t2i = torch.randn(2, 3)
-    sim_i2t_m = torch.randn(2, 3)
-    sim_t2i_m = torch.randn(2, 3)
-    sim_targets = torch.randn(2, 3)
-    output = itc_loss_module(sim_i2t, sim_t2i, sim_i2t_m, sim_t2i_m, sim_targets).item()
-    expected = -1.928954
-    assert_expected(output, expected, rtol=0, atol=1e-4)
-
-
-def test_itm_loss_invalid_input_batch_size(itm_loss_module):
-    # embeddings_neg's batch size (dim 0) should be double of embeddings_pos's batch size
-    embeddings_pos = torch.randn(2, 5, 3)
-    embeddings_neg = torch.randn(2, 5, 3)
-    with pytest.raises(ValueError):
-        itm_loss_module(embeddings_pos, embeddings_neg)
-
-
-def test_itm_loss_invalid_input_hidden_size(itm_loss_module):
-    # embeddings hidden size (dim 2) should match the hidden size of itm_loss_module
-    embeddings_pos = torch.randn(2, 5, 4)
-    embeddings_neg = torch.randn(4, 5, 4)
-    with pytest.raises(RuntimeError):
-        itm_loss_module(embeddings_pos, embeddings_neg)
-
-
-def test_itm_loss(itm_loss_module):
-    embeddings_pos = torch.randn(2, 5, 3)
-    embeddings_neg = torch.randn(4, 5, 3)
-    output = itm_loss_module(embeddings_pos, embeddings_neg).item()
-    expected = 0.813487
-    assert_expected(output, expected, rtol=0, atol=1e-4)
-
-
-def test_mlm_loss_invalid_labels(mlm_loss_module):
-    # labels dimensions should match the first two dimensions of the embeddings
-    labels = torch.randint(10, (2, 6))
-    embeddings = torch.randn(2, 5, 3)
-    embeddings_m = torch.randn(2, 5, 3)
-    weights = torch.randn(2)
-    with pytest.raises(RuntimeError):
-        mlm_loss_module(labels, embeddings, embeddings_m, weights)
-
-
-def test_mlm_loss_invalid_embeddings(mlm_loss_module):
-    labels = torch.randint(10, (2, 5))
-    # embeddings hidden size (dim 2) should match the hidden size of mlm_loss_module
-    embeddings = torch.randn(2, 5, 4)
-    embeddings_m = torch.randn(2, 5, 4)
-    weights = torch.randn(2)
-    with pytest.raises(RuntimeError):
-        mlm_loss_module(labels, embeddings, embeddings_m, weights)
-
-
-def test_mlm_loss_invalid_weights(mlm_loss_module):
-    labels = torch.randint(10, (2, 5))
-    embeddings = torch.randn(2, 5, 3)
-    embeddings_m = torch.randn(2, 5, 3)
-    weights = torch.randn(3)  # all inputs should have the same batch size (dim 0)
-    with pytest.raises(RuntimeError):
-        mlm_loss_module(labels, embeddings, embeddings_m, weights)
-
-
-def test_mlm_loss(mlm_loss_module):
-    labels = torch.randint(10, (2, 5))
-    embeddings = torch.randn(2, 5, 3)
-    embeddings_m = torch.randn(2, 5, 3)
-    weights = torch.randn(2)
-    output = mlm_loss_module(labels, embeddings, embeddings_m, weights).item()
-    expected = 13.533014
-    assert_expected(output, expected, rtol=0, atol=1e-4)
+    def test_mlm_loss(self):
+        labels = torch.randint(10, (2, 5))
+        embeddings = torch.randn(2, 5, 3)
+        embeddings_m = torch.randn(2, 5, 3)
+        weights = torch.randn(2)
+        output = self.loss(labels, embeddings, embeddings_m, weights).item()
+        expected = -12.189002
+        assert_expected(output, expected, rtol=0, atol=1e-4)

--- a/torchmultimodal/modules/losses/albef.py
+++ b/torchmultimodal/modules/losses/albef.py
@@ -9,7 +9,6 @@ from typing import Callable, Optional
 import torch
 import torch.nn.functional as F
 from torch import nn, Tensor
-from torch.nn import CrossEntropyLoss
 
 
 class ImageTextContrastiveLoss(nn.Module):
@@ -160,7 +159,6 @@ class MaskedLanguageModelingLoss(nn.Module):
         self.prediction_head = PredictionHead(
             vocab_size, hidden_size, layer_norm_eps, transform_act_fn
         )
-        self.loss_fn = CrossEntropyLoss(reduction="none")
 
     def forward(
         self,
@@ -173,8 +171,10 @@ class MaskedLanguageModelingLoss(nn.Module):
         # shift prediction scores and labels by one for next-token prediction
         prediction_scores = prediction_scores[:, :-1, :].contiguous()
         labels = labels[:, 1:].contiguous()
-        mlm_loss = self.loss_fn(
-            prediction_scores.view(-1, self.vocab_size), labels.view(-1)
+        mlm_loss = F.cross_entropy(
+            prediction_scores.view(-1, self.vocab_size),
+            labels.view(-1),
+            reduction="none",
         )
         mlm_loss = mlm_loss.view(batch_size, -1).sum(1)
 

--- a/torchmultimodal/modules/losses/albef.py
+++ b/torchmultimodal/modules/losses/albef.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn, Tensor
+from torch.nn import CrossEntropyLoss
+
+
+class ImageTextContrastiveLoss(nn.Module):
+    """
+    Compute the image-text contrastive loss from image-text similarity, as used in ALBEF.
+
+    Args:
+        alpha (float): The interpolation value of momentum similarity and sim_targets.
+
+    Inputs:
+        sim_i2t (Tensor): Image to text similarity.
+        sim_t2i (Tensor): Text to image similarity.
+        sim_i2t_m (Tensor): Image to text similarity from momentum models.
+        sim_t2i_m (Tensor): Text to image similarity from momentum models.
+        sim_targets (Optional[Tensor]): Similarity pseudo-targets from momentum models. Default is the diagonal matrix.
+            Requires all inputs to have the same size.
+    """
+
+    def __init__(
+        self,
+        alpha: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.alpha = alpha
+
+    def forward(
+        self,
+        sim_i2t: Tensor,
+        sim_t2i: Tensor,
+        sim_i2t_m: Tensor,
+        sim_t2i_m: Tensor,
+        sim_targets: Optional[Tensor] = None,
+    ) -> Tensor:
+        if sim_targets is None:
+            sim_targets = torch.zeros(sim_i2t.size()).to(sim_i2t.device)
+            sim_targets.fill_diagonal_(1)
+
+        with torch.no_grad():
+            sim_i2t_targets = (
+                self.alpha * F.softmax(sim_i2t_m, dim=1)
+                + (1 - self.alpha) * sim_targets
+            )
+            sim_t2i_targets = (
+                self.alpha * F.softmax(sim_t2i_m, dim=1)
+                + (1 - self.alpha) * sim_targets
+            )
+
+        loss_i2t = -torch.sum(
+            F.log_softmax(sim_i2t, dim=1) * sim_i2t_targets, dim=1
+        ).mean()
+        loss_t2i = -torch.sum(
+            F.log_softmax(sim_t2i, dim=1) * sim_t2i_targets, dim=1
+        ).mean()
+
+        loss_itc = (loss_i2t + loss_t2i) / 2
+        return loss_itc
+
+
+class ImageTextMatchingLoss(nn.Module):
+    """
+    Compute the image-text matching loss by predicting whether an image-text pair is matched or not.
+
+    Args:
+        hidden_size (int): The image-text multimodal embedding hidden size.
+
+    Inputs:
+        embeddings_pos (Tensor of shape (batch_size, seq_length, hidden_size)):
+            The multimodal embeddings for positive image-text pairs.
+        embeddings_neg (Tensor of shape (2 * batch_size, seq_length, hidden_size)):
+            The multimodal embeddings for negative image-text pairs.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 768,
+    ) -> None:
+        super().__init__()
+        self.itm_head = nn.Linear(
+            hidden_size, 2
+        )  # binary output indicating image-text matches
+
+    def forward(
+        self,
+        embeddings_pos: Tensor,
+        embeddings_neg: Tensor,
+    ) -> Tensor:
+        batch_size = embeddings_pos.size(0)
+        vl_embeddings = torch.cat(
+            [embeddings_pos[:, 0, :], embeddings_neg[:, 0, :]], dim=0
+        )
+        vl_output = self.itm_head(vl_embeddings)
+        itm_labels = torch.cat(
+            [
+                torch.ones(batch_size, dtype=torch.long),
+                torch.zeros(2 * batch_size, dtype=torch.long),
+            ],
+            dim=0,
+        ).to(vl_embeddings.device)
+        loss_itm = F.cross_entropy(vl_output, itm_labels)
+        return loss_itm
+
+
+class MaskedLanguageModelingLoss(nn.Module):
+    """
+    Compute the autoregressive masked language modeling loss by predicting the next token.
+
+    Args:
+        masked_token_id (int): The token id indicating a masked token. Default is -100.
+        vocab_size (int): The number of different tokens the prediction_head can predict. Default is 30522.
+        hidden_size (int): The hidden size of the prediction_head. Default is 768.
+        layer_norm_eps (float): The epsilon used by the prediction_head normalization layer. Default is 1e-12.
+        alpha (float): The interpolation value between mlm_loss and loss_distill. Default is 0.
+        transform_act_fn (Callable[[Tensor], Tensor]): The activation function in the prediction_head. Default is GELU.
+
+    Inputs:
+        labels (Tensor): The masked output tokens.
+        hidden_states (Tensor): The hidden states of preceding tokens.
+        hidden_states_m (Tensor): The hidden states of preceding tokens from momentum models.
+        weights (Tensor): The weight for each output.
+    """
+
+    def __init__(
+        self,
+        mask_token_id: int = -100,
+        vocab_size: int = 30522,
+        hidden_size: int = 768,
+        layer_norm_eps: float = 1e-12,
+        alpha: float = 0.0,
+        transform_act_fn: Callable[[Tensor], Tensor] = nn.functional.gelu,
+    ) -> None:
+        super().__init__()
+        self.mask_token_id = mask_token_id
+        self.vocab_size = vocab_size
+        self.alpha = alpha
+        self.prediction_head = PredictionHead(
+            vocab_size, hidden_size, layer_norm_eps, transform_act_fn
+        )
+        self.loss_fn = CrossEntropyLoss(reduction="none")
+
+    def forward(
+        self,
+        labels: Tensor,
+        hidden_states: Tensor,
+        hidden_states_m: Tensor,
+        weights: Tensor,
+    ) -> Tensor:
+        batch_size = labels.size(0)
+        prediction_scores = self.prediction_head(hidden_states)
+        # shift prediction scores and labels by one for next-token prediction
+        prediction_scores = prediction_scores[:, :-1, :].contiguous()
+        labels = labels[:, 1:].contiguous()
+        with torch.no_grad():
+            prediction_scores_m = self.prediction_head(hidden_states_m)
+            prediction_scores_m = prediction_scores_m[:, :-1, :].contiguous()
+        loss_distill = -torch.sum(
+            F.log_softmax(prediction_scores, dim=-1)
+            * F.softmax(prediction_scores_m, dim=-1),
+            dim=-1,
+        )
+        loss_distill = (loss_distill * (labels != self.mask_token_id)).sum(1)
+        mlm_loss = self.loss_fn(
+            prediction_scores.view(-1, self.vocab_size), labels.view(-1)
+        )
+        mlm_loss = mlm_loss.view(batch_size, -1).sum(1)
+        mlm_loss = (1 - self.alpha) * mlm_loss + self.alpha * loss_distill
+        mlm_loss = weights * mlm_loss
+        mlm_loss = mlm_loss.sum() / batch_size
+        return mlm_loss
+
+
+class PredictionHead(nn.Module):
+    """
+    Predict the following token autoregressively.
+
+    Args:
+        vocab_size (int): The number of different tokens the prediction_head can predict.
+        hidden_size (int): The hidden size of the prediction_head.
+        layer_norm_eps (float): The epsilon used by the prediction_head normalization layer.
+        transform_act_fn (Callable[[Tensor], Tensor]): The activation function in the prediction_head.
+
+    Inputs:
+        hidden_states (Tensor): The hidden states of preceding tokens.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        layer_norm_eps: float,
+        transform_act_fn: Callable[[Tensor], Tensor],
+    ) -> None:
+        super().__init__()
+        self.dense = nn.Linear(hidden_size, hidden_size)
+        self.transform_act_fn = transform_act_fn
+        self.layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.decoder = nn.Linear(hidden_size, vocab_size, bias=False)
+        self.decoder.bias = nn.Parameter(torch.zeros(vocab_size))
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.transform_act_fn(hidden_states)
+        hidden_states = self.layer_norm(hidden_states)
+        hidden_states = self.decoder(hidden_states)
+        return hidden_states

--- a/torchmultimodal/modules/losses/albef.py
+++ b/torchmultimodal/modules/losses/albef.py
@@ -205,8 +205,7 @@ class PredictionHead(nn.Module):
         self.dense = nn.Linear(hidden_size, hidden_size)
         self.transform_act_fn = transform_act_fn
         self.layer_norm = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
-        self.decoder = nn.Linear(hidden_size, vocab_size, bias=False)
-        self.decoder.bias = nn.Parameter(torch.zeros(vocab_size))
+        self.decoder = nn.Linear(hidden_size, vocab_size)
 
     def forward(self, hidden_states: Tensor) -> Tensor:
         hidden_states = self.dense(hidden_states)

--- a/torchmultimodal/modules/losses/albef.py
+++ b/torchmultimodal/modules/losses/albef.py
@@ -114,7 +114,7 @@ class ImageTextMatchingLoss(nn.Module):
 
 class MaskedLanguageModelingLoss(nn.Module):
     """
-    Compute the autoregressive masked language modeling loss by predicting the next token.
+    Compute the autoregressive masked language modeling loss by predicting the next token, as used in VQA.
 
     Args:
         masked_token_id (int): The token id indicating a masked token. Default is -100.
@@ -125,10 +125,12 @@ class MaskedLanguageModelingLoss(nn.Module):
         transform_act_fn (Callable[[Tensor], Tensor]): The activation function in the prediction_head. Default is GELU.
 
     Inputs:
-        labels (Tensor): The masked output tokens.
-        hidden_states (Tensor): The hidden states of preceding tokens.
-        hidden_states_m (Tensor): The hidden states of preceding tokens from momentum models.
-        weights (Tensor): The weight for each output.
+        labels (Tensor of shape (batch_size, seq_length)): The masked output tokens.
+        hidden_states (Tensor of shape (batch_size, seq_length, hidden_size)):
+            The hidden states of preceding tokens.
+        hidden_states_m (Tensor of shape (batch_size, seq_length, hidden_size)):
+            The hidden states of preceding tokens from momentum models.
+        weights (Tensor of shape (batch_size)): The weight for each output.
     """
 
     def __init__(

--- a/torchmultimodal/modules/losses/albef.py
+++ b/torchmultimodal/modules/losses/albef.py
@@ -76,9 +76,9 @@ class ImageTextMatchingLoss(nn.Module):
         hidden_size (int): The image-text multimodal embedding hidden size.
 
     Inputs:
-        embeddings_pos (Tensor of shape (batch_size, seq_length, hidden_size)):
+        embeddings_pos (Tensor of shape (batch_size_pos, hidden_size)):
             The multimodal embeddings for positive image-text pairs.
-        embeddings_neg (Tensor of shape (2 * batch_size, seq_length, hidden_size)):
+        embeddings_neg (Tensor of shape (batch_size_neg, hidden_size)):
             The multimodal embeddings for negative image-text pairs.
     """
 
@@ -96,15 +96,12 @@ class ImageTextMatchingLoss(nn.Module):
         embeddings_pos: Tensor,
         embeddings_neg: Tensor,
     ) -> Tensor:
-        batch_size = embeddings_pos.size(0)
-        vl_embeddings = torch.cat(
-            [embeddings_pos[:, 0, :], embeddings_neg[:, 0, :]], dim=0
-        )
+        vl_embeddings = torch.cat([embeddings_pos, embeddings_neg], dim=0)
         vl_output = self.itm_head(vl_embeddings)
         itm_labels = torch.cat(
             [
-                torch.ones(batch_size, dtype=torch.long),
-                torch.zeros(2 * batch_size, dtype=torch.long),
+                torch.ones(embeddings_pos.size(0), dtype=torch.long),
+                torch.zeros(embeddings_neg.size(0), dtype=torch.long),
             ],
             dim=0,
         ).to(vl_embeddings.device)


### PR DESCRIPTION
Summary:
This PR implements the ITC, ITM, and MLM losses used for the ALBEF model
* `ImageTextContrastiveLoss` (ITC) uses image-text similarity from the ALBEF model output to compute the contrastive loss.   [(ALBEF repo implementation)](https://github.com/salesforce/ALBEF/blob/6224e78e5292757ca9c7d5add3e415010955a58b/models/model_pretrain.py#L116-L128)
* `ImageTextMatchingLoss` (ITM) uses positive and negative image-text pairs to predict whether an image and a text are matched or not. [(ALBEF repo implementation)](https://github.com/salesforce/ALBEF/blob/6224e78e5292757ca9c7d5add3e415010955a58b/models/model_pretrain.py#L180-L185)
* `MaskedLanguageModelingLoss` (MLM) computes the loss by predicting the next token auto-regressively. [(ALBEF repo implementation)](https://github.com/salesforce/ALBEF/blob/6224e78e5292757ca9c7d5add3e415010955a58b/models/xbert.py#L1417-L1431)

Test plan:
Wrote unit tests
