### PR TITLE
VideoCLIP training script

### DIFF
--- a/examples/mugen/retrieval/configs/eval.yaml
+++ b/examples/mugen/retrieval/configs/eval.yaml
@@ -7,7 +7,7 @@ dataset_args:
   sequence_length: 32
   audio_sample_rate: 22050
   audio_sample_length: 70560
-  resolution: 224
+  resolution: 256
   bbox_smap_for_agent: False
   bbox_smap_for_monsters: False
   use_manual_annotation: True

--- a/examples/mugen/retrieval/configs/train.yaml
+++ b/examples/mugen/retrieval/configs/train.yaml
@@ -47,6 +47,7 @@ videoclip_args:
   proj_out_dim: 256
   proj_dropout: 0.1
 accelerator: "auto"
-max_epochs: 10
+devices: 4
+max_epochs: 20
 log_every_n_steps: 100
 default_root_dir: null

--- a/examples/mugen/retrieval/configs/train.yaml
+++ b/examples/mugen/retrieval/configs/train.yaml
@@ -1,0 +1,52 @@
+_target_: examples.mugen.retrieval.definitions.TrainingArgs
+dataset_args:
+  _target_: examples.mugen.data.mugen_dataset.MUGENDatasetArgs
+  data_path: "datasets/coinrun/coinrun_dataset_jsons/release"
+  asset_path: "datasets/coinrun/assets"
+  sample_every_n_frames: 3
+  sequence_length: 32
+  audio_sample_rate: 22050
+  audio_sample_length: 70560
+  resolution: 224
+  bbox_smap_for_agent: False
+  bbox_smap_for_monsters: False
+  use_manual_annotation: True
+  use_auto_annotation: False
+  use_downsampled_trainset: False
+  fixed_start_idx: False
+  get_game_frame: True
+  get_seg_map: False
+  get_text_desc: True
+  get_audio: False
+  debug: False
+datamodule_args:
+  _target_: examples.mugen.retrieval.definitions.DataModuleArgs
+  batch_size: 16
+  num_workers: 4
+  shuffle: False
+  bert_text_transform:
+    _target_: examples.mugen.retrieval.definitions.BertTextTransformArgs
+  video_transform:
+    _target_: examples.mugen.retrieval.definitions.VideoTransformArgs
+lightningmodule_args:
+  _target_: examples.mugen.retrieval.definitions.LightningModuleArgs
+  logit_scale: 0.07
+  logit_scale_max: 100.0
+  learning_rate: 0.001
+  weight_decay: 0.001
+videoclip_args:
+  _target_: examples.mugen.retrieval.definitions.VideoCLIPArgs
+  text_pretrained: True
+  text_trainable: False
+  text_model_name: "distilbert-base-uncased"
+  text_model_config: null
+  text_padding_value: 0
+  video_pretrained: True
+  video_trainable: True
+  video_pretrain_path: "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/S3D_kinetics400.pt"
+  proj_out_dim: 256
+  proj_dropout: 0.1
+accelerator: "auto"
+max_epochs: 10
+log_every_n_steps: 100
+default_root_dir: null

--- a/examples/mugen/retrieval/definitions.py
+++ b/examples/mugen/retrieval/definitions.py
@@ -47,6 +47,9 @@ class DataModuleArgs:
 class LightningModuleArgs:
     logit_scale: float = 0.07
     logit_scale_max: float = 100.0
+    learning_rate: float = 1e-3
+    weight_decay: float = 1e-3
+    recall_ks: Tuple[int] = (1, 5, 10)
 
 
 @dataclass
@@ -70,7 +73,7 @@ class EvaluationArgs:
     dataset_args: MUGENDatasetArgs = MUGENDatasetArgs(
         get_game_frame=True,
         get_text_desc=True,
-        resolution=224,
+        resolution=256,
         fixed_start_idx=False,
         use_manual_annotation=True,
         use_auto_annotation=False,
@@ -80,3 +83,22 @@ class EvaluationArgs:
     videoclip_args: VideoCLIPArgs = VideoCLIPArgs()
     checkpoint_path: str = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/videoclip_lightning_mugen.pt"
     accelerator: str = "auto"
+
+
+@dataclass
+class TrainingArgs:
+    dataset_args: MUGENDatasetArgs = MUGENDatasetArgs(
+        get_game_frame=True,
+        get_text_desc=True,
+        resolution=224,
+        fixed_start_idx=False,
+        use_manual_annotation=True,
+        use_auto_annotation=False,
+    )
+    datamodule_args: DataModuleArgs = DataModuleArgs()
+    lightningmodule_args: LightningModuleArgs = LightningModuleArgs()
+    videoclip_args: VideoCLIPArgs = VideoCLIPArgs()
+    accelerator: str = "auto"
+    max_epochs: int = 1000
+    log_every_n_steps: int = 100
+    default_root_dir: Optional[str] = None

--- a/examples/mugen/retrieval/definitions.py
+++ b/examples/mugen/retrieval/definitions.py
@@ -99,6 +99,7 @@ class TrainingArgs:
     lightningmodule_args: LightningModuleArgs = LightningModuleArgs()
     videoclip_args: VideoCLIPArgs = VideoCLIPArgs()
     accelerator: str = "auto"
+    devices: int = 4
     max_epochs: int = 1000
     log_every_n_steps: int = 100
     default_root_dir: Optional[str] = None

--- a/examples/mugen/retrieval/train.py
+++ b/examples/mugen/retrieval/train.py
@@ -10,6 +10,7 @@ from examples.mugen.retrieval.model import VideoCLIPLightningModule
 from hydra.utils import instantiate
 from omegaconf import OmegaConf
 from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks import ModelCheckpoint
 from torchmultimodal.transforms.bert_text_transform import BertTextTransform
 from torchmultimodal.transforms.video_transform import VideoTransform
 
@@ -45,6 +46,7 @@ def train():
         **vars(args.videoclip_args),
     )
 
+    checkpoint_callback = ModelCheckpoint(save_top_k=-1)
     trainer = Trainer(
         accelerator=args.accelerator,
         devices=args.devices,
@@ -52,6 +54,7 @@ def train():
         max_epochs=args.max_epochs,
         log_every_n_steps=args.log_every_n_steps,
         default_root_dir=args.default_root_dir,
+        callbacks=[checkpoint_callback],
     )
     trainer.fit(
         model=model,

--- a/examples/mugen/retrieval/train.py
+++ b/examples/mugen/retrieval/train.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from examples.mugen.data.mugen_datamodules import MUGENDataModule
+from examples.mugen.data.mugen_dataset import MUGENDatasetArgs
+from examples.mugen.retrieval.model import VideoCLIPLightningModule
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+from pytorch_lightning import Trainer
+from torchmultimodal.transforms.bert_text_transform import BertTextTransform
+from torchmultimodal.transforms.video_transform import VideoTransform
+
+
+def get_yaml_config():
+    cli_conf = OmegaConf.from_cli()
+    if "config" not in cli_conf:
+        raise ValueError(
+            "Please pass 'config' to specify configuration yaml file for running VideoCLIP training"
+        )
+    yaml_conf = OmegaConf.load(cli_conf.config)
+    conf = instantiate(yaml_conf)
+    return conf
+
+
+def train():
+    args = get_yaml_config()
+
+    dataset_args: MUGENDatasetArgs = args.dataset_args
+    datamodule = MUGENDataModule(
+        dataset_args,
+        text_transform=BertTextTransform(
+            **vars(args.datamodule_args.bert_text_transform)
+        ),
+        video_transform=VideoTransform(**vars(args.datamodule_args.video_transform)),
+        batch_size=args.datamodule_args.batch_size,
+        num_workers=args.datamodule_args.num_workers,
+        shuffle=args.datamodule_args.shuffle,
+    )
+
+    model = VideoCLIPLightningModule(
+        **vars(args.lightningmodule_args),
+        **vars(args.videoclip_args),
+    )
+
+    trainer = Trainer(
+        accelerator=args.accelerator,
+        devices=1,
+        max_epochs=args.max_epochs,
+        log_every_n_steps=args.log_every_n_steps,
+        default_root_dir=args.default_root_dir,
+    )
+    trainer.fit(
+        model=model,
+        train_dataloaders=datamodule.train_dataloader(),
+        val_dataloaders=datamodule.val_dataloader(),
+    )
+
+
+if __name__ == "__main__":
+    train()

--- a/examples/mugen/retrieval/train.py
+++ b/examples/mugen/retrieval/train.py
@@ -47,7 +47,8 @@ def train():
 
     trainer = Trainer(
         accelerator=args.accelerator,
-        devices=1,
+        devices=args.devices,
+        strategy="ddp_find_unused_parameters_false",
         max_epochs=args.max_epochs,
         log_every_n_steps=args.log_every_n_steps,
         default_root_dir=args.default_root_dir,


### PR DESCRIPTION
Summary:
Training script for VideoCLIP on MUGEN dataset.

- `definitions.py`: add `TrainingArgs`, which includes lightning Trainer args like `max_epochs`
- `train.py`: training script
- `configs/train.yaml`: training config 
- `configs/eval.yaml`: fix default resolution value  ([default dataset args](https://github.com/mugen-org/MUGEN_baseline/blob/main/lib/data/mugen_data.py#L52), [eval command](https://github.com/mugen-org/MUGEN_baseline/blob/b45da493f3ddbcced52d44eee02d443f90842474/retrieval/experiments/eval_all.sh))
- `model.py`: remove recall calculation at end of training epoch, add split markers to recall logging (e.g. test/recall and validation/recall)

Test plan:
`python train.py config=configs/train.yaml`
[tensorboard](https://colab.research.google.com/drive/1RfZBYqpxmGiNCna-70_xm2ce85eEjB9I?usp=sharing) of logged results
