### PR TITLE
Fix package exclusion in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ LONG_DESCRIPTION_CONTENT_TYPE = "text/markdown"
 AUTHOR = "PyTorch Multimodal"
 AUTHOR_EMAIL = "kartikayk@fb.com"
 # Need to exclude folders in test as well so as they don't create an extra package
-EXCLUDES = ("examples", "test")
+EXCLUDES = ("examples*", "test*")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Fix the issue with examples and tests getting packaged

Test plan:
python setup.py bdist_wheel
unzip torchmultimodal/dist/*.whl => checked no examples or tests existed after unzip

