### PR TITLE
Move LateFusion, TwoTower from architectures to models

### DIFF
--- a/examples/cnn_lstm/cnn_lstm.py
+++ b/examples/cnn_lstm/cnn_lstm.py
@@ -10,7 +10,7 @@ from examples.cnn_lstm.cnn_encoder import CNNEncoder
 from examples.cnn_lstm.lstm_encoder import LSTMEncoder
 
 from torch import nn
-from torchmultimodal.architectures.late_fusion import LateFusionArchitecture
+from torchmultimodal.models.late_fusion import LateFusion
 from torchmultimodal.modules.fusions.concat_fusion import ConcatFusionModule
 from torchmultimodal.modules.layers.mlp import MLP
 
@@ -35,7 +35,7 @@ def cnn_lstm_classifier(
     # parameters for the classifier
     classifier_in_dim: int = 450,
     num_classes: int = 2,
-) -> LateFusionArchitecture:
+) -> LateFusion:
     """
     A simple example to show the composability in TorchMultimodal, and how to
     make use of builder functions to build a given model from an
@@ -43,11 +43,11 @@ def cnn_lstm_classifier(
     building the individual layers and simplifies the interface for the
     architecture. In this example, we are explicitly working with the "text"
     and "image" modalities. This is reflected in the ModuleDict passed to the
-    LateFusionArchitecture's init function. Note that these keys should match up
+    LateFusion's init function. Note that these keys should match up
     with the input of the forward function, which will raise an error in case there's
     a mismatch.
 
-    We use the LateFusionArchitecture to build a multimodal classifier
+    We use the LateFusion to build a multimodal classifier
     which uses a CNN to encode images, an LSTM to encode text and a
     simple MLP as a classifier. The output is raw scores.
 
@@ -98,7 +98,7 @@ def cnn_lstm_classifier(
 
     # The use of builder functions allows us to keep the architecture
     # interfaces clean and intuitive
-    return LateFusionArchitecture(
+    return LateFusion(
         encoders=nn.ModuleDict({"image": image_encoder, "text": text_encoder}),
         fusion_module=fusion_module,
         head_module=classifier,

--- a/test/architectures/test_late_fusion.py
+++ b/test/architectures/test_late_fusion.py
@@ -8,7 +8,7 @@ import unittest
 
 import torch
 from test.test_utils import assert_expected
-from torchmultimodal.architectures.late_fusion import LateFusionArchitecture
+from torchmultimodal.models.late_fusion import LateFusion
 from torchmultimodal.modules.fusions.concat_fusion import ConcatFusionModule
 
 
@@ -19,7 +19,7 @@ class TestLateFusion(unittest.TestCase):
         )
         self.fusion_module = ConcatFusionModule()
         self.head_module = torch.nn.Identity()
-        self.late_fusion = LateFusionArchitecture(
+        self.late_fusion = LateFusion(
             self.encoders,
             self.fusion_module,
             self.head_module,

--- a/test/architectures/test_two_tower.py
+++ b/test/architectures/test_two_tower.py
@@ -9,8 +9,8 @@ from typing import List
 
 import torch
 from torch import nn, Tensor
-from torchmultimodal.architectures.late_fusion import LateFusionArchitecture
-from torchmultimodal.architectures.two_tower import TwoTower
+from torchmultimodal.models.late_fusion import LateFusion
+from torchmultimodal.models.two_tower import TwoTower
 from torchmultimodal.modules.fusions.concat_fusion import ConcatFusionModule
 
 
@@ -21,12 +21,12 @@ class Concat(nn.Module):
 
 class TestTwoTower(unittest.TestCase):
     def setUp(self):
-        self.tower_1 = LateFusionArchitecture(
+        self.tower_1 = LateFusion(
             {"c1": nn.Identity(), "c2": nn.Identity()},
             ConcatFusionModule(),
             nn.Identity(),
         )
-        self.tower_2 = LateFusionArchitecture(
+        self.tower_2 = LateFusion(
             {"c3": nn.Identity(), "c4": nn.Identity()},
             ConcatFusionModule(),
             nn.Identity(),

--- a/torchmultimodal/models/late_fusion.py
+++ b/torchmultimodal/models/late_fusion.py
@@ -10,7 +10,7 @@ import torch
 from torch import nn
 
 
-class LateFusionArchitecture(nn.Module):
+class LateFusion(nn.Module):
     """A generic architecture for late fusion multimodal models.
 
     A late fusion model contains separate encoders for each modality,

--- a/torchmultimodal/models/two_tower.py
+++ b/torchmultimodal/models/two_tower.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from typing import Dict, List, NamedTuple, Optional
 
 from torch import nn, Tensor
-from torchmultimodal.architectures.late_fusion import LateFusionArchitecture
+from torchmultimodal.models.late_fusion import LateFusion
 
 
 class TwoTowerOutput(NamedTuple):
@@ -21,7 +21,7 @@ class TwoTower(nn.Module):
     A two tower architecture with a pair of late fusion models
     (for now, can be extended) followed by a fusion for output of each tower.
     Args:
-        tower_id_to_tower (Dict[str, LateFusionArchitecture]): mapping of tower id
+        tower_id_to_tower (Dict[str, LateFusion]): mapping of tower id
         to tower model. Size should be 2, same tower should be passed in
         for shared towers
         tower fusion (nn.Module): Module fusing list of tensors (tower outputs)
@@ -35,7 +35,7 @@ class TwoTower(nn.Module):
 
     def __init__(
         self,
-        tower_id_to_tower: Dict[str, LateFusionArchitecture],
+        tower_id_to_tower: Dict[str, LateFusion],
         tower_fusion: nn.Module,
         shared_tower_id_to_channel_mapping: Optional[Dict[str, Dict[str, str]]] = None,
     ):


### PR DESCRIPTION
Summary: Torchmultimodal is moving away from the "architectures" concept. As a result, all models in the `torchmultimodal/architectures/` folder have been moved to `torchmultimodal/models/`. Two of the models, LateFusion and TwoTower, have internal dependencies and could not be moved via OSS PR. This diff performs this move and refactors the appropriate dependencies.

Reviewed By: ankitade

Differential Revision: D37891704

