### PR TITLE
[Lint] Correct type annotation in util torch_load_module

### DIFF
--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -100,7 +100,7 @@ def tensor_slice(x: Tensor, begin: List[int], size: List[int]) -> Tensor:
 
 
 def load_module_from_url(
-    model: torch.nn.Module, url: str, strict: bool = True, progress: bool = True
+    model: nn.Module, url: str, strict: bool = True, progress: bool = True
 ) -> None:
     local_path = _PATH_MANAGER.get_local_path(url)
     if not torch.cuda.is_available():
@@ -138,7 +138,7 @@ class PretrainedMixin:
         strict: bool = True,
     ) -> Any:
         assert isinstance(
-            self, torch.nn.Module
+            self, nn.Module
         ), "load_model can only be called on an nn.Module instance"
         if os.path.exists(pretrained_url):
             state_dict = torch.load(pretrained_url)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #260
* #259
* #258
* #257
* #256
* #255
* __->__ #254

Summary:
Correct type annotation from `torch.nn.Module` to `nn.Module` in the utility function

Test Plan:

CI

Differential Revision: [D38621046](https://our.internmc.facebook.com/intern/diff/D38621046)