### PR TITLE
[BE] Migrate codebook unit test to pytest

### DIFF
--- a/test/modules/layers/test_codebook.py
+++ b/test/modules/layers/test_codebook.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
 import warnings
 from collections import OrderedDict
+
+import pytest
 
 import torch
 from test.test_utils import assert_expected, set_rng_seed
@@ -14,240 +15,295 @@ from torch import nn, tensor
 from torchmultimodal.modules.layers.codebook import Codebook
 
 
-class TestCodebook(unittest.TestCase):
-    """
-    Test the Codebook class
-    """
+@pytest.fixture(autouse=True)
+def random_seed():
+    set_rng_seed(4)
 
-    def setUp(self):
-        set_rng_seed(4)
-        self.num_embeddings = 4
-        self.embedding_dim = 5
 
-        # This is 2x5x3
-        self.encoded = torch.Tensor(
+@pytest.fixture
+def num_embeddings():
+    return 4
+
+
+@pytest.fixture
+def embedding_dim():
+    return 5
+
+
+@pytest.fixture
+def encoded():
+    # This is 2x5x3
+    encoded = tensor(
+        [
             [
-                [[-1, 0, 1], [2, 1, 0], [0, -1, -1], [0, 2, -1], [-2, -1, 1]],
-                [[2, 2, -1], [1, -1, -2], [0, 0, 0], [1, 2, 1], [1, 0, 0]],
-            ]
-        )
-        self.encoded.requires_grad_()
-        # This is 4x5
-        self.embedding_weights = torch.Tensor(
-            [[1, 0, -1, -1, 2], [2, -2, 0, 0, 1], [2, 1, 0, 1, 1], [-1, -2, 0, 2, 0]]
-        )
-        # This is 4x3
-        self.input_tensor_flat = torch.Tensor(
-            [[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]
-        )
-
-        self.vq = Codebook(
-            num_embeddings=self.num_embeddings,
-            embedding_dim=self.embedding_dim,
-            decay=0.3,
-        )
-
-    def test_quantized_output(self):
-        self.vq.embedding = self.embedding_weights
-        self.vq._is_embedding_init = True
-        output = self.vq(self.encoded)
-        _, actual_quantized_flat, actual_codebook_indices, actual_quantized = output
-        # This is shape (2,5,3)
-        expected_quantized = torch.Tensor(
+                [-1.0, 0.0, 1.0],
+                [2.0, 1.0, 0.0],
+                [0.0, -1.0, -1.0],
+                [0.0, 2.0, -1.0],
+                [-2.0, -1.0, 1.0],
+            ],
             [
-                [
-                    [2.0, 2.0, 1.0],
-                    [1.0, 1.0, 0.0],
-                    [0.0, 0.0, -1.0],
-                    [1.0, 1.0, -1.0],
-                    [1.0, 1.0, 2.0],
-                ],
-                [
-                    [2.0, 2.0, -1.0],
-                    [1.0, -2.0, -2.0],
-                    [0.0, 0.0, 0.0],
-                    [1.0, 0.0, 2.0],
-                    [1.0, 1.0, 0.0],
-                ],
-            ]
-        )
-        expected_quantized_flat = (
-            expected_quantized.permute(0, 2, 1).contiguous().view(-1, 5)
-        )
-        expected_codebook_indices = torch.Tensor([2, 2, 0, 2, 1, 3]).type(
-            torch.LongTensor
-        )
+                [2.0, 2.0, -1.0],
+                [1.0, -1.0, -2.0],
+                [0.0, 0.0, 0.0],
+                [1.0, 2.0, 1.0],
+                [1.0, 0.0, 0.0],
+            ],
+        ]
+    )
+    encoded.requires_grad_()
 
-        assert_expected(actual_quantized, expected_quantized)
-        assert_expected(actual_quantized_flat, expected_quantized_flat)
-        assert_expected(actual_codebook_indices, expected_codebook_indices)
+    return encoded
 
-    def test_preprocess(self):
-        encoded_flat, permuted_shape = self.vq._preprocess(self.encoded)
 
-        expected_flat_shape = torch.tensor([6, 5])
-        expected_permuted_shape = torch.tensor([2, 3, 5])
+@pytest.fixture
+def embedding_weights():
+    # This is 4x5
+    return tensor(
+        [
+            [1.0, 0.0, -1.0, -1.0, 2.0],
+            [2.0, -2.0, 0.0, 0.0, 1.0],
+            [2.0, 1.0, 0.0, 1.0, 1.0],
+            [-1.0, -2.0, 0.0, 2.0, 0.0],
+        ]
+    )
 
-        actual_flat_shape = torch.tensor(encoded_flat.shape)
-        actual_permuted_shape = torch.tensor(permuted_shape)
 
-        assert_expected(actual_flat_shape, expected_flat_shape)
+@pytest.fixture
+def input_tensor_flat():
+    # This is 4x3
+    return tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
 
-        assert_expected(actual_permuted_shape, expected_permuted_shape)
 
-    def test_preprocess_channel_dim_assertion(self):
-        with self.assertRaises(ValueError):
-            _, _ = self.vq._preprocess(self.encoded[:, :4, :])
+@pytest.fixture
+def codebook(num_embeddings, embedding_dim):
+    return Codebook(
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        decay=0.3,
+    )
 
-    def test_postprocess(self):
-        quantized = self.vq._postprocess(self.input_tensor_flat, torch.Size([2, 2, 3]))
-        actual_quantized_shape = torch.tensor(quantized.shape)
-        expected_quantized_shape = torch.tensor([2, 3, 2])
 
-        assert_expected(actual_quantized_shape, expected_quantized_shape)
-
-    def test_init_embedding_and_preprocess(self):
-        assert not self.vq._is_embedding_init, "embedding init flag not False initially"
-
-        _, _ = self.vq._init_embedding_and_preprocess(self.encoded)
-
-        assert self.vq._is_embedding_init, "embedding init flag not True after init"
-
-        actual_weight = self.vq.embedding
-        expected_weight = torch.Tensor(
+def test_quantized_output(codebook, embedding_weights, encoded):
+    codebook.embedding = embedding_weights
+    codebook._is_embedding_init = True
+    output = codebook(encoded)
+    _, actual_quantized_flat, actual_codebook_indices, actual_quantized = output
+    # This is shape (2,5,3)
+    expected_quantized = tensor(
+        [
             [
-                [2.0, -1.0, 0.0, 2.0, 0.0],
-                [2.0, 1.0, 0.0, 1.0, 1.0],
-                [0.0, 1.0, -1.0, 2.0, -1.0],
-                [1.0, 0.0, -1.0, -1.0, 1.0],
-            ]
-        )
-        assert_expected(actual_weight, expected_weight)
-
-        actual_code_avg = self.vq.code_avg
-        expected_code_avg = actual_weight
-        assert_expected(actual_code_avg, expected_code_avg)
-
-        actual_code_usage = self.vq.code_usage
-        expected_code_usage = torch.ones(self.num_embeddings)
-        assert_expected(actual_code_usage, expected_code_usage)
-
-    def test_ema_update_embedding(self):
-        encoded_flat, _ = self.vq._init_embedding_and_preprocess(self.encoded)
-        distances = torch.cdist(encoded_flat, self.vq.embedding, p=2.0) ** 2
-        codebook_indices = torch.argmin(distances, dim=1)
-        self.vq._ema_update_embedding(encoded_flat, codebook_indices)
-
-        actual_weight = self.vq.embedding
-        expected_weight = torch.Tensor(
+                [2.0, 2.0, 1.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 0.0, -1.0],
+                [1.0, 1.0, -1.0],
+                [1.0, 1.0, 2.0],
+            ],
             [
-                [0.7647, -1.4118, 0.0000, 1.5882, 0.0000],
-                [2.0000, 1.0000, 0.0000, 1.0000, 1.0000],
-                [-0.4118, 1.4118, -0.5882, 1.1765, -1.4118],
-                [1.0000, 0.0000, -1.0000, -1.0000, 1.0000],
-            ]
-        )
-        assert_expected(actual_weight, expected_weight, rtol=0.0, atol=1e-4)
+                [2.0, 2.0, -1.0],
+                [1.0, -2.0, -2.0],
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 2.0],
+                [1.0, 1.0, 0.0],
+            ],
+        ]
+    )
+    expected_quantized_flat = (
+        expected_quantized.permute(0, 2, 1).contiguous().view(-1, 5)
+    )
+    expected_codebook_indices = tensor([2.0, 2.0, 0.0, 2.0, 1.0, 3.0]).type(
+        torch.LongTensor
+    )
+    expected_codebook_indices = tensor([2, 2, 0, 2, 1, 3]).type(torch.LongTensor)
 
-        actual_code_avg = self.vq.code_avg
-        expected_code_avg = torch.Tensor(
+    assert_expected(actual_quantized, expected_quantized)
+    assert_expected(actual_quantized_flat, expected_quantized_flat)
+    assert_expected(actual_codebook_indices, expected_codebook_indices)
+
+
+def test_preprocess(codebook, encoded):
+    encoded_flat, permuted_shape = codebook._preprocess(encoded)
+
+    expected_flat_shape = torch.tensor([6, 5])
+    expected_permuted_shape = torch.tensor([2, 3, 5])
+
+    actual_flat_shape = torch.tensor(encoded_flat.shape)
+    actual_permuted_shape = torch.tensor(permuted_shape)
+
+    assert_expected(actual_flat_shape, expected_flat_shape)
+
+    assert_expected(actual_permuted_shape, expected_permuted_shape)
+
+
+def test_preprocess_channel_dim_assertion(codebook, encoded):
+    with pytest.raises(ValueError):
+        codebook._preprocess(encoded[:, :4, :])
+
+
+def test_postprocess(codebook, input_tensor_flat):
+    quantized = codebook._postprocess(input_tensor_flat, torch.Size([2, 2, 3]))
+    actual_quantized_shape = torch.tensor(quantized.shape)
+    expected_quantized_shape = torch.tensor([2, 3, 2])
+
+    assert_expected(actual_quantized_shape, expected_quantized_shape)
+
+
+def test_init_embedding_and_preprocess(codebook, encoded, num_embeddings):
+    assert not codebook._is_embedding_init, "embedding init flag not False initially"
+
+    _, _ = codebook._init_embedding_and_preprocess(encoded)
+
+    assert codebook._is_embedding_init, "embedding init flag not True after init"
+
+    actual_weight = codebook.embedding
+    expected_weight = tensor(
+        [
+            [2.0, -1.0, 0.0, 2.0, 0.0],
+            [2.0, 1.0, 0.0, 1.0, 1.0],
+            [0.0, 1.0, -1.0, 2.0, -1.0],
+            [1.0, 0.0, -1.0, -1.0, 1.0],
+        ]
+    )
+    assert_expected(actual_weight, expected_weight)
+
+    actual_code_avg = codebook.code_avg
+    expected_code_avg = actual_weight
+    assert_expected(actual_code_avg, expected_code_avg)
+
+    actual_code_usage = codebook.code_usage
+    expected_code_usage = torch.ones(num_embeddings)
+    assert_expected(actual_code_usage, expected_code_usage)
+
+
+def test_ema_update_embedding(codebook, encoded):
+    encoded_flat, _ = codebook._init_embedding_and_preprocess(encoded)
+    distances = torch.cdist(encoded_flat, codebook.embedding, p=2.0) ** 2
+    codebook_indices = torch.argmin(distances, dim=1)
+    codebook._ema_update_embedding(encoded_flat, codebook_indices)
+
+    actual_weight = codebook.embedding
+    expected_weight = tensor(
+        [
+            [0.7647, -1.4118, 0.0000, 1.5882, 0.0000],
+            [2.0000, 1.0000, 0.0000, 1.0000, 1.0000],
+            [-0.4118, 1.4118, -0.5882, 1.1765, -1.4118],
+            [1.0000, 0.0000, -1.0000, -1.0000, 1.0000],
+        ]
+    )
+    assert_expected(actual_weight, expected_weight, rtol=0.0, atol=1e-4)
+
+    actual_code_avg = codebook.code_avg
+    expected_code_avg = tensor(
+        [
+            [1.3000, -2.4000, 0.0000, 2.7000, 0.0000],
+            [2.0000, 1.0000, 0.0000, 1.0000, 1.0000],
+            [-0.7000, 2.4000, -1.0000, 2.0000, -2.4000],
+            [1.0000, 0.0000, -1.0000, -1.0000, 1.0000],
+        ]
+    )
+    assert_expected(actual_code_avg, expected_code_avg, rtol=0.0, atol=1e-4)
+
+    actual_code_usage = codebook.code_usage
+    expected_code_usage = tensor([1.7000, 1.0000, 1.7000, 1.0000])
+    assert_expected(actual_code_usage, expected_code_usage, rtol=0.0, atol=1e-4)
+
+
+def test_register_buffer_tensors(codebook, encoded):
+    out = codebook(encoded)
+    out.quantized.sum().backward()
+
+    msg_has_grad = "tensor assigned to buffer but accumulated grad"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert not codebook.code_avg.grad, msg_has_grad
+        assert not codebook.code_usage.grad, msg_has_grad
+        assert not codebook.embedding.grad, msg_has_grad
+
+    assert not list(
+        codebook.parameters()
+    ), "buffer variables incorrectly assigned as params"
+
+
+def test_init_embedding_smaller_encoded(codebook, encoded):
+    encoded_small = encoded[:1, :, :2]
+    encoded_small_flat, _ = codebook._init_embedding_and_preprocess(encoded_small)
+    embed = codebook.embedding
+    # Check for each embedding vector if there is one equal encoded vector + noise
+    for emb in embed:
+        assert any(
             [
-                [1.3000, -2.4000, 0.0000, 2.7000, 0.0000],
-                [2.0000, 1.0000, 0.0000, 1.0000, 1.0000],
-                [-0.7000, 2.4000, -1.0000, 2.0000, -2.4000],
-                [1.0000, 0.0000, -1.0000, -1.0000, 1.0000],
+                torch.isclose(emb, enc, rtol=0, atol=0.01).all()
+                for enc in encoded_small_flat
             ]
-        )
-        assert_expected(actual_code_avg, expected_code_avg, rtol=0.0, atol=1e-4)
+        ), "embedding initialized from encoder output incorrectly"
 
-        actual_code_usage = self.vq.code_usage
-        expected_code_usage = torch.Tensor([1.7000, 1.0000, 1.7000, 1.0000])
-        assert_expected(actual_code_usage, expected_code_usage, rtol=0.0, atol=1e-4)
 
-    def test_register_buffer_tensors(self):
-        out = self.vq(self.encoded)
-        out.quantized.sum().backward()
+def test_codebook_restart(codebook, encoded):
+    # First init and diversify embedding
+    encoded_flat, _ = codebook._init_embedding_and_preprocess(encoded)
+    # Use only embedding vector at index = 1 and force restarts.
+    # Slightly modify encoded_flat to make sure vectors restart to something new
+    encoded_flat_noise = encoded_flat + torch.randn_like(encoded_flat)
+    codebook_indices_low_usage = torch.ones(encoded_flat.shape[0], dtype=torch.long)
+    codebook._ema_update_embedding(encoded_flat_noise, codebook_indices_low_usage)
 
-        msg_has_grad = "tensor assigned to buffer but accumulated grad"
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            assert not self.vq.code_avg.grad, msg_has_grad
-            assert not self.vq.code_usage.grad, msg_has_grad
-            assert not self.vq.embedding.grad, msg_has_grad
-
-        assert not list(
-            self.vq.parameters()
-        ), "buffer variables incorrectly assigned as params"
-
-    def test_init_embedding_smaller_encoded(self):
-        encoded_small = self.encoded[:1, :, :2]
-        encoded_small_flat, _ = self.vq._init_embedding_and_preprocess(encoded_small)
-        embed = self.vq.embedding
-        # Check for each embedding vector if there is one equal encoded vector + noise
-        for emb in embed:
+    # Check if embedding contains restarts
+    for i, emb in enumerate(codebook.embedding):
+        # We used only emb vector with index = 1, so check it was not restarted
+        if i == 1:
+            assert_expected(
+                emb,
+                codebook.code_avg[1] / codebook.code_usage[1],
+                rtol=0,
+                atol=1e-4,
+            )
+        # Compare each embedding vector to each encoded vector.
+        # If at least one match, then restart happened.
+        else:
             assert any(
                 [
-                    torch.isclose(emb, enc, rtol=0, atol=0.01).all()
-                    for enc in encoded_small_flat
+                    torch.isclose(emb, enc, rtol=0, atol=1e-4).all()
+                    for enc in encoded_flat_noise
                 ]
-            ), "embedding initialized from encoder output incorrectly"
+            ), "embedding restarted from encoder output incorrectly"
 
-    def test_codebook_restart(self):
-        # First init and diversify embedding
-        encoded_flat, _ = self.vq._init_embedding_and_preprocess(self.encoded)
-        # Use only embedding vector at index = 1 and force restarts.
-        # Slightly modify encoded_flat to make sure vectors restart to something new
-        encoded_flat_noise = encoded_flat + torch.randn_like(encoded_flat)
-        codebook_indices_low_usage = torch.ones(encoded_flat.shape[0], dtype=torch.long)
-        self.vq._ema_update_embedding(encoded_flat_noise, codebook_indices_low_usage)
 
-        # Check if embedding contains restarts
-        for i, emb in enumerate(self.vq.embedding):
-            # We used only emb vector with index = 1, so check it was not restarted
-            if i == 1:
-                assert_expected(
-                    emb, self.vq.code_avg[1] / self.vq.code_usage[1], rtol=0, atol=1e-4
-                )
-            # Compare each embedding vector to each encoded vector.
-            # If at least one match, then restart happened.
-            else:
-                assert any(
-                    [
-                        torch.isclose(emb, enc, rtol=0, atol=1e-4).all()
-                        for enc in encoded_flat_noise
-                    ]
-                ), "embedding restarted from encoder output incorrectly"
+def test_load_state_dict():
+    state_dict = OrderedDict(
+        [
+            ("linear.weight", tensor([[1.0]])),
+            ("linear.bias", tensor([2.0])),
+            ("codebook.embedding", tensor([[3.0]])),
+            ("codebook.code_usage", tensor([4.0])),
+            ("codebook.code_avg", tensor([[5.0]])),
+        ]
+    )
 
-    def test_load_state_dict(self):
-        state_dict = OrderedDict(
-            [
-                ("linear.weight", tensor([[1.0]])),
-                ("linear.bias", tensor([2.0])),
-                ("codebook.embedding", tensor([[3.0]])),
-                ("codebook.code_usage", tensor([4.0])),
-                ("codebook.code_avg", tensor([[5.0]])),
-            ]
-        )
+    class DummyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(1, 1)
+            self.codebook = Codebook(1, 1)
 
-        class DummyModel(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = nn.Linear(1, 1)
-                self.codebook = Codebook(1, 1)
+    model = DummyModel()
+    assert not model.codebook._is_embedding_init
+    model.load_state_dict(state_dict)
+    assert model.codebook._is_embedding_init
 
-        model = DummyModel()
-        assert not model.codebook._is_embedding_init
-        model.load_state_dict(state_dict)
-        assert model.codebook._is_embedding_init
+    actual = model.codebook.embedding
+    expected = state_dict["codebook.embedding"]
+    assert_expected(actual, expected)
 
-        actual = model.codebook.embedding
-        expected = state_dict["codebook.embedding"]
-        assert_expected(actual, expected)
+    actual = model.codebook.code_usage
+    expected = state_dict["codebook.code_usage"]
+    assert_expected(actual, expected)
 
-        actual = model.codebook.code_usage
-        expected = state_dict["codebook.code_usage"]
-        assert_expected(actual, expected)
+    actual = model.codebook.code_avg
+    expected = state_dict["codebook.code_avg"]
+    assert_expected(actual, expected)
 
-        actual = model.codebook.code_avg
-        expected = state_dict["codebook.code_avg"]
-        assert_expected(actual, expected)
+
+def test_lookup(codebook, embedding_weights):
+    codebook.embeddings = embedding_weights
+    x_input = tensor([])
+    # tensor([[1, 0, -1, -1, 2], [2, -2, 0, 0, 1], [2, 1, 0, 1, 1], [-1, -2, 0, 2, 0]])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #264
* #257
* #263
* __->__ #259
* #262
* #258
* #256
* #255
* #254

Summary:
- `unittest` to `pytest`
- Use `assert_expected_wrapper` for `CodebookOutput` value assertion

Test Plan:
```
$ python -m pytest --cov=torchmultimodal/modules/layers/ test/modules/layers/test_codebook.py -vv
================================================= test session starts ==================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/langong/local/miniconda3/envs/t2v/bin/python
cachedir: .pytest_cache
rootdir: /Users/langong/gpt_attention, configfile: pyproject.toml
plugins: mock-3.8.2, cov-3.0.0
collected 11 items

test/modules/layers/test_codebook.py::TestCodebook::test_quantized_output PASSED                                 [  9%]
test/modules/layers/test_codebook.py::TestCodebook::test_preprocess PASSED                                       [ 18%]
test/modules/layers/test_codebook.py::TestCodebook::test_preprocess_channel_dim_assertion PASSED                 [ 27%]
test/modules/layers/test_codebook.py::TestCodebook::test_postprocess PASSED                                      [ 36%]
test/modules/layers/test_codebook.py::TestCodebook::test_init_embedding PASSED                                   [ 45%]
test/modules/layers/test_codebook.py::TestCodebook::test_ema_update_embedding PASSED                             [ 54%]
test/modules/layers/test_codebook.py::TestCodebook::test_register_buffer_tensors PASSED                          [ 63%]
test/modules/layers/test_codebook.py::TestCodebook::test_init_embedding_smaller_encoded PASSED                   [ 72%]
test/modules/layers/test_codebook.py::TestCodebook::test_codebook_restart PASSED                                 [ 81%]
test/modules/layers/test_codebook.py::TestCodebook::test_load_state_dict PASSED                                  [ 90%]
test/modules/layers/test_codebook.py::TestCodebook::test_lookup PASSED                                           [100%]

---------- coverage: platform darwin, python 3.8.13-final-0 ----------
Name                                                   Stmts   Miss  Cover
--------------------------------------------------------------------------
torchmultimodal/modules/layers/codebook.py                87      1    99%
--------------------------------------------------------------------------
TOTAL                                                    489    403    18%


================================================== 11 passed in 1.56s ============
```

Differential Revision: [D38642049](https://our.internmc.facebook.com/intern/diff/D38642049)