### PR TITLE
Add more variant and pretrained_weight capability (#130)

### DIFF
--- a/test/models/test_omnivore.py
+++ b/test/models/test_omnivore.py
@@ -4,46 +4,110 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-
+import pytest
 import torch
 import torchmultimodal.models.omnivore as omnivore
 
-from test.test_utils import set_rng_seed
+from test.test_utils import assert_expected, set_rng_seed
 from torchmultimodal.utils.common import get_current_device
 
 
-class TestOmnivoreModel(unittest.TestCase):
-    def setUp(self):
-        set_rng_seed(42)
-        self.device = get_current_device()
+@pytest.fixture(autouse=True)
+def device():
+    set_rng_seed(42)
+    return get_current_device()
 
-    def test_omnivore_swin_t_forward(self):
-        model = omnivore.omnivore_swin_t().to(self.device)
-        self.assertTrue(isinstance(model, torch.nn.Module))
 
-        image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
-        image_score = model(image, input_type="image")
-        self.assertEqual(image_score.size(), torch.Size((1, 1000)))
-        self.assertAlmostEqual(image_score.abs().sum().item(), 200.27572, 2)
+@pytest.fixture(autouse=True)
+def omnivore_swin_t_model(device):
+    return omnivore.omnivore_swin_t().to(device)
 
-        rgbd = torch.randn(1, 4, 1, 112, 112)
-        rgbd_score = model(rgbd, input_type="rgbd")
-        self.assertEqual(rgbd_score.size(), torch.Size((1, 19)))
-        self.assertAlmostEqual(rgbd_score.abs().sum().item(), 3.10466, 3)
 
-        video = torch.randn(1, 3, 4, 112, 112)
-        video_score = model(video, input_type="video")
-        self.assertEqual(video_score.size(), torch.Size((1, 400)))
-        self.assertAlmostEqual(video_score.abs().sum().item(), 97.57287, 2)
+@pytest.fixture(autouse=True)
+def omnivore_swin_s_model(device):
+    return omnivore.omnivore_swin_s().to(device)
 
-    def test_omnivore_forward_wrong_input_type(self):
-        model = omnivore.omnivore_swin_t().to(self.device)
 
-        image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
-        with self.assertRaises(AssertionError) as cm:
-            _ = model(image, input_type="_WRONG_TYPE_")
-            self.assertEqual(
-                "Unsupported input_type: _WRONG_TYPE_, please use one of {'video', 'rgbd', 'image'}",
-                str(cm.exception),
-            )
+@pytest.fixture(autouse=True)
+def omnivore_swin_b_model(device):
+    return omnivore.omnivore_swin_b().to(device)
+
+
+def test_omnivore_swin_t_forward(omnivore_swin_t_model):
+    model = omnivore_swin_t_model
+
+    image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
+    image_score = model(image, input_type="image")
+
+    assert_expected(image_score.size(), torch.Size((1, 1000)))
+    assert_expected(
+        image_score.abs().sum(), torch.tensor(194.83563), rtol=1e-3, atol=1e-3
+    )
+
+    rgbd = torch.randn(1, 4, 1, 112, 112)
+    rgbd_score = model(rgbd, input_type="rgbd")
+    assert_expected(rgbd_score.size(), torch.Size((1, 19)))
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(3.18015), rtol=1e-3, atol=1e-3)
+
+    video = torch.randn(1, 3, 4, 112, 112)
+    video_score = model(video, input_type="video")
+    assert_expected(video_score.size(), torch.Size((1, 400)))
+    assert_expected(
+        video_score.abs().sum(), torch.tensor(100.87259), rtol=1e-3, atol=1e-3
+    )
+
+
+def test_omnivore_swin_s_forward(omnivore_swin_s_model):
+    model = omnivore_swin_s_model
+
+    image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
+    image_score = model(image, input_type="image")
+
+    assert_expected(image_score.size(), torch.Size((1, 1000)))
+    assert_expected(
+        image_score.abs().sum(), torch.tensor(240.41123), rtol=1e-3, atol=1e-3
+    )
+
+    rgbd = torch.randn(1, 4, 1, 112, 112)
+    rgbd_score = model(rgbd, input_type="rgbd")
+    assert_expected(rgbd_score.size(), torch.Size((1, 19)))
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(5.73624), rtol=1e-3, atol=1e-3)
+
+    video = torch.randn(1, 3, 4, 112, 112)
+    video_score = model(video, input_type="video")
+    assert_expected(video_score.size(), torch.Size((1, 400)))
+    assert_expected(
+        video_score.abs().sum(), torch.tensor(100.75939), rtol=1e-3, atol=1e-3
+    )
+
+
+def test_omnivore_swin_b_forward(omnivore_swin_b_model):
+    model = omnivore_swin_b_model
+
+    image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
+    image_score = model(image, input_type="image")
+
+    assert_expected(image_score.size(), torch.Size((1, 1000)))
+    assert_expected(
+        image_score.abs().sum(), torch.tensor(293.43484), rtol=1e-3, atol=1e-3
+    )
+
+    rgbd = torch.randn(1, 4, 1, 112, 112)
+    rgbd_score = model(rgbd, input_type="rgbd")
+    assert_expected(rgbd_score.size(), torch.Size((1, 19)))
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(6.76342), rtol=1e-3, atol=1e-3)
+
+    video = torch.randn(1, 3, 4, 112, 112)
+    video_score = model(video, input_type="video")
+    assert_expected(video_score.size(), torch.Size((1, 400)))
+    assert_expected(
+        video_score.abs().sum(), torch.tensor(131.65342), rtol=1e-3, atol=1e-3
+    )
+
+
+def test_omnivore_forward_wrong_input_type(omnivore_swin_t_model):
+    model = omnivore_swin_t_model
+
+    image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
+    with pytest.raises(AssertionError, match="Unsupported input_type: _WRONG_TYPE_.+"):
+        _ = model(image, input_type="_WRONG_TYPE_")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,10 +9,10 @@ import random
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import torch
 import torch.distributed as dist
-from torch import Tensor
 
 
 def gpu_test(gpu_count: int = 1):
@@ -71,9 +71,7 @@ def get_asset_path(file_name: str) -> str:
     return str(_ASSET_DIR.joinpath(file_name))
 
 
-def assert_expected(
-    actual: Tensor, expected: Tensor, rtol: float = None, atol: float = None
-):
+def assert_expected(actual: Any, expected: Any, rtol: float = None, atol: float = None):
     torch.testing.assert_close(
         actual,
         expected,

--- a/test/utils/test_common.py
+++ b/test/utils/test_common.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import pytest
 
 import pytest
 

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -133,6 +133,21 @@ def transpose_for_scores(
     return x.permute(0, 2, 1, 3)
 
 
+def load_module_from_url(
+    model: torch.nn.Module, url: str, progress: bool = True
+) -> None:
+    model_dir = os.path.join(
+        torch.hub.get_dir(),
+        "multimodal",
+        hashlib.sha256(url.encode("utf-8")).hexdigest(),
+    )
+
+    state_dict = torch.hub.load_state_dict_from_url(
+        url, model_dir=model_dir, progress=progress
+    )
+    model.load_state_dict(state_dict)
+
+
 @torch.no_grad()
 def remove_grad(model: nn.Module) -> None:
     for param in model.parameters():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148
* #134
* #147
* #133
* __->__ #154

Summary:
Adding new variant: swin_s and swin_b with pretrained weight for omnivore.

Test Plan:
Create a test for each variant, also I change the test to use pytest instead of unittest.

Usage:
Here are example script to get the pretrained weight:
```
import torchmultimodal.models.omnivore as omnivore

model = omnivore.omnivore_swin_s(pretrained=True)
```

Reviewed By: langong347

Differential Revision: D37834886

Pulled By: YosuaMichael

fbshipit-source-id: 8a80d6c9d399eb22c87f43cca76bd2be73013774

[MUGEN]Spatialtemporal position embedding;tensor slicing utility