### PR TITLE
[FLAVA] Add flava_model checkpoint and use in zero shot script

### DIFF
--- a/examples/flava/coco_zero_shot.py
+++ b/examples/flava/coco_zero_shot.py
@@ -14,7 +14,7 @@ from flava.data.transforms import (
 )
 from torch import nn
 from torch.utils.data import DataLoader
-from torchmultimodal.models.flava.flava_model import flava_model_for_pretraining
+from torchmultimodal.models.flava.flava_model import flava_model
 from torchvision.datasets import CocoCaptions
 
 logging.basicConfig(level=logging.INFO)
@@ -61,8 +61,7 @@ def main():
     dataset = CocoCaptions(
         root=args.data_root, annFile=args.annotations, transforms=transform
     )
-    # TODO: Replace with flava_model when it supports loading from ckpt
-    flava = flava_model_for_pretraining(pretrained_model_key="flava_full")
+    flava = flava_model(pretrained_model_key="flava_full")
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     logger.info(f"Using device: {device}")
     flava = flava.to(device)

--- a/examples/flava/coco_zero_shot.py
+++ b/examples/flava/coco_zero_shot.py
@@ -73,8 +73,8 @@ def main():
     for batch_idx, batch in enumerate(dataloader):
         logger.info(f"Batch id {batch_idx}")
         image, text = batch
-        text_emb = flava.encode_text(text.to(device))
-        image_emb = flava.encode_image(image.to(device))
+        _, text_emb = flava.encode_text(text.to(device), projection=True)
+        _, image_emb = flava.encode_image(image.to(device), projection=True)
         text_embeds.append(text_emb.detach().cpu())
         image_embeds.append(image_emb.detach().cpu())
 

--- a/examples/flava/notebooks/RemapFLAVACheckpoint.ipynb
+++ b/examples/flava/notebooks/RemapFLAVACheckpoint.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# Re-map FLAVA checkpoint\n",
     "\n",
-    "Generalizing FLAVA components with the rest of the codebase can cause existing model checkpoints to go out of sync with the updated architecture. This notebook shows how to load the existing checkpoint, re-map the old layers to the new layers, and save the new checkpoint.\n",
+    "Modifying FLAVA's components can cause existing model checkpoints to go out of sync with the updated architecture. This notebook shows how to load the existing checkpoint, re-map the old layers to the new layers, and save the new checkpoint.\n",
     "\n",
-    "If you wish to save a new checkpoint, you must have access to the PyTorch AWS S3 account."
+    "To upload a new checkpoint, you must have access to the PyTorch AWS S3 account, and manually upload it from a local copy."
    ]
   },
   {
@@ -32,7 +32,8 @@
     "import torch\n",
     "from torchmultimodal.models.flava.flava_model import flava_model_for_classification, flava_model_for_pretraining\n",
     "\n",
-    "flava_classification = flava_model_for_classification(num_classes=3)"
+    "# flava_classification = flava_model_for_classification(num_classes=3)\n",
+    "flava_pretraining = flava_model_for_pretraining(pretrained_model_key='flava_full')"
    ]
   },
   {
@@ -50,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flava_classification"
+    "flava_pretraining"
    ]
   },
   {
@@ -90,9 +91,7 @@
    "id": "29870590",
    "metadata": {},
    "source": [
-    "### Load checkpoint\n",
-    "\n",
-    "One more time except don't load into the FLAVA class, keep it as `state_dict`"
+    "### Load old state dict"
    ]
   },
   {
@@ -102,10 +101,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Replace this path if it changes\n",
-    "old_model_url = 'https://huggingface.co/aps/flava_full_pretrained_encoders_torchmm/resolve/main/pytorch_model.bin'\n",
+    "# Load from url, replace this path if it changes\n",
+    "# old_model_url = 'https://download.pytorch.org/models/multimodal/flava/flava_model.pt'\n",
+    "# old_state_dict = torch.hub.load_state_dict_from_url(old_model_url)\n",
     "\n",
-    "old_state_dict = torch.hub.load_state_dict_from_url(old_model_url)"
+    "# Or get from loaded model\n",
+    "old_state_dict = flava_pretraining.model.state_dict()"
    ]
   },
   {
@@ -123,7 +124,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_state_dict = map_state_dict(old_state_dict)"
+    "#new_state_dict = map_state_dict(old_state_dict)\n",
+    "new_state_dict = old_state_dict"
    ]
   },
   {
@@ -141,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "save_path = '/Users/rafiayub/flava.bin'\n",
+    "save_path = '/Users/rafiayub/flava_model.pt'\n",
     "torch.save(new_state_dict, save_path)"
    ]
   }

--- a/examples/flava/requirements.txt
+++ b/examples/flava/requirements.txt
@@ -6,3 +6,4 @@ DALL-E==0.1
 omegaconf==2.1.2
 hydra-core==1.1.2
 transformers==4.16.0
+pycocotools==2.0.4

--- a/test/models/flava/test_flava_checkpoint.py
+++ b/test/models/flava/test_flava_checkpoint.py
@@ -159,13 +159,13 @@ class TestFLAVACheckpoint:
         output = model(*inputs_model, skip_unmasked_mm_encoder=False)
 
         actual = torch.sum(output.image.last_hidden_state)
-        expected = torch.tensor(-1316.753173828125)
-        assert_expected(actual, expected, rtol=0, atol=1e-4)
+        expected = torch.tensor(-1316.7531)
+        assert_expected(actual, expected, rtol=0, atol=1e-3)
 
         actual = torch.sum(output.text.last_hidden_state)
-        expected = torch.tensor(-240.57443237304688)
-        assert_expected(actual, expected, rtol=0, atol=1e-4)
+        expected = torch.tensor(-240.5744)
+        assert_expected(actual, expected, rtol=0, atol=1e-3)
 
         actual = torch.sum(output.multimodal.last_hidden_state)
-        expected = torch.tensor(-4367.087890625)
-        assert_expected(actual, expected, rtol=0, atol=1e-4)
+        expected = torch.tensor(-4367.0878)
+        assert_expected(actual, expected, rtol=0, atol=1e-3)

--- a/test/models/flava/test_flava_checkpoint.py
+++ b/test/models/flava/test_flava_checkpoint.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from test.test_utils import assert_expected, set_rng_seed
 from torchmultimodal.models.flava.flava_model import (
+    flava_model,
     flava_model_for_classification,
     flava_model_for_pretraining,
 )
@@ -64,6 +65,10 @@ class TestFLAVACheckpoint:
         return gather_inputs
 
     @pytest.fixture
+    def inputs_model(self, image_input, text_input):
+        return image_input, text_input
+
+    @pytest.fixture
     def classification_model(self):
         return flava_model_for_classification(
             num_classes=3, pretrained_model_key="flava_full"
@@ -72,6 +77,10 @@ class TestFLAVACheckpoint:
     @pytest.fixture
     def pretraining_model(self):
         return flava_model_for_pretraining(pretrained_model_key="flava_full")
+
+    @pytest.fixture
+    def model(self):
+        return flava_model(pretrained_model_key="flava_full")
 
     def _assert_tensor_dicts_equal(self, dict_actual, dict_expected):
         for key in dict_expected:
@@ -145,3 +154,18 @@ class TestFLAVACheckpoint:
             global_contrastive_loss=None,
         )
         self._assert_tensor_dicts_equal(actual, expected)
+
+    def test_flava_model(self, model, inputs_model):
+        output = model(*inputs_model, skip_unmasked_mm_encoder=False)
+
+        actual = torch.sum(output.image.last_hidden_state)
+        expected = torch.tensor(-1316.753173828125)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+        actual = torch.sum(output.text.last_hidden_state)
+        expected = torch.tensor(-240.57443237304688)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+        actual = torch.sum(output.multimodal.last_hidden_state)
+        expected = torch.tensor(-4367.087890625)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)

--- a/torchmultimodal/models/flava/flava_model.py
+++ b/torchmultimodal/models/flava/flava_model.py
@@ -65,6 +65,10 @@ FLAVA_FOR_PRETRAINED_MAPPING = {
     "flava_full": "https://download.pytorch.org/models/multimodal/flava/flava_for_pretraining_unified.pt",
 }
 
+FLAVA_MODEL_MAPPING = {
+    "flava_full": "https://download.pytorch.org/models/multimodal/flava/flava_model.pt",
+}
+
 
 def flava_multimodal_encoder(
     hidden_size: int = 768,
@@ -452,6 +456,7 @@ def flava_model(
     multimodal_layer_norm_eps: float = 1e-12,
     # projection
     text_and_image_proj_size: int = 768,
+    pretrained_model_key: Optional[str] = None,
     **kwargs: Any,
 ) -> FLAVAModel:
     image_encoder = flava_image_encoder(
@@ -468,7 +473,6 @@ def flava_model(
         patch_size=patch_size,
         num_channels=num_channels,
     )
-
     text_encoder = flava_text_encoder(
         hidden_size=text_hidden_size,
         num_attention_heads=text_num_attention_heads,
@@ -500,7 +504,7 @@ def flava_model(
     image_projection = nn.Linear(image_hidden_size, text_and_image_proj_size)
     text_projection = nn.Linear(text_hidden_size, text_and_image_proj_size)
 
-    return FLAVAModel(
+    flava = FLAVAModel(
         image_encoder=image_encoder,
         text_encoder=text_encoder,
         mm_encoder=mm_encoder,
@@ -509,6 +513,11 @@ def flava_model(
         text_projection=text_projection,
         image_projection=image_projection,
     )
+
+    if pretrained_model_key is not None:
+        flava.load_model(FLAVA_MODEL_MAPPING[pretrained_model_key])
+
+    return flava
 
 
 def flava_model_for_pretraining(

--- a/torchmultimodal/models/flava/flava_model.py
+++ b/torchmultimodal/models/flava/flava_model.py
@@ -66,7 +66,7 @@ FLAVA_FOR_PRETRAINED_MAPPING = {
 }
 
 FLAVA_MODEL_MAPPING = {
-    "flava_full": "https://download.pytorch.org/models/multimodal/flava/flava_model.pt",
+    "flava_full": "https://download.pytorch.org/models/multimodal/flava/flava_model_unified.pt",
 }
 
 


### PR DESCRIPTION
Merge after #221 

Summary:
- Saved checkpoint from `FLAVAForPreTraining.model` for `flava_model` and uploaded to S3
- Added `pretrained_model_key` to `flava_model` to load the checkpoint. Default is None.
- Replaced `flava_model_for_pretraining` with `flava_model` in COCO zero-shot eval script
- Added new checkpoint test for `flava_model`
- Minor cosmetic updates to checkpoint remap notebook

Test plan:
`pytest test/models/flava/test_flava_checkpoint.py -vv`
```
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.9.12, pytest-7.1.1, pluggy-1.0.0 -- /fsx/users/rafiayub/conda/envs/torchmm/bin/python
cachedir: .pytest_cache
rootdir: /data/home/rafiayub/torchmultimodal, configfile: pyproject.toml
plugins: cov-3.0.0, mock-3.8.2
collected 3 items                                                                                                                                                                                   

test/models/flava/test_flava_checkpoint.py::TestFLAVACheckpoint::test_flava_model_for_classification PASSED                                                                                   [ 33%]
test/models/flava/test_flava_checkpoint.py::TestFLAVACheckpoint::test_flava_model_for_pretraining PASSED                                                                                      [ 66%]
test/models/flava/test_flava_checkpoint.py::TestFLAVACheckpoint::test_flava_model PASSED    
```
`pytest test/models/flava/test_flava.py -vv`
```
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.9.12, pytest-7.1.1, pluggy-1.0.0 -- /fsx/users/rafiayub/conda/envs/torchmm/bin/python
cachedir: .pytest_cache
rootdir: /data/home/rafiayub/torchmultimodal, configfile: pyproject.toml
plugins: cov-3.0.0, mock-3.8.2
collected 8 items                                                                                                                                                                                   

test/models/flava/test_flava.py::TestFLAVA::test_forward_classification PASSED                                                                                                                [ 12%]
test/models/flava/test_flava.py::TestFLAVA::test_forward_pretraining PASSED                                                                                                                   [ 25%]
test/models/flava/test_flava.py::TestFLAVAModel::test_forward_image PASSED                                                                                                                    [ 37%]
test/models/flava/test_flava.py::TestFLAVAModel::test_forward_image_text PASSED                                                                                                               [ 50%]
test/models/flava/test_flava.py::TestFLAVAModel::test_forward_masked_image PASSED                                                                                                             [ 62%]
test/models/flava/test_flava.py::TestFLAVAModel::test_forward_masked_image_and_text PASSED                                                                                                    [ 75%]
test/models/flava/test_flava.py::TestFLAVAModel::test_forward_masked_text PASSED                                                                                                              [ 87%]
test/models/flava/test_flava.py::TestFLAVAModel::test_forward_text PASSED                                                                                                                     [100%]

======================================================================================== 8 passed in 17.73s =========================================================================================
```
`python -m flava.coco_zero_shot --data_root /datasets01/COCO/022719/val2017 --annotations /datasets01/COCO/022719/annotations/captions_val2017.json`
```
INFO:root:image_to_text_recall@1 0.39660000801086426
INFO:root:image_to_text_recall@5 0.7110000252723694
INFO:root:text_to_image_recall@1 0.3959999978542328
INFO:root:text_to_image_recall@5 0.6958000063896179
```