### PR TITLE
[FLAVA] Change order of fixtures in checkpoint test

### DIFF
--- a/test/models/flava/test_flava_checkpoint.py
+++ b/test/models/flava/test_flava_checkpoint.py
@@ -70,17 +70,32 @@ class TestFLAVACheckpoint:
 
     @pytest.fixture
     def classification_model(self):
-        return flava_model_for_classification(
-            num_classes=3, pretrained_model_key="flava_full"
-        )
+        def get_model():
+            flava = flava_model_for_classification(
+                num_classes=3, pretrained_model_key="flava_full"
+            )
+            flava.eval()
+            return flava
+
+        return get_model
 
     @pytest.fixture
     def pretraining_model(self):
-        return flava_model_for_pretraining(pretrained_model_key="flava_full")
+        def get_model():
+            flava = flava_model_for_pretraining(pretrained_model_key="flava_full")
+            flava.eval()
+            return flava
+
+        return get_model
 
     @pytest.fixture
     def model(self):
-        return flava_model(pretrained_model_key="flava_full")
+        def get_model():
+            flava = flava_model(pretrained_model_key="flava_full")
+            flava.eval()
+            return flava
+
+        return get_model
 
     def _assert_tensor_dicts_equal(self, dict_actual, dict_expected):
         for key in dict_expected:
@@ -102,70 +117,78 @@ class TestFLAVACheckpoint:
         mm_input = inputs_classification("mm")
         image_input = inputs_classification("image")
         text_input = inputs_classification("text")
-        classification_model.eval()
-        output = classification_model(*mm_input)
+        flava = classification_model()
+
+        output = flava(*mm_input)
         actual = output.loss
         expected = torch.tensor(1.0827)
         assert_expected(actual, expected, rtol=0, atol=1e-4)
 
-        output = classification_model(*image_input)
+        output = flava(*image_input)
         actual = output.loss
         expected = torch.tensor(1.0849)
         assert_expected(actual, expected, rtol=0, atol=1e-4)
 
-        output = classification_model(*text_input)
+        output = flava(*text_input)
         actual = output.loss
         expected = torch.tensor(1.0822)
         assert_expected(actual, expected, rtol=0, atol=1e-4)
 
-    def test_flava_model_for_pretraining(self, pretraining_model, inputs_pretraining):
-        output = pretraining_model(*inputs_pretraining("mm"))
+    def test_flava_model_for_pretraining(self, inputs_pretraining, pretraining_model):
+        mm_input = inputs_pretraining("mm")
+        image_input = inputs_pretraining("image")
+        text_input = inputs_pretraining("text")
+        flava = pretraining_model()
+
+        output = flava(*mm_input)
         actual = output.losses
         expected = dict(
-            mmm_text_loss=15.8243,
-            mmm_image_loss=11.9815,
+            mmm_text_loss=10.9567,
+            mmm_image_loss=11.2143,
             mim_loss=None,
             mlm_loss=None,
-            itm_loss=0.7904,
-            global_contrastive_loss=0.6195,
+            itm_loss=1.1485,
+            global_contrastive_loss=0.7104,
         )
         self._assert_tensor_dicts_equal(actual, expected)
 
-        output = pretraining_model(*inputs_pretraining("image"))
+        output = flava(*image_input)
         actual = output.losses
         expected = dict(
             mmm_text_loss=None,
             mmm_image_loss=None,
-            mim_loss=10.5971,
+            mim_loss=10.5749,
             mlm_loss=None,
             itm_loss=None,
             global_contrastive_loss=None,
         )
         self._assert_tensor_dicts_equal(actual, expected)
 
-        output = pretraining_model(*inputs_pretraining("text"))
+        output = flava(*text_input)
         actual = output.losses
         expected = dict(
             mmm_text_loss=None,
             mmm_image_loss=None,
             mim_loss=None,
-            mlm_loss=18.9983,
+            mlm_loss=16.1049,
             itm_loss=None,
             global_contrastive_loss=None,
         )
         self._assert_tensor_dicts_equal(actual, expected)
 
-    def test_flava_model(self, model, inputs_model):
-        output = model(*inputs_model, skip_unmasked_mm_encoder=False)
+    def test_flava_model(self, inputs_model, model):
+        flava = model()
+
+        output = flava(*inputs_model, skip_unmasked_mm_encoder=False)
 
         actual = torch.sum(output.image.last_hidden_state)
-        expected = torch.tensor(-1316.7531)
+        expected = torch.tensor(-1321.3137)
         assert_expected(actual, expected, rtol=0, atol=1e-3)
 
         actual = torch.sum(output.text.last_hidden_state)
-        expected = torch.tensor(-240.5744)
+        expected = torch.tensor(-220.2462)
         assert_expected(actual, expected, rtol=0, atol=1e-3)
 
         actual = torch.sum(output.multimodal.last_hidden_state)
-        expected = torch.tensor(-4367.0878)
+        expected = torch.tensor(-4358.3115)
         assert_expected(actual, expected, rtol=0, atol=1e-3)


### PR DESCRIPTION
Summary:
Ensure FLAVA changes do not break tests due to random initialization order by reordering fixtures in tests and making sure the test inputs are always first.

Test plan:
`pytest test/models/flava/test_flava_checkpoint.py -vv`
```
===================================================================================== test session starts ======================================================================================
platform linux -- Python 3.9.12, pytest-7.1.1, pluggy-1.0.0 -- /fsx/users/rafiayub/conda/envs/torchmm/bin/python
cachedir: .pytest_cache
rootdir: /data/home/rafiayub/torchmultimodal, configfile: pyproject.toml
plugins: hydra-core-1.1.2, cov-3.0.0, mock-3.8.2
collected 3 items                                                                                                                                                                              

test/models/flava/test_flava_checkpoint.py::TestFLAVACheckpoint::test_flava_model_for_classification PASSED                                                                              [ 33%]
test/models/flava/test_flava_checkpoint.py::TestFLAVACheckpoint::test_flava_model_for_pretraining PASSED                                                                                 [ 66%]
test/models/flava/test_flava_checkpoint.py::TestFLAVACheckpoint::test_flava_model PASSED                                                                                                 [100%]

======================================================================================= warnings summary =======================================================================================
test/models/flava/test_flava_checkpoint.py::TestFLAVACheckpoint::test_flava_model_for_pretraining
  /data/home/rafiayub/torchmultimodal/test/models/flava/test_flava_checkpoint.py:105: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
    else torch.tensor(dict_actual[key])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================ 3 passed, 1 warning in 19.96s =================================================================================
```
