### PR TITLE
Add changelog for MUGEN dataset

### DIFF
--- a/examples/mugen/data/CHANGELOG.md
+++ b/examples/mugen/data/CHANGELOG.md
@@ -5,11 +5,11 @@ The format of this document is based on [Keep a Changelog](http://keepachangelog
 ## [Unreleased] - 2022-07-26
 
 Changes are noted with respect to the [original MUGEN dataset API](https://github.com/mugen-org/MUGEN_baseline/tree/main/lib/data).
- 
+
 ### Added
-- Added `README.md` instructions on how to download assets. 
+- Added `README.md` instructions on how to download assets.
 - Added optional data transform arguments to data module.
- 
+
 ### Changed
 - Replaced command-line arguments with `MUGENDatasetArgs` and direct arguments to `MugenDataModule`.
 - Renamed `data.py` --> `mugen_datamodules.py` and renamed `VideoData` class to `MUGENDataModule`.

--- a/examples/mugen/data/CHANGELOG.md
+++ b/examples/mugen/data/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+
+The format of this document is based on [Keep a Changelog](http://keepachangelog.com/).
+
+## [Unreleased] - 2022-07-26
+
+Changes are noted with respect to the [original MUGEN dataset API](https://github.com/mugen-org/MUGEN_baseline/tree/main/lib/data).
+ 
+### Added
+- Added `README.md` instructions on how to download assets. 
+- Added optional data transform arguments to data module.
+ 
+### Changed
+- Replaced command-line arguments with `MUGENDatasetArgs` and direct arguments to `MugenDataModule`.
+- Renamed `data.py` --> `mugen_datamodules.py` and renamed `VideoData` class to `MUGENDataModule`.
+- Renamed `mugen_data.py` --> `mugen_dataset.py`.
+- Replaced dependencies on OpenAI's `jukebox` and MUGEN's `audio_vqvae` by placing relevant functionality in `audio_utils.py`.
+
+### Removed
+- Removed `data/coinrun/assets` folder.


### PR DESCRIPTION
Summary:
Add formal documentation for changes to MUGEN dataset code compared to original researchers' code. Changes are based on [PR #186](https://github.com/facebookresearch/multimodal/pull/186).
