### PR TITLE
[Unification] Use scaled dot product attention in ALBEFTransformerSelfAttention

### DIFF
--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -40,15 +40,10 @@ def get_extended_attention_mask(attention_mask: Tensor) -> Tensor:
             "Wrong shape for attention_mask (shape {})".format(attention_mask.shape)
         )
 
-    # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
-    # masked positions, this operation will create a tensor which is 0.0 for
-    # positions we want to attend and -10000.0 for masked positions.
-    # Since we are adding it to the raw scores before the softmax, this is
-    # effectively the same as removing these entirely.
     extended_attention_mask = extended_attention_mask.to(
         dtype=attention_mask.dtype
     )  # fp16 compatibility
-    extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+
     return extended_attention_mask
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #162
* #152
* #151
* __->__ #150
* #149

## Summary
Small diffs building up to a unified `SelfAttention` class used across all models by generalizing one piece at a time.

This diff makes `scaled_dot_product_attention` the basic attention calculation in ALBEF.

## Test plan
`pytest test -vv`
`pytest examples -vv`

Differential Revision: [D37893409](https://our.internmc.facebook.com/intern/diff/D37893409)