### PR TITLE
[ALBEF] model refactoring

### DIFF
--- a/test/models/test_albef.py
+++ b/test/models/test_albef.py
@@ -10,7 +10,13 @@ import pytest
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torch import nn, Tensor
-from torchmultimodal.models.albef import ALBEFModel, ALBEFSimilarity
+from torchmultimodal.models.albef import (
+    _copy_params_momentum_models,
+    _momentum_update,
+    ALBEFModel,
+    ALBEFModelWithSimilarity,
+    ALBEFSimilarity,
+)
 from torchmultimodal.modules.encoders.albef_multimodal_encoder import (
     ALBEFMultimodalEncoder,
 )
@@ -43,25 +49,18 @@ def multimodal_encoder():
 
 
 @pytest.fixture(autouse=True)
-def dummy_albef_model():
-    return ALBEFModel(
-        nn.Linear(3, 2),
-        nn.Linear(3, 2),
-        nn.Linear(3, 2),
-        nn.Linear(3, 2),
-        nn.Linear(3, 2),
-        embed_dim=2,
-        queue_size=4,
-        momentum=0.75,
-    )
-
-
-@pytest.fixture(autouse=True)
 def albef_model(vision_encoder, text_encoder, multimodal_encoder):
     return ALBEFModel(
         vision_encoder,
         text_encoder,
         multimodal_encoder,
+    )
+
+
+@pytest.fixture(autouse=True)
+def albef_with_sim(albef_model):
+    return ALBEFModelWithSimilarity(
+        albef_model,
         nn.Linear(3, 2),
         nn.Linear(3, 2),
         embed_dim=2,
@@ -80,8 +79,8 @@ def albef_model_output(albef_model):
 def test_albef_image_embeddings(albef_model_output):
     expected = Tensor(
         [
+            [[1.364883, -1.003092, -0.361791], [-0.634884, 1.411830, -0.776947]],
             [[1.401580, -0.537510, -0.864071], [1.378901, -0.417473, -0.961429]],
-            [[1.413948, -0.729806, -0.684143], [-1.313033, 1.111438, 0.201595]],
         ]
     )
     assert_expected(albef_model_output.image_embeddings, expected, rtol=0, atol=1e-4)
@@ -90,8 +89,8 @@ def test_albef_image_embeddings(albef_model_output):
 def test_albef_image_embeddings_momentum(albef_model_output):
     expected = Tensor(
         [
+            [[1.364883, -1.003092, -0.361791], [-0.634884, 1.411830, -0.776947]],
             [[1.401580, -0.537510, -0.864070], [1.378902, -0.417473, -0.961429]],
-            [[1.413949, -0.729807, -0.684141], [-1.313033, 1.111438, 0.201595]],
         ]
     )
     assert_expected(albef_model_output.image_embeddings_m, expected, rtol=0, atol=1e-4)
@@ -100,95 +99,117 @@ def test_albef_image_embeddings_momentum(albef_model_output):
 def test_albef_text_embeddings(albef_model_output):
     expected = Tensor(
         [
-            [[-1.372420, 0.981756, 0.390664], [1.305102, -1.124284, -0.180818]],
-            [[-1.320019, 0.220507, 1.099512], [1.366452, -0.998831, -0.367621]],
+            [[-0.317956, 1.352367, -1.034411], [1.064044, -1.338780, 0.274735]],
+            [[-1.320019, 0.220507, 1.099512], [1.411497, -0.781628, -0.629869]],
         ]
     )
     assert_expected(albef_model_output.text_embeddings, expected, rtol=0, atol=1e-4)
 
 
-def test_albef_vl_embeddings(albef_model_output):
+def test_albef_text_embeddings_momentum(albef_model_output):
     expected = Tensor(
         [
-            [-1.398094, 0.883438, 0.514656],
-            [-1.115577, 1.310528, -0.194951],
-            [-0.706023, 1.414213, -0.708190],
-            [-1.402520, 0.544084, 0.858435],
-            [-1.402520, 0.544084, 0.858435],
-            [-0.706023, 1.414213, -0.708190],
+            [[-0.317956, 1.352367, -1.034411], [1.064044, -1.338780, 0.274735]],
+            [[-1.320019, 0.220507, 1.099512], [1.411497, -0.781628, -0.629869]],
         ]
     )
-    assert_expected(albef_model_output.vl_embeddings, expected, rtol=0, atol=1e-4)
+    assert_expected(albef_model_output.text_embeddings_m, expected, rtol=0, atol=1e-4)
 
 
-def test_copy_params_momentum_models(dummy_albef_model):
-    dummy_albef_model.models_m = [nn.Linear(3, 2) for _ in range(5)]
-    dummy_albef_model._copy_params_momentum_models()
-    for model, model_m in zip(dummy_albef_model.models, dummy_albef_model.models_m):
-        for param, param_m in zip(model.parameters(), model_m.parameters()):
-            assert_expected(param, param_m, rtol=0, atol=1e-4)
-            assert not param_m.requires_grad
+def test_albef_multimodal_embeddings(albef_model_output):
+    expected = Tensor(
+        [
+            [[-0.068738, 1.257666, -1.188928], [1.409873, -0.609056, -0.800817]],
+            [[-1.402520, 0.544084, 0.858435], [1.202279, -1.246038, 0.043760]],
+        ]
+    )
+    assert_expected(
+        albef_model_output.multimodal_embeddings, expected, rtol=0, atol=1e-4
+    )
 
 
-def test_dequeue_and_enqueue(dummy_albef_model):
+def test_albef_multimodal_embeddings_momentum(albef_model_output):
+    expected = Tensor(
+        [
+            [[-0.068738, 1.257666, -1.188928], [1.409873, -0.609056, -0.800817]],
+            [[-1.402520, 0.544084, 0.858435], [1.202279, -1.246038, 0.043760]],
+        ]
+    )
+    assert_expected(
+        albef_model_output.multimodal_embeddings_m, expected, rtol=0, atol=1e-4
+    )
+
+
+def test_copy_params_momentum_models():
+    model = nn.Linear(3, 2)
+    model_m = nn.Linear(3, 2)
+    _copy_params_momentum_models(model, model_m)
+    for param, param_m in zip(model.parameters(), model_m.parameters()):
+        assert_expected(param, param_m, rtol=0, atol=1e-4)
+        assert not param_m.requires_grad
+
+
+def test_dequeue_and_enqueue(albef_with_sim):
     image_feat_m = torch.randn(2, 2)
     text_feat_m = torch.randn(2, 2)
-    dummy_albef_model._dequeue_and_enqueue(image_feat_m, text_feat_m)
+    idx = Tensor([[2], [1]]).type(torch.long)
+    albef_with_sim._dequeue_and_enqueue(image_feat_m, text_feat_m, idx)
     assert_expected(
-        dummy_albef_model.image_queue[:, 0:2], image_feat_m.T, rtol=0, atol=1e-4
+        albef_with_sim.image_queue[:, 0:2],
+        image_feat_m.T,
+        rtol=0,
+        atol=1e-4,
     )
-    assert_expected(
-        dummy_albef_model.text_queue[:, 0:2], text_feat_m.T, rtol=0, atol=1e-4
-    )
+    assert_expected(albef_with_sim.text_queue[:, 0:2], text_feat_m.T, rtol=0, atol=1e-4)
+    assert_expected(albef_with_sim.idx_queue[:, 0:2], idx.T, rtol=0, atol=1e-4)
 
 
-def test_momentum_update(dummy_albef_model):
+def test_momentum_update():
     init_weight = Tensor([[1, 2, 3], [4, 5, 6]])
     init_weight_m = Tensor([[6, 5, 4], [3, 2, 1]])
-    dummy_albef_model.vision_encoder.weight = nn.Parameter(init_weight)
-    dummy_albef_model.vision_encoder_m.weight = nn.Parameter(init_weight_m)
-    dummy_albef_model._momentum_update()
+    model = nn.Linear(3, 2)
+    model_m = nn.Linear(3, 2)
+    model.weight = nn.Parameter(init_weight)
+    model_m.weight = nn.Parameter(init_weight_m)
+    _momentum_update(model, model_m, 0.75)
     expected_weight_m = Tensor([[4.75, 4.25, 3.75], [3.25, 2.75, 2.25]])
-    assert_expected(
-        dummy_albef_model.vision_encoder.weight, init_weight, rtol=0, atol=1e-4
-    )
-    assert_expected(
-        dummy_albef_model.vision_encoder_m.weight, expected_weight_m, rtol=0, atol=1e-4
-    )
+    assert_expected(model.weight, init_weight, rtol=0, atol=1e-4)
+    assert_expected(model_m.weight, expected_weight_m, rtol=0, atol=1e-4)
 
 
-def test_similarity(dummy_albef_model):
-    dummy_albef_model.image_queue = torch.randn(2, 4)
-    dummy_albef_model.text_queue = torch.randn(2, 4)
-    image_feat = torch.randn(2, 2)
-    text_feat = torch.randn(2, 2)
-    image_feat_m = torch.randn(2, 2)
-    text_feat_m = torch.randn(2, 2)
-    output = dummy_albef_model._similarity(
-        image_feat, text_feat, image_feat_m, text_feat_m
+def test_similarity(albef_with_sim):
+    albef_with_sim.image_queue = torch.randn(2, 4)
+    albef_with_sim.text_queue = torch.randn(2, 4)
+    image_embeds = torch.randn(2, 5, 3)
+    image_embeds_m = torch.randn(2, 5, 3)
+    text_embeds = torch.randn(2, 7, 3)
+    text_embeds_m = torch.randn(2, 7, 3)
+    idx = Tensor([[2], [1]]).type(torch.long)
+    output = albef_with_sim._similarity(
+        image_embeds, image_embeds_m, text_embeds, text_embeds_m, idx
     )
     expected_sim_i2t = Tensor(
         [
-            [6.502346, -7.115936, -2.145788, -6.376165, -24.799065, 9.196653],
-            [6.027566, 0.114348, 1.448457, -1.095767, -9.806778, 4.751029],
+            [-8.987030, 2.026297, 15.253501, -1.860801, -0.848526, 13.968639],
+            [8.694868, -13.275172, 7.817042, -15.054668, -7.098372, -4.353704],
         ]
     )
     expected_sim_t2i = Tensor(
         [
-            [1.810656, 7.657638, 3.690561, -3.923022, -0.312378, -1.590274],
-            [-8.485663, -23.672398, -12.058897, 11.247606, 3.449185, 0.094083],
+            [1.554099, 13.017061, 1.329893, -7.265085, -13.645567, -24.406017],
+            [14.280089, -4.813700, -26.382078, -18.587244, 8.058000, 4.677015],
         ]
     )
     expected_sim_i2t_m = Tensor(
         [
-            [10.874029, -5.082995, -0.096355, -5.771802, -28.081427, 11.545799],
-            [-28.726080, -29.685524, -21.830336, -15.685751, -10.502577, -6.253645],
+            [-14.285593, 12.297211, 6.138124, 10.562518, 5.003767, 14.855797],
+            [4.378431, -10.728498, 12.003965, -13.604518, -6.404640, 1.081460],
         ]
     )
     expected_sim_t2i_m = Tensor(
         [
-            [10.874029, -28.726080, -9.868037, 20.097771, -14.018656, 35.459442],
-            [-5.082995, -29.685524, -13.870997, 15.797729, -0.453870, 9.397278],
+            [-14.285593, 4.378431, 26.256630, 18.763636, -7.592294, -3.874518],
+            [12.297211, -10.728498, -24.761192, -13.457666, 13.999524, 16.140541],
         ]
     )
     assert_expected(output.sim_i2t, expected_sim_i2t, rtol=0, atol=1e-4)
@@ -197,7 +218,7 @@ def test_similarity(dummy_albef_model):
     assert_expected(output.sim_t2i_m, expected_sim_t2i_m, rtol=0, atol=1e-4)
 
 
-def test_neg_embeddings(dummy_albef_model):
+def test_neg_embeddings(albef_with_sim):
     image_embeds = torch.randn(2, 1, 3)
     text_embeds = torch.randn(2, 1, 3)
     text_atts = torch.randn(2, 1)
@@ -207,20 +228,16 @@ def test_neg_embeddings(dummy_albef_model):
         sim_i2t_m=torch.randn(2, 5),
         sim_t2i_m=torch.randn(2, 5),
     )
-    (
-        image_embeds_neg,
-        text_embeds_neg,
-        text_atts_neg,
-    ) = dummy_albef_model._neg_embeddings(
+    image_embeds_neg, text_embeds_neg, text_atts_neg = albef_with_sim._neg_embeddings(
         image_embeds, text_embeds, text_atts, similarity
     )
     expected_image_embeds_neg = Tensor(
-        [[0.360331, 0.022756, -0.614475], [-1.006015, 1.046856, 0.119976]]
+        [[0.373975, 0.941025, 0.132136], [1.607509, 1.356168, -0.130043]]
     ).unsqueeze(1)
     expected_text_embeds_neg = Tensor(
-        [[0.560847, 0.789766, -0.013260], [0.910636, -1.927051, 0.644789]]
+        [[-0.413785, -0.197094, -1.121131], [-1.144303, -1.731178, -0.771461]]
     ).unsqueeze(1)
-    expected_text_atts_neg = Tensor([0.111645, -0.351305]).unsqueeze(1)
+    expected_text_atts_neg = Tensor([-0.976535, 0.799085]).unsqueeze(1)
     assert_expected(image_embeds_neg, expected_image_embeds_neg, rtol=0, atol=1e-4)
     assert_expected(text_embeds_neg, expected_text_embeds_neg, rtol=0, atol=1e-4)
     assert_expected(text_atts_neg, expected_text_atts_neg, rtol=0, atol=1e-4)

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -316,7 +316,7 @@ def _copy_params_momentum_models(model: nn.Module, model_m: nn.Module) -> None:
 
 
 @torch.no_grad()
-def _momentum_update(model, model_m: nn.Module, momentum: nn.Module) -> None:
+def _momentum_update(model: nn.Module, model_m: nn.Module, momentum: float) -> None:
     for param, param_m in zip(model.parameters(), model_m.parameters()):
         param_m.data = param_m.data * momentum + param.data * (1 - momentum)
 

--- a/torchmultimodal/models/albef.py
+++ b/torchmultimodal/models/albef.py
@@ -73,7 +73,7 @@ class ALBEFModel(nn.Module):
         text_encoder: nn.Module,
         multimodal_encoder: nn.Module,
         momentum: float = 0.995,
-    ):
+    ) -> None:
         super().__init__()
         self.vision_encoder = vision_encoder
         self.text_encoder = text_encoder
@@ -186,7 +186,7 @@ class ALBEFModelWithSimilarity(nn.Module):
         text: Tensor,
         text_atts: Tensor,
         idx: Tensor,
-    ):
+    ) -> ALBEFWithSimilarityOutput:
         outputs = self.model(image, text, text_atts)
 
         idx = idx.view(-1, 1)
@@ -309,14 +309,14 @@ class ALBEFModelWithSimilarity(nn.Module):
 
 
 @torch.no_grad()
-def _copy_params_momentum_models(model, model_m) -> None:
+def _copy_params_momentum_models(model: nn.Module, model_m: nn.Module) -> None:
     for param, param_m in zip(model.parameters(), model_m.parameters()):
         param_m.data.copy_(param.data)
         param_m.requires_grad = False
 
 
 @torch.no_grad()
-def _momentum_update(model, model_m, momentum) -> None:
+def _momentum_update(model, model_m: nn.Module, momentum: nn.Module) -> None:
     for param, param_m in zip(model.parameters(), model_m.parameters()):
         param_m.data = param_m.data * momentum + param.data * (1 - momentum)
 

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -11,7 +11,7 @@ from dataclasses import fields
 from typing import List, Optional
 
 import torch
-from torch import Tensor
+from torch import nn, Tensor
 
 
 def get_current_device():
@@ -131,6 +131,18 @@ def transpose_for_scores(
 ) -> Tensor:
     x = x.unflatten(-1, (num_attention_heads, attention_head_size))
     return x.permute(0, 2, 1, 3)
+
+
+@torch.no_grad()
+def remove_grad(model: nn.Module) -> None:
+    for param in model.parameters():
+        param.requires_grad = False
+
+
+@torch.no_grad()
+def momentum_update(model: nn.Module, model_m: nn.Module, momentum: float) -> None:
+    for param, param_m in zip(model.parameters(), model_m.parameters()):
+        param_m.data = param_m.data * momentum + param.data * (1 - momentum)
 
 
 class PretrainedMixin:


### PR DESCRIPTION
Summary:
This PR refactors `ALBEFModel` for different downstream tasks. 
* `ALBEFModel`: the core model that outputs unimodal and multimodal embeddings (momentum embeddings too). 
(VQA can use this class because it only needs mlm loss)

* `ALBEFModelWithSimilarity`: outputs unimodal and multimodal embeddings (no momentum embeddings), negative image-text multimodal embeddings (for ITM loss), and similarity outputs (for ITC loss). 
(Retrieval can use this class because it needs ITM and ITC losses)


Test plan:
Passed unit tests in `test/models/test_albef.py`
