### PR TITLE
[FLAVA] Add notebook that remaps checkpoint

### DIFF
--- a/examples/flava/notebooks/RemapFLAVACheckpoint.ipynb
+++ b/examples/flava/notebooks/RemapFLAVACheckpoint.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7bba54ed",
+   "id": "7cc982d1",
    "metadata": {},
    "source": [
     "# Re-map FLAVA checkpoint\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "766cfb62",
+   "id": "411e4191",
    "metadata": {},
    "source": [
     "### Load original model\n",
@@ -24,8 +24,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "089eb63b",
+   "execution_count": 3,
+   "id": "88ee917b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5014210",
+   "id": "5f00b369",
    "metadata": {},
    "source": [
     "### Print summary"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97c18aa6",
+   "id": "cc286394",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23d845e8",
+   "id": "0d774455",
    "metadata": {},
    "source": [
     "### Mapping function\n",
@@ -65,8 +65,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3d9183d5",
+   "execution_count": 4,
+   "id": "cc9e4537",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae1ee7d1",
+   "id": "29870590",
    "metadata": {},
    "source": [
     "### Load checkpoint\n",
@@ -97,8 +97,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "64ca8c27",
+   "execution_count": 5,
+   "id": "41f64d26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58bfb326",
+   "id": "75322113",
    "metadata": {},
    "source": [
     "### Perform re-mapping"
@@ -118,8 +118,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "14b831fb",
+   "execution_count": 6,
+   "id": "17363ae8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,10 +128,21 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65dd78d8",
+   "id": "d94c4133",
    "metadata": {},
    "source": [
     "### Save updated checkpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bc6baad9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_path = '/Users/rafiayub/flava.bin'\n",
+    "torch.save(new_state_dict, save_path)"
    ]
   }
  ],

--- a/examples/flava/notebooks/RemapFLAVACheckpoint.ipynb
+++ b/examples/flava/notebooks/RemapFLAVACheckpoint.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7bba54ed",
+   "metadata": {},
+   "source": [
+    "# Re-map FLAVA checkpoint\n",
+    "\n",
+    "Generalizing FLAVA components with the rest of the codebase can cause existing model checkpoints to go out of sync with the updated architecture. This notebook shows how to load the existing checkpoint, re-map the old layers to the new layers, and save the new checkpoint.\n",
+    "\n",
+    "If you wish to save a new checkpoint, you must have access to the PyTorch AWS S3 account."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "766cfb62",
+   "metadata": {},
+   "source": [
+    "### Load original model\n",
+    "\n",
+    "Load the existing checkpoint into the FLAVA class to see what the architecture currently is."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "089eb63b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torchmultimodal.models.flava.flava_model import flava_model_for_classification, flava_model_for_pretraining\n",
+    "\n",
+    "flava_classification = flava_model_for_classification(num_classes=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5014210",
+   "metadata": {},
+   "source": [
+    "### Print summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97c18aa6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flava_classification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23d845e8",
+   "metadata": {},
+   "source": [
+    "### Mapping function\n",
+    "\n",
+    "Replace this function with the code needed to map the old layer weights to the new layer weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d9183d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "def map_state_dict(state_dict):\n",
+    "    mapped_state_dict = {}\n",
+    "    for param, val in state_dict.items():\n",
+    "        res = re.search('attention.attention', param)\n",
+    "        if res:\n",
+    "            idx = res.start()\n",
+    "            new_param = param[:idx] + param[idx+10:]\n",
+    "        else:\n",
+    "            new_param = param\n",
+    "        mapped_state_dict[new_param] = val\n",
+    "    return mapped_state_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae1ee7d1",
+   "metadata": {},
+   "source": [
+    "### Load checkpoint\n",
+    "\n",
+    "One more time except don't load into the FLAVA class, keep it as `state_dict`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64ca8c27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Replace this path if it changes\n",
+    "old_model_url = 'https://huggingface.co/aps/flava_full_pretrained_encoders_torchmm/resolve/main/pytorch_model.bin'\n",
+    "\n",
+    "old_state_dict = torch.hub.load_state_dict_from_url(old_model_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58bfb326",
+   "metadata": {},
+   "source": [
+    "### Perform re-mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14b831fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_state_dict = map_state_dict(old_state_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65dd78d8",
+   "metadata": {},
+   "source": [
+    "### Save updated checkpoint"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Summary:
As more components of FLAVA are unified/generalized with the other models, the checkpoint will fall out of sync and will no longer be able to load. Here, I upload a notebook that lets you quickly write a mapping function to remap the state_dict of the old checkpoint to the new architecture and executes it. I've added it to examples since I will likely run this notebook more times as unification proceeds.

Colab link: https://colab.research.google.com/drive/1j9Hl6uroFx2Ud642jfhQjFEFlo9uKrOi?usp=sharing

Test plan:
None, this does not overwrite the existing checkpoint. The updated FLAVA checkpoint link is reflected in #168 