### PR TITLE
[Unification] Move get_extended_attention_mask to utils

### DIFF
--- a/torchmultimodal/models/flava/flava_text_encoder.py
+++ b/torchmultimodal/models/flava/flava_text_encoder.py
@@ -5,11 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 from functools import partial
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional
 
 import torch
 from packaging import version
-from torch import device, nn, Tensor
+from torch import nn, Tensor
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
 from torchmultimodal.modules.layers.transformer import (
     FLAVATransformerEncoder,
@@ -17,6 +17,7 @@ from torchmultimodal.modules.layers.transformer import (
     init_transformer_weights,
 )
 from torchmultimodal.modules.losses.flava import Pooler
+from torchmultimodal.utils.attention import get_extended_attention_mask
 
 
 class TextEmbeddings(nn.Module):
@@ -131,39 +132,6 @@ class TextTransformer(nn.Module):
 
         self.apply(weight_init_fn)
 
-    def get_extended_attention_mask(
-        self, attention_mask: Tensor, input_shape: Tuple[int, ...], device: device
-    ) -> Tensor:
-        """
-        Makes broadcastable attention and causal masks so that future and masked tokens are ignored.
-        Arguments:
-            attention_mask (`torch.Tensor`):
-                Mask with ones indicating tokens to attend to, zeros for tokens to ignore.
-            input_shape (`Tuple[int]`):
-                The shape of the input to the model.
-            device: (`torch.device`):
-                The device of the input to the model.
-        Returns:
-            `torch.Tensor` The extended attention mask, with a the same dtype as `attention_mask.dtype`.
-        """
-        # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
-        # ourselves in which case we just need to make it broadcastable to all heads.
-        if attention_mask.dim() == 3:
-            extended_attention_mask = attention_mask[:, None, :, :]
-        elif attention_mask.dim() == 2:
-            # Provided a padding mask of dimensions [batch_size, seq_length]
-            # - if the model is an encoder, make the mask broadcastable to [batch_size, num_heads, seq_length, seq_length]
-            extended_attention_mask = attention_mask[:, None, None, :]
-        else:
-            raise ValueError(
-                f"Wrong shape for input_ids (shape {input_shape}) or attention_mask (shape {attention_mask.shape})"
-            )
-
-        extended_attention_mask = extended_attention_mask.to(
-            dtype=attention_mask.dtype
-        )  # fp16 compatibility
-        return extended_attention_mask
-
     def forward(
         self,
         input_ids: Optional[Tensor] = None,
@@ -185,8 +153,8 @@ class TextTransformer(nn.Module):
         # We can provide a self-attention mask of dimensions
         # [batch_size, from_seq_length, to_seq_length]
         # ourselves in which case we just need to make it broadcastable to all heads.
-        extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(
-            attention_mask, input_shape, device
+        extended_attention_mask: torch.Tensor = get_extended_attention_mask(
+            attention_mask
         )
 
         embedding_output = self.embeddings(

--- a/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_multimodal_encoder.py
@@ -11,7 +11,7 @@ from torch import nn, Tensor
 from torchmultimodal.modules.encoders.albef_text_encoder import (
     ALBEFTransformerAttention,
 )
-from torchmultimodal.utils.common import get_extended_attention_mask
+from torchmultimodal.utils.attention import get_extended_attention_mask
 
 
 class ALBEFMultimodalEncoder(nn.Module):

--- a/torchmultimodal/modules/encoders/albef_text_encoder.py
+++ b/torchmultimodal/modules/encoders/albef_text_encoder.py
@@ -13,7 +13,7 @@ from torchmultimodal.modules.layers.attention import (
     scaled_dot_product_attention,
     split_multihead,
 )
-from torchmultimodal.utils.common import get_extended_attention_mask
+from torchmultimodal.utils.attention import get_extended_attention_mask
 
 
 class ALBEFTextEncoder(nn.Module):

--- a/torchmultimodal/utils/attention.py
+++ b/torchmultimodal/utils/attention.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch import Tensor
+
+
+def get_extended_attention_mask(attention_mask: Tensor) -> Tensor:
+    """
+    Makes broadcastable attention and causal masks so that future and masked tokens are ignored.
+
+    Args:
+        attention_mask (Tensor): Mask with ones indicating tokens to attend to, zeros for tokens to ignore.
+    Returns:
+        extended_attention_mask (Tensor): extended attention mask with the same dtype as attention_mask.dtype.
+    """
+
+    if attention_mask.dim() == 3:
+        extended_attention_mask = attention_mask[:, None, :, :]
+    elif attention_mask.dim() == 2:
+        extended_attention_mask = attention_mask[:, None, None, :]
+    else:
+        raise ValueError(
+            "Wrong shape for attention_mask (shape {})".format(attention_mask.shape)
+        )
+
+    extended_attention_mask = extended_attention_mask.to(
+        dtype=attention_mask.dtype
+    )  # fp16 compatibility
+
+    return extended_attention_mask


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172
* #170
* #169
* #168
* #162
* __->__ #152
* #151

## Summary
Small diffs building up to a unified `SelfAttention` class used across all models by generalizing one piece at a time.

This diff moves `get_extended_attention_mask` from FLAVA and ALBEF into utils.

## Test plan
`pytest test -vv`
`pytest examples -vv`
[Notebook](https://colab.research.google.com/drive/1qc0njVryPWuzCsEaaVupMzU1pcXwZjhG?usp=sharing) with FLAVA checkpoint loading functions. Tested checkpoints on random inputs to ensure they align with previous version before unification and that loading is successful. A separate [PR](https://github.com/facebookresearch/multimodal/pull/161) adds this check as an optional test.

Differential Revision: [D37935055](https://our.internmc.facebook.com/intern/diff/D37935055)