### PR TITLE
[MUGEN] Replace shape with latent_shape in position embedding

### DIFF
--- a/test/modules/layers/test_position_embedding.py
+++ b/test/modules/layers/test_position_embedding.py
@@ -18,7 +18,7 @@ class TestBroadcastedPositionEmbedding:
     @pytest.fixture(scope="class")
     def pos_emb(self):
         _pos_emb = BroadcastedPositionEmbedding(
-            shape=(1, 2, 3),
+            latent_shape=(1, 2, 3),
             embedding_dim=6,
         )
         _pos_emb.embedding = nn.ParameterDict(
@@ -40,7 +40,7 @@ class TestBroadcastedPositionEmbedding:
     def test_init_bad_embedding_dim(self):
         """Test raising error when the embedding dim is not allowed"""
         with pytest.raises(ValueError):
-            BroadcastedPositionEmbedding(shape=(1, 2, 3), embedding_dim=5)
+            BroadcastedPositionEmbedding(latent_shape=(1, 2, 3), embedding_dim=5)
 
     def test_broadcast(self, pos_emb):
         """Test embedding along each dim is broadcasted correctly"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #264
* #257
* #263
* #259
* #262
* __->__ #258
* #256
* #255
* #254

Summary:
- Make it clear that position embedding is added to the latent encodings not the input data
- Change `shape` to `latent_shape`

Test Plan:

CI

Differential Revision: [D38642050](https://our.internmc.facebook.com/intern/diff/D38642050)