### PR TITLE
Change python requirement from 3.8 to 3.7

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: Check out repo
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As a first open source example, researchers will be able to train and extend FLA
 
 ## Installation
 
-TorchMultimodal requires Python >= 3.8. The library can be installed with or without CUDA support.
+TorchMultimodal requires Python >= 3.7. The library can be installed with or without CUDA support.
 
 ### Building from Source
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         name=DISTNAME,
         include_package_data=True,
         packages=find_packages(exclude=EXCLUDES),
-        python_requires=">=3.8",
+        python_requires=">=3.7",
         install_requires=read_requirements("requirements.txt"),
         version=_get_version(),
         description=DESCRIPTION,

--- a/torchmultimodal/models/flava/flava_model.py
+++ b/torchmultimodal/models/flava/flava_model.py
@@ -12,7 +12,7 @@ import math
 from collections import namedtuple, OrderedDict
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 from torch import nn, Tensor
@@ -31,6 +31,7 @@ from torchmultimodal.modules.losses.flava import (
     Pooler,
 )
 from torchmultimodal.utils.common import ModelOutput, PretrainedMixin
+from typing_extensions import Literal
 
 
 EMBEDDING_OPTIONS = Literal["image", "text", "mm"]


### PR DESCRIPTION
Summary:
3.7 is default in colab and also on the cluster. 
- Change import statement in flava 
- Update readme and CI

Test plan:
pytest on 3.7 conda env
CI

