### PR TITLE
[MDETR] Add contrastive alignment loss

### DIFF
--- a/examples/mdetr/LoadAndComparePretrainedWeights.ipynb
+++ b/examples/mdetr/LoadAndComparePretrainedWeights.ipynb
@@ -56,7 +56,10 @@
       "/data/home/ebs/miniconda3/envs/mdetr-notebook/lib/python3.8/site-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and will be removed in 0.15, please use 'weights' instead.\n",
       "  warnings.warn(\n",
       "/data/home/ebs/miniconda3/envs/mdetr-notebook/lib/python3.8/site-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and will be removed in 0.15. The current behavior is equivalent to passing `weights=ResNet101_Weights.IMAGENET1K_V1`. You can also use `weights=ResNet101_Weights.DEFAULT` to get the most up-to-date weights.\n",
-      "  warnings.warn(msg)\n"
+      "  warnings.warn(msg)\n",
+      "Some weights of the model checkpoint at roberta-base were not used when initializing RobertaModel: ['lm_head.layer_norm.weight', 'lm_head.decoder.weight', 'lm_head.dense.bias', 'lm_head.dense.weight', 'lm_head.bias', 'lm_head.layer_norm.bias']\n",
+      "- This IS expected if you are initializing RobertaModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing RobertaModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n"
      ]
     },
     {
@@ -95,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "id": "0d45b440-3021-4a6c-9069-51277919e6b5",
    "metadata": {},
    "outputs": [],
@@ -218,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 4,
    "id": "3ced58d3-f4a2-4fc5-86c2-5cd8c6f49d6e",
    "metadata": {},
    "outputs": [],
@@ -280,27 +283,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 5,
    "id": "41bd2387-1b23-4a8e-a852-93cc49e8ae1b",
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data/home/ebs/mdetr/models/position_encoding.py:41: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
+      "  dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_pos_feats)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mask sizes: torch.Size([2, 4]), torch.Size([2, 16])\n",
-      "In transformer encoder: size = torch.Size([20, 2, 256]), None, torch.Size([2, 20]), torch.Size([20, 2, 256])\n",
-      "\n",
-      "        In transformer decoder: \n",
-      "        size = torch.Size([100, 2, 256]), torch.Size([20, 2, 256]), torch.Size([16, 2, 256]), \n",
-      "        None, None, torch.Size([2, 16]), \n",
-      "        None, torch.Size([2, 20]), torch.Size([20, 2, 256]),\n",
-      "        torch.Size([100, 2, 256]) \n",
-      "        \n",
-      "Maximum difference in pred_logits is 1.049041748046875e-05\n",
-      "Maximum difference in pred_boxes is 7.748603820800781e-07\n",
-      "Maximum difference in proj_queries is 2.682209014892578e-07\n",
-      "Maximum difference in proj_tokens is 6.705522537231445e-07\n"
+      "Maximum difference in pred_logits is 1.239776611328125e-05\n",
+      "Maximum difference in pred_boxes is 3.337860107421875e-06\n",
+      "Maximum difference in proj_queries is 2.384185791015625e-07\n",
+      "Maximum difference in proj_tokens is 3.129243850708008e-07\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data/home/ebs/torchmultimodal/torchmultimodal/modules/encoders/mdetr_image_encoder.py:96: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
+      "  dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_pos_feats)\n"
      ]
     }
    ],

--- a/examples/mdetr/LoadAndComparePretrainedWeights.ipynb
+++ b/examples/mdetr/LoadAndComparePretrainedWeights.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 1,
    "id": "e9c13575-2049-4b20-9ae3-5fd9b93109e6",
    "metadata": {},
    "outputs": [],
@@ -43,17 +43,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 2,
    "id": "dff97610-8c5e-4f06-8aee-11baa3f52a60",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data/home/ebs/miniconda3/envs/mdetr-notebook/lib/python3.8/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "/data/home/ebs/miniconda3/envs/mdetr-notebook/lib/python3.8/site-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and will be removed in 0.15, please use 'weights' instead.\n",
+      "  warnings.warn(\n",
+      "/data/home/ebs/miniconda3/envs/mdetr-notebook/lib/python3.8/site-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and will be removed in 0.15. The current behavior is equivalent to passing `weights=ResNet101_Weights.IMAGENET1K_V1`. You can also use `weights=ResNet101_Weights.DEFAULT` to get the most up-to-date weights.\n",
+      "  warnings.warn(msg)\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "<All keys matched successfully>"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -83,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 15,
    "id": "0d45b440-3021-4a6c-9069-51277919e6b5",
    "metadata": {},
    "outputs": [],
@@ -170,6 +182,7 @@
     "    \n",
     "    # Miscellaneous renaming (this can probably be cleaned up)\n",
     "    mapped_state_dict = {k.replace('transformer.text_encoder', 'text_encoder'): v for k, v in mapped_state_dict.items() if 'embeddings' not in k}\n",
+    "\n",
     "    for k, v in mdetr_state_dict.items():\n",
     "        if not k.startswith('transformer.text_encoder') and not k.startswith('transformer.resizer') and 'input_proj' not in k:\n",
     "            mapped_state_dict[k.replace('backbone.0', 'image_backbone')] = v\n",
@@ -195,15 +208,17 @@
     "            k_new = '.'.join(k_split[:-2] + [\"mlp\", \"model\", str(3*(i-1)), k_split[-1]])\n",
     "            mapped_state_dict[k_new] = v\n",
     "            del mapped_state_dict[k]\n",
-    "    # Drop contrastive losses (not used in our MDETR model class)\n",
-    "    mapped_state_dict = filter_dict(lambda x: 'contrastive' not in x, mapped_state_dict)\n",
+    "        if 'contrastive' in k:\n",
+    "            k_new = k.replace('align','alignment').replace('projection_image', 'image_projection').replace('projection_text', 'text_projection')\n",
+    "            mapped_state_dict[k_new] = v\n",
+    "            del mapped_state_dict[k]\n",
     "    \n",
     "    return mapped_state_dict\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 25,
    "id": "3ced58d3-f4a2-4fc5-86c2-5cd8c6f49d6e",
    "metadata": {},
    "outputs": [],
@@ -249,17 +264,23 @@
     "        self.mm_mdetr.load_state_dict(self.mapped_state_dict)\n",
     "        self.mm_mdetr.eval()\n",
     "        self.mm_out = self.mm_mdetr(self.test_tensors, self.text.input_ids)\n",
-    "        \n",
+    "        self.mm_out_dict = {\n",
+    "            'pred_logits': self.mm_out.pred_logits, \n",
+    "            'pred_boxes': self.mm_out.pred_boxes, \n",
+    "            'proj_queries': self.mm_out.projected_queries,\n",
+    "            'proj_tokens': self.mm_out.projected_tokens\n",
+    "            \n",
+    "        }\n",
     "    def compare_results(self):\n",
-    "        for k in self.mm_out.keys():\n",
-    "            tensor_diff = max_diff(self.mm_out[k], self.mdetr_out[k])\n",
+    "        for k in self.mm_out_dict.keys():\n",
+    "            tensor_diff = max_diff(self.mm_out_dict[k], self.mdetr_out[k])\n",
     "            print(f\"Maximum difference in {k} is {tensor_diff}\")\n",
     "        "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 26,
    "id": "41bd2387-1b23-4a8e-a852-93cc49e8ae1b",
    "metadata": {},
    "outputs": [
@@ -277,7 +298,9 @@
       "        torch.Size([100, 2, 256]) \n",
       "        \n",
       "Maximum difference in pred_logits is 1.049041748046875e-05\n",
-      "Maximum difference in pred_boxes is 2.1457672119140625e-06\n"
+      "Maximum difference in pred_boxes is 7.748603820800781e-07\n",
+      "Maximum difference in proj_queries is 2.682209014892578e-07\n",
+      "Maximum difference in proj_tokens is 6.705522537231445e-07\n"
      ]
     }
    ],

--- a/examples/mdetr/contrastive_alignment_loss.py
+++ b/examples/mdetr/contrastive_alignment_loss.py
@@ -1,0 +1,113 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Tuple
+
+import torch
+from torch import Tensor
+from transformers.tokenization_utils_base import BatchEncoding
+
+
+def contrastive_alignment_loss(
+    projected_queries: Tensor,
+    projected_tokens: Tensor,
+    target_tokens: List[List[List[int]]],
+    indices: List[Tuple[Tensor, Tensor]],
+    num_boxes: int,
+    tokenized: BatchEncoding,
+    temperature: float = 0.07,
+):
+    """Contrastive alignment loss.
+
+    Enforces alignment between the text representations after cross encoder and the
+    object representations after the decoder.
+
+                projected_queries (Tensor): Tensor containing object representations
+                    projected to query dimension.
+                    Size: (batch_size, num_queries, contrastive_dim)
+                projected_tokens: Tensor containing text representations projected
+                    to token dimension.
+                    Size: (batch_size, num_tokens, contrastive_dim)
+                target_tokens (List[List[List[int]]]): A very nested list of tokens
+                    that correspond to each target. From outermost to innermost:
+                    batch, object, list of disjoint (start, end) tokens
+                indices (List[Tuple[Tensor, Tensor]]): A list of size batch_size,
+                containing tuples of (index_i, index_j) where:
+                    - index_i is the indices of the selected predictions (in order)
+                    - index_j is the indices of the corresponding selected targets
+                For each batch element, it holds:
+                    len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+            num_boxes (int): Normalization factor. Should equal the average number of
+                boxes per local batch.
+            tokenized (BatchEncoding): Tokenized output from a transformers fast tokenizer.
+                Used for token lookup based on character positions.
+            temperature (float): Scaling factor used in calculating the logits.
+                Default: 0.07
+    """
+
+    logits = (
+        torch.matmul(projected_queries, projected_tokens.transpose(-1, -2))
+        / temperature
+    )  # BS x (num_queries) x (num_tokens)
+
+    positive_map = construct_positive_map(logits, target_tokens, indices, tokenized)
+
+    positive_logits = -logits.masked_fill(~positive_map, 0)
+    negative_logits = logits
+
+    # Calculate the contrastive loss for all objects
+    boxes_with_pos = positive_map.any(2)
+    pos_term = positive_logits.sum(2)
+    neg_term = negative_logits.logsumexp(2)
+    nb_pos = positive_map.sum(2) + 1e-6
+    box_to_token_loss = (
+        ((pos_term / nb_pos + neg_term)).masked_fill(~boxes_with_pos, 0).sum()
+    )
+
+    # Calculate the contrastive loss for all tokens
+    tokens_with_pos = positive_map.any(1)
+    pos_term = positive_logits.sum(1)
+    neg_term = negative_logits.logsumexp(1)
+    nb_pos = positive_map.sum(1) + 1e-6
+    tokens_to_boxes_loss = (
+        ((pos_term / nb_pos + neg_term)).masked_fill(~tokens_with_pos, 0).sum()
+    )
+
+    tot_loss = (box_to_token_loss + tokens_to_boxes_loss) / 2
+
+    return tot_loss / num_boxes
+
+
+def construct_positive_map(logits: Tensor, target_tokens, indices, tokenized):
+    # construct a map such that positive_map[k, i,j] = True iff query i is associated to token j in batch item k
+    # For efficency, the construction happens on CPU, then the whole matrix is transferred to GPU in one go.
+    positive_map = torch.zeros(logits.shape, dtype=torch.bool)
+    for i, ((idx_src, idx_tgt), tgt) in enumerate(zip(indices, target_tokens)):
+        cur_tokens = [tgt[j] for j in idx_tgt]
+        for j, tok_list in enumerate(cur_tokens):
+            for (beg, end) in tok_list:
+                beg_pos = tokenized.char_to_token(i, beg)
+                end_pos = tokenized.char_to_token(i, end - 1)
+                if beg_pos is None:
+                    try:
+                        beg_pos = tokenized.char_to_token(beg + 1)
+                        if beg_pos is None:
+                            beg_pos = tokenized.char_to_token(beg + 2)
+                    except Exception:
+                        beg_pos = None
+                if end_pos is None:
+                    try:
+                        end_pos = tokenized.char_to_token(end - 2)
+                        if end_pos is None:
+                            end_pos = tokenized.char_to_token(end - 3)
+                    except Exception:
+                        end_pos = None
+                if beg_pos is None or end_pos is None:
+                    continue
+
+                assert beg_pos is not None and end_pos is not None
+                positive_map[i, idx_src[j], beg_pos : end_pos + 1].fill_(True)
+    return positive_map.to(logits.device)

--- a/examples/mdetr/test/test_contrastive_alignment_loss.py
+++ b/examples/mdetr/test/test_contrastive_alignment_loss.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from examples.mdetr.contrastive_alignment_loss import contrastive_alignment_loss
+from test.test_utils import assert_expected, set_rng_seed
+from transformers import RobertaTokenizerFast
+
+
+@pytest.fixture(scope="class", autouse=True)
+def rng():
+    set_rng_seed(0)
+
+
+class TestContrastiveAlignmentLoss:
+    @pytest.fixture(scope="class")
+    def batch_size(self):
+        return 2
+
+    @pytest.fixture(scope="class")
+    def num_queries(self):
+        return 20
+
+    @pytest.fixture(scope="class")
+    def num_tokens(self):
+        return 255
+
+    @pytest.fixture(scope="class")
+    def contrastive_dim(self):
+        return 8
+
+    @pytest.fixture(scope="class")
+    def projected_tokens(self, batch_size, num_tokens, contrastive_dim):
+        return torch.randn(batch_size, num_tokens, contrastive_dim)
+
+    @pytest.fixture(scope="class")
+    def projected_queries(self, batch_size, num_queries, contrastive_dim):
+        return torch.randn(batch_size, num_queries, contrastive_dim)
+
+    @pytest.fixture(scope="class")
+    def target_tokens(self):
+        return [
+            [
+                [[39, 44]],
+                [[39, 44]],
+                [[39, 44]],
+                [[39, 44]],
+                [[39, 44]],
+                [[39, 44]],
+                [[39, 44]],
+                [[39, 44]],
+                [[39, 44]],
+                [[39, 44]],
+                [[48, 57]],
+                [[39, 44]],
+                [[15, 22]],
+                [[39, 44]],
+                [[39, 44]],
+                [[0, 3]],
+                [[39, 44]],
+            ],
+            [
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[33, 48]],
+                [[9, 18]],
+                [[33, 48]],
+                [[33, 48]],
+                [[0, 5]],
+                [[33, 48]],
+            ],
+        ]
+
+    @pytest.fixture(scope="class")
+    def indices(self):
+        indices = [
+            (torch.Tensor([5, 7, 9]), torch.Tensor([2, 1, 0])),
+            (
+                torch.Tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                torch.Tensor([9, 8, 4, 6, 0, 2, 3, 1, 5, 7]),
+            ),
+        ]
+        return [(x[0].to(dtype=torch.int), x[1].to(dtype=torch.int)) for x in indices]
+
+    @pytest.fixture(scope="class")
+    def num_boxes(self):
+        return 25
+
+    @pytest.fixture(scope="class")
+    def tokenized(self):
+        captions = [
+            "Man talking on a phone , surrounded by books in an office .",
+            "A man on the phone surrounded by stacks of books .",
+        ]
+        tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")
+        tokenized = tokenizer.batch_encode_plus(
+            captions, padding="longest", return_tensors="pt"
+        )
+        return tokenized
+
+    def test_contrastive_alignment_loss(
+        self,
+        projected_queries,
+        projected_tokens,
+        target_tokens,
+        indices,
+        num_boxes,
+        tokenized,
+    ):
+        expected = torch.tensor(30.3021)
+        actual = contrastive_alignment_loss(
+            projected_queries,
+            projected_tokens,
+            target_tokens,
+            indices,
+            num_boxes,
+            tokenized,
+        )
+        assert_expected(expected, actual, rtol=0, atol=1e-3)

--- a/examples/mdetr/test/test_contrastive_alignment_loss.py
+++ b/examples/mdetr/test/test_contrastive_alignment_loss.py
@@ -6,42 +6,45 @@
 
 import pytest
 import torch
-from examples.mdetr.contrastive_alignment_loss import contrastive_alignment_loss
+from examples.mdetr.contrastive_alignment_loss import (
+    construct_positive_map,
+    contrastive_alignment_loss,
+)
 from test.test_utils import assert_expected, set_rng_seed
 from transformers import RobertaTokenizerFast
 
 
-@pytest.fixture(scope="class", autouse=True)
+@pytest.fixture(autouse=True)
 def rng():
     set_rng_seed(0)
 
 
 class TestContrastiveAlignmentLoss:
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def batch_size(self):
         return 2
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def num_queries(self):
         return 20
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def num_tokens(self):
         return 255
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def contrastive_dim(self):
         return 8
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def projected_tokens(self, batch_size, num_tokens, contrastive_dim):
         return torch.randn(batch_size, num_tokens, contrastive_dim)
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def projected_queries(self, batch_size, num_queries, contrastive_dim):
         return torch.randn(batch_size, num_queries, contrastive_dim)
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def target_tokens(self):
         return [
             [
@@ -83,7 +86,7 @@ class TestContrastiveAlignmentLoss:
             ],
         ]
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def indices(self):
         indices = [
             (torch.Tensor([5, 7, 9]), torch.Tensor([2, 1, 0])),
@@ -94,11 +97,11 @@ class TestContrastiveAlignmentLoss:
         ]
         return [(x[0].to(dtype=torch.int), x[1].to(dtype=torch.int)) for x in indices]
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def num_boxes(self):
         return 25
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def tokenized(self):
         captions = [
             "Man talking on a phone , surrounded by books in an office .",
@@ -129,3 +132,51 @@ class TestContrastiveAlignmentLoss:
             tokenized,
         )
         assert_expected(expected, actual, rtol=0, atol=1e-3)
+
+    def test_construct_positive_map(
+        self, batch_size, num_queries, num_tokens, target_tokens, indices, tokenized
+    ):
+        logits = torch.ones(batch_size, num_queries, num_tokens)
+
+        actual = construct_positive_map(logits, target_tokens, indices, tokenized)
+        actual_nonzero_entries = torch.nonzero(actual)
+        expected_size = (batch_size, num_queries, num_tokens)
+        expected_nonzero_entries = torch.LongTensor(
+            [
+                [0, 5, 9],
+                [0, 7, 9],
+                [0, 9, 9],
+                [1, 0, 8],
+                [1, 0, 9],
+                [1, 0, 10],
+                [1, 1, 8],
+                [1, 1, 9],
+                [1, 1, 10],
+                [1, 2, 8],
+                [1, 2, 9],
+                [1, 2, 10],
+                [1, 3, 8],
+                [1, 3, 9],
+                [1, 3, 10],
+                [1, 4, 8],
+                [1, 4, 9],
+                [1, 4, 10],
+                [1, 5, 8],
+                [1, 5, 9],
+                [1, 5, 10],
+                [1, 6, 8],
+                [1, 6, 9],
+                [1, 6, 10],
+                [1, 7, 8],
+                [1, 7, 9],
+                [1, 7, 10],
+                [1, 8, 8],
+                [1, 8, 9],
+                [1, 8, 10],
+                [1, 9, 8],
+                [1, 9, 9],
+                [1, 9, 10],
+            ]
+        )
+        assert actual.size() == expected_size
+        assert_expected(actual_nonzero_entries, expected_nonzero_entries)

--- a/test/models/test_mdetr.py
+++ b/test/models/test_mdetr.py
@@ -188,34 +188,34 @@ class TestMDETR:
         num_classes_full,
     ):
         out = mdetr(test_tensors, input_ids)
-        logits_actual = out["pred_logits"]
-        boxes_actual = out["pred_boxes"]
+        logits_actual = out.pred_logits
+        boxes_actual = out.pred_boxes
         logits_expected = torch.Tensor(
             [
-                -0.8136,
-                -0.8156,
-                -0.8094,
-                -0.8099,
-                -0.8226,
-                -0.8106,
-                -0.8104,
-                -0.8207,
-                -0.8172,
-                -0.8063,
+                -0.8264,
+                -0.8312,
+                -0.8164,
+                -0.8235,
+                -0.8361,
+                -0.8247,
+                -0.8258,
+                -0.8323,
+                -0.8297,
+                -0.8214,
             ]
         )
         boxes_expected = torch.Tensor(
             [
-                0.5612,
-                0.5623,
-                0.5615,
-                0.5617,
-                0.5620,
-                0.5614,
-                0.5617,
-                0.5611,
-                0.5615,
-                0.5620,
+                0.5595,
+                0.5601,
+                0.5598,
+                0.5597,
+                0.5601,
+                0.5595,
+                0.5597,
+                0.5593,
+                0.5596,
+                0.5601,
             ]
         )
         assert logits_actual.size() == (

--- a/test/modules/encoders/test_mdetr_text_encoder.py
+++ b/test/modules/encoders/test_mdetr_text_encoder.py
@@ -138,7 +138,6 @@ class TestMDETRTextEncoder(unittest.TestCase):
         self.assertEqual(
             out.size(), (self.batch_size, self.input_length, self.hidden_size)
         )
-        print(actual)
         assert_expected(actual, expected, rtol=0.0, atol=1e-4)
 
     def test_mdetr_modified_transformer(self):

--- a/torchmultimodal/models/mdetr.py
+++ b/torchmultimodal/models/mdetr.py
@@ -150,14 +150,11 @@ class MDETR(nn.Module):
             text_memory=text_memory_resized,
             text_attention_mask=text_attention_mask,
         )
-        outputs_class = self.class_embed(transformer_outputs.decoder_hidden_states)
-        outputs_coord = self.bbox_embed(
-            transformer_outputs.decoder_hidden_states
-        ).sigmoid()
+        final_hidden_state = transformer_outputs.decoder_hidden_states[-1]
+        outputs_class = self.class_embed(final_hidden_state)
+        outputs_coord = self.bbox_embed(final_hidden_state).sigmoid()
         projected_queries = F.normalize(
-            self.contrastive_alignment_image_projection(
-                transformer_outputs.decoder_hidden_states
-            ),
+            self.contrastive_alignment_image_projection(final_hidden_state),
             p=2,
             dim=-1,
         )
@@ -168,11 +165,11 @@ class MDETR(nn.Module):
             p=2,
             dim=-1,
         )
-        # Return projections from the last layer of the decoders
+
         return MDETROutput(
-            pred_logits=outputs_class[-1],
-            pred_boxes=outputs_coord[-1],
-            projected_queries=projected_queries[-1],
+            pred_logits=outputs_class,
+            pred_boxes=outputs_coord,
+            projected_queries=projected_queries,
             projected_tokens=projected_tokens,
         )
 

--- a/torchmultimodal/models/mdetr.py
+++ b/torchmultimodal/models/mdetr.py
@@ -6,9 +6,10 @@
 
 import math
 from copy import deepcopy
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, List, NamedTuple, Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 from torch import nn, Tensor
 from torchmultimodal.modules.encoders.mdetr_image_encoder import (
     mdetr_resnet101_backbone,
@@ -19,6 +20,18 @@ from torchmultimodal.modules.encoders.mdetr_text_encoder import (
 )
 from torchmultimodal.modules.layers.mlp import MLP
 from torchvision.models import resnet101
+
+
+class MDETRTransformerOutput(NamedTuple):
+    decoder_hidden_states: torch.Tensor
+    text_memory: torch.Tensor
+
+
+class MDETROutput(NamedTuple):
+    pred_logits: torch.Tensor
+    pred_boxes: torch.Tensor
+    projected_queries: torch.Tensor
+    projected_tokens: torch.Tensor
 
 
 class MDETR(nn.Module):
@@ -71,6 +84,8 @@ class MDETR(nn.Module):
         query_embed: nn.Module,
         bbox_embed: nn.Module,
         class_embed: nn.Module,
+        contrastive_alignment_image_projection: nn.Module,
+        contrastive_alignment_text_projection: nn.Module,
     ):
         super().__init__()
         self.image_backbone = image_backbone
@@ -82,6 +97,12 @@ class MDETR(nn.Module):
         self.query_embed = query_embed
         self.bbox_embed = bbox_embed
         self.class_embed = class_embed
+        self.contrastive_alignment_image_projection = (
+            contrastive_alignment_image_projection
+        )
+        self.contrastive_alignment_text_projection = (
+            contrastive_alignment_text_projection
+        )
 
     def _pad_images(self, images: List[Tensor]) -> Tuple[Tensor, Tensor]:
         max_size = tuple(max(s) for s in zip(*[img.shape for img in images]))
@@ -106,7 +127,7 @@ class MDETR(nn.Module):
         mask = padded_text == padding_idx
         return padded_text, mask
 
-    def forward(self, images: List[Tensor], text: List[Tensor]) -> Dict[str, Tensor]:
+    def forward(self, images: List[Tensor], text: List[Tensor]) -> MDETROutput:
 
         images, image_mask = self._pad_images(images)
         text, text_attention_mask = self._pad_text(text)
@@ -121,7 +142,7 @@ class MDETR(nn.Module):
 
         text_memory_resized = self.text_projection(text_memory)
 
-        hs = self.transformer(
+        transformer_outputs = self.transformer(
             self.image_projection(image_embeddings),
             image_mask,
             query_embed,
@@ -129,16 +150,31 @@ class MDETR(nn.Module):
             text_memory=text_memory_resized,
             text_attention_mask=text_attention_mask,
         )
-        outputs_class = self.class_embed(hs)
-        outputs_coord = self.bbox_embed(hs).sigmoid()
-
+        outputs_class = self.class_embed(transformer_outputs.decoder_hidden_states)
+        outputs_coord = self.bbox_embed(
+            transformer_outputs.decoder_hidden_states
+        ).sigmoid()
+        projected_queries = F.normalize(
+            self.contrastive_alignment_image_projection(
+                transformer_outputs.decoder_hidden_states
+            ),
+            p=2,
+            dim=-1,
+        )
+        projected_tokens = F.normalize(
+            self.contrastive_alignment_text_projection(
+                transformer_outputs.text_memory
+            ).transpose(0, 1),
+            p=2,
+            dim=-1,
+        )
         # Return projections from the last layer of the decoders
-        out = {
-            "pred_logits": outputs_class[-1],
-            "pred_boxes": outputs_coord[-1],
-        }
-
-        return out
+        return MDETROutput(
+            pred_logits=outputs_class[-1],
+            pred_boxes=outputs_coord[-1],
+            projected_queries=projected_queries[-1],
+            projected_tokens=projected_tokens,
+        )
 
 
 class MDETRTransformer(nn.Module):
@@ -217,7 +253,7 @@ class MDETRTransformer(nn.Module):
         pos_embed: Tensor,
         text_memory: Tensor,
         text_attention_mask: Tensor,
-    ) -> Tensor:
+    ) -> MDETRTransformerOutput:
         # flatten NxCxHxW to HWxNxC
         bs = image_embeddings.size(0)
         image_embeddings = image_embeddings.flatten(2).permute(2, 0, 1)
@@ -251,7 +287,9 @@ class MDETRTransformer(nn.Module):
             pos=pos_embed,
             query_pos=query_embed,
         )
-        return hs.transpose(1, 2)
+        return MDETRTransformerOutput(
+            decoder_hidden_states=hs.transpose(1, 2), text_memory=text_memory
+        )
 
 
 class TransformerEncoder(nn.Module):
@@ -639,6 +677,7 @@ def mdetr_resnet101(
     transformer_dim_feedforward: int = 2048,
     transformer_dropout: float = 0.1,
     return_intermediate_dec: bool = True,
+    contrastive_dim: int = 64,
 ) -> MDETR:
     image_backbone = resnet101()
     image_backbone = mdetr_resnet101_backbone()
@@ -664,6 +703,8 @@ def mdetr_resnet101(
     bbox_embed = MLP(hidden_dim, 4, [hidden_dim] * 2, dropout=0.0)
     # The + 1 here corresponds to the "no class" label
     class_embed = nn.Linear(hidden_dim, num_classes + 1)
+    contrastive_alignment_image_projection = nn.Linear(hidden_dim, contrastive_dim)
+    contrastive_alignment_text_projection = nn.Linear(hidden_dim, contrastive_dim)
     mdetr = MDETR(
         image_backbone,
         text_encoder,
@@ -674,5 +715,7 @@ def mdetr_resnet101(
         query_embed,
         bbox_embed,
         class_embed,
+        contrastive_alignment_image_projection,
+        contrastive_alignment_text_projection,
     )
     return mdetr


### PR DESCRIPTION
Summary:
This PR adds support for the contrastive alignment loss from MDETR. This loss also necessitates
adding two projections to the MDETR model, and returning some intermediate outputs. I modified the
return types of MDETRTransformer and MDETR to be NamedTuples in the process of making these changes.

Note that the contrastive alignment loss uses the mapping between character positions and token IDs
and so needs access to the transformers tokenizer. For this reason I am putting this loss in examples/
instead of in core.

Test plan:
Added a new test for the contrastive loss, updated the existing MDETR model tests
to account for different random initialization orders and new params.
Confirmed in LoadAndComparePretrainedWeights.ipynb that the outputs line up with the MDETR checkpoint.

```
python -m pytest -v
...
========================= 175 passed, 2 skipped, 2 xfailed, 6 warnings in 46.57s ================
```
