### PR TITLE
[Unification] Unify attention utils

### DIFF
--- a/test/modules/layers/test_attention.py
+++ b/test/modules/layers/test_attention.py
@@ -12,8 +12,10 @@ from torchmultimodal.modules.layers.attention import (
     AxialAttention,
     AxialAttentionBlock,
     FullAttention,
+    merge_multihead,
     MultiHeadAttention,
     scaled_dot_product_attention,
+    split_multihead,
 )
 
 
@@ -115,14 +117,14 @@ class TestAttention(unittest.TestCase):
 
     def test_split_multihead(self):
         x = torch.randn(1, *self.input_shape, 6)
-        self.mha.n_head = 2
-        out = self.mha._split_multihead(x)
+        n_head = 2
+        out = split_multihead(x, n_head)
         actual = torch.tensor(out.shape)
         expected = torch.tensor((1, 2, *self.input_shape, 3))
         assert_expected(actual, expected)
 
-    def test_combine_multihead(self):
-        out = self.mha._combine_multihead(self.q)
+    def test_merge_multihead(self):
+        out = merge_multihead(self.q)
         actual = torch.tensor(out.shape)
         expected = torch.tensor((1, *self.input_shape, self.hidden_dim))
         assert_expected(actual, expected)

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -8,11 +8,12 @@ from typing import Callable, Optional
 
 import torch
 from torch import nn, Tensor
-from torchmultimodal.modules.layers.attention import scaled_dot_product_attention
-from torchmultimodal.utils.common import (
-    get_extended_attention_mask,
-    transpose_for_scores,
+from torchmultimodal.modules.layers.attention import (
+    merge_multihead,
+    scaled_dot_product_attention,
+    split_multihead,
 )
+from torchmultimodal.utils.common import get_extended_attention_mask
 
 
 class ALBEFTextEncoder(nn.Module):
@@ -250,22 +251,14 @@ class ALBEFTransformerSelfAttention(nn.Module):
             mixed_value_layer = self.value(encoder_hidden_states)
             attention_mask = None
 
-        query_layer = transpose_for_scores(
-            self.num_attention_heads, self.attention_head_size, mixed_query_layer
-        )
-        key_layer = transpose_for_scores(
-            self.num_attention_heads, self.attention_head_size, mixed_key_layer
-        )
-        value_layer = transpose_for_scores(
-            self.num_attention_heads, self.attention_head_size, mixed_value_layer
-        )
+        query_layer = split_multihead(mixed_query_layer, self.num_attention_heads)
+        key_layer = split_multihead(mixed_key_layer, self.num_attention_heads)
+        value_layer = split_multihead(mixed_value_layer, self.num_attention_heads)
 
         context_layer, _ = scaled_dot_product_attention(
             query_layer, key_layer, value_layer, attention_mask
         )
 
-        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
-        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
-        context_layer = context_layer.view(*new_context_layer_shape)
+        context_layer = merge_multihead(context_layer)
 
         return context_layer

--- a/torchmultimodal/modules/layers/transformer.py
+++ b/torchmultimodal/modules/layers/transformer.py
@@ -13,9 +13,12 @@ from typing import Any, Callable, Optional, Tuple
 
 import torch
 from torch import nn, Tensor
-from torchmultimodal.modules.layers.attention import scaled_dot_product_attention
+from torchmultimodal.modules.layers.attention import (
+    merge_multihead,
+    scaled_dot_product_attention,
+    split_multihead,
+)
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
-from torchmultimodal.utils.common import transpose_for_scores
 
 FLAVATransformerOutput = namedtuple(
     "FLAVATransformerOutput",
@@ -60,18 +63,13 @@ class FLAVASelfAttention(nn.Module):
         attention_mask: Optional[Tensor] = None,
         head_mask: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Tensor]:
-        mixed_query_layer = self.query(hidden_states)
-        key_layer = transpose_for_scores(
-            self.num_attention_heads, self.attention_head_size, self.key(hidden_states)
-        )
-        value_layer = transpose_for_scores(
-            self.num_attention_heads,
-            self.attention_head_size,
-            self.value(hidden_states),
-        )
 
-        query_layer = transpose_for_scores(
-            self.num_attention_heads, self.attention_head_size, mixed_query_layer
+        key_layer = split_multihead(self.key(hidden_states), self.num_attention_heads)
+        value_layer = split_multihead(
+            self.value(hidden_states), self.num_attention_heads
+        )
+        query_layer = split_multihead(
+            self.query(hidden_states), self.num_attention_heads
         )
 
         context_layer, attention_probs = scaled_dot_product_attention(
@@ -83,9 +81,7 @@ class FLAVASelfAttention(nn.Module):
             self.attn_dropout,
         )
 
-        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
-        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
-        context_layer = context_layer.view(*new_context_layer_shape)
+        context_layer = merge_multihead(context_layer)
 
         outputs = (context_layer, attention_probs)
         return outputs

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -121,13 +121,6 @@ def tensor_slice(x: Tensor, begin: List[int], size: List[int]) -> Tensor:
     return x[slices]
 
 
-def transpose_for_scores(
-    num_attention_heads: int, attention_head_size: int, x: Tensor
-) -> Tensor:
-    x = x.unflatten(-1, (num_attention_heads, attention_head_size))
-    return x.permute(0, 2, 1, 3)
-
-
 @torch.no_grad()
 def remove_grad(model: nn.Module) -> None:
     for param in model.parameters():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172
* #170
* #169
* #168
* #162
* #152
* __->__ #151

## Summary
Small diffs building up to a unified `SelfAttention` class used across all models by generalizing one piece at a time.

Replaces `transpose_for_scores` and shape permutations in `FLAVASelfAttention` and `ALBEFTransformerSelfAttention` with `split_multihead`, 'merge_multihead`.

## Test plan
`pytest test -vv`
`pytest examples -vv`
[Notebook](https://colab.research.google.com/drive/1qc0njVryPWuzCsEaaVupMzU1pcXwZjhG?usp=sharing) with FLAVA checkpoint loading functions. Tested checkpoints on random inputs to ensure they align with previous version before unification and that loading is successful. A separate [PR](https://github.com/facebookresearch/multimodal/pull/161) adds this check as an optional test.

Differential Revision: [D37929520](https://our.internmc.facebook.com/intern/diff/D37929520)