### PR TITLE
[Unification] Move masks out of attention modules and return attn probs

### DIFF
--- a/test/modules/layers/test_attention.py
+++ b/test/modules/layers/test_attention.py
@@ -55,7 +55,7 @@ def kv(input_shape, hidden_dim):
 
 @pytest.fixture
 def full_attn(input_shape):
-    return FullAttention(input_shape, causal=False, attn_dropout=0.0)
+    return FullAttention(attn_dropout=0.0)
 
 
 @pytest.fixture
@@ -204,7 +204,7 @@ class TestMultiheadAttention:
 
 
 def test_scaled_dot_product_attention(q, kv):
-    actual = scaled_dot_product_attention(q, kv, kv)
+    actual, _ = scaled_dot_product_attention(q, kv, kv)
     expected = torch.tensor(
         [
             [
@@ -269,20 +269,18 @@ def test_axial_attention(axial_attn, q, kv):
     )
     assert_expected(actual, expected, rtol=0, atol=1e-4)
     
-def test_split_multihead(self):
-    x = torch.randn(1, *self.input_shape, 6)
-    n_head = 2
-    out = split_multihead(x, n_head)
+def test_split_multihead(input_shape):
+    x = torch.randn(1, *input_shape, 6)  # (b, d1, ..., dn, c)
+    out = split_multihead(x, 2)
     actual = torch.tensor(out.shape)
-    expected = torch.tensor((1, 2, *self.input_shape, 3))
+    expected = torch.tensor((1, 2, *input_shape, 3))  # (b, h, d1, ..., dn, c // h)
     assert_expected(actual, expected)
 
-def test_merge_multihead(self):
-    out = merge_multihead(self.q)
+def test_merge_multihead(input_shape, hidden_dim, q):
+    out = merge_multihead(q)
     actual = torch.tensor(out.shape)
-    expected = torch.tensor((1, *self.input_shape, self.hidden_dim))
+    expected = torch.tensor((1, *input_shape, hidden_dim))
     assert_expected(actual, expected)
-
 
 class TestAxialBlock:
     @pytest.fixture

--- a/torchmultimodal/modules/layers/attention.py
+++ b/torchmultimodal/modules/layers/attention.py
@@ -180,8 +180,6 @@ class MultiHeadAttention(nn.Module):
         return a
 
 
-# TODO: retire causal once mask generation is moved out of FullAttention
-#   causal inside FullAttention does not affect caching of k, v
 class FullAttention(nn.Module):
     """Computes attention over the entire n-dimensional input.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172
* #170
* #169
* #168
* __->__ #162
* #152
* #151

## Summary
Small diffs building up to a unified `SelfAttention` class used across all models by generalizing one piece at a time.

This diff moves decoding masks out of attention modules into a user specified argument. We can then simplify the `FullAttention` API. This diff also updates attention modules to return the attention probabilities as well. The [original PR](https://github.com/facebookresearch/multimodal/pull/167) got squashed with this while running rebase.

## Test plan
`pytest test -vv`
`pytest examples -vv`

Differential Revision: [D37938513](https://our.internmc.facebook.com/intern/diff/D37938513)