### PR TITLE
[Test] Enable numerical test and NamedTuple (for expected) in assert_expected_wrapper

### DIFF
--- a/test/models/test_gpt.py
+++ b/test/models/test_gpt.py
@@ -329,7 +329,7 @@ class TestMultimodalTransformerDecoder:
             "attention_weights": None,
             "past_key_values": None,
         }
-        assert_expected_wrapper(actual, expected)
+        assert_expected_wrapper(actual, expected, rtol=1e-5, atol=1e-4)
 
     def test_forward_out_modality(self, mm_decoder, out_modality):
         actual = mm_decoder(
@@ -344,7 +344,7 @@ class TestMultimodalTransformerDecoder:
             "attention_weights": None,
             "past_key_values": None,
         }
-        assert_expected_wrapper(actual, expected)
+        assert_expected_wrapper(actual, expected, rtol=1e-5, atol=1e-4)
 
     def test_forward_two_modality(self, mm_decoder, in_modality, out_modality):
         actual = mm_decoder(
@@ -363,7 +363,7 @@ class TestMultimodalTransformerDecoder:
             "attention_weights": None,
             "past_key_values": None,
         }
-        assert_expected_wrapper(actual, expected)
+        assert_expected_wrapper(actual, expected, rtol=1e-5, atol=1e-4)
 
     def test_forward_eval_right_shift_on(
         self, mm_decoder, in_modality, out_modality, mocker
@@ -391,7 +391,7 @@ class TestMultimodalTransformerDecoder:
             "attention_weights": None,
             "past_key_values": None,
         }
-        assert_expected_wrapper(actual, expected)
+        assert_expected_wrapper(actual, expected, rtol=1e-5, atol=1e-4)
 
     def test_forward_eval_right_shift_off(
         self, mm_decoder, in_modality, out_modality, mocker
@@ -418,7 +418,7 @@ class TestMultimodalTransformerDecoder:
             "attention_weights": None,
             "past_key_values": None,
         }
-        assert_expected_wrapper(actual, expected)
+        assert_expected_wrapper(actual, expected, rtol=1e-5, atol=1e-4)
 
     def test_bad_pos_ids(self, mm_decoder, in_modality, in_seq_len):
         in_pos_ids = torch.arange(
@@ -469,7 +469,7 @@ class TestTransformerDecoderLayer:
             "attention_weights": None,
             "past_key_values": None,
         }
-        assert_expected_wrapper(actual, expected)
+        assert_expected_wrapper(actual, expected, rtol=1e-5, atol=1e-4)
 
     def test_forward_masked(
         self, decoder_layer, x_input, self_attn_mask, self_head_mask
@@ -484,7 +484,7 @@ class TestTransformerDecoderLayer:
             "attention_weights": None,
             "past_key_values": None,
         }
-        assert_expected_wrapper(actual, expected)
+        assert_expected_wrapper(actual, expected, rtol=1e-5, atol=1e-4)
 
     def test_forward_additional_output(self, decoder_layer, x_input):
         actual = decoder_layer(x_input, use_cache=True, return_attn_weights=True)
@@ -500,7 +500,7 @@ class TestTransformerDecoderLayer:
                 "v": ([1, 2, 3, 2], 5.1630),
             },  # (b, h, seq_len, d_model//h)
         }
-        assert_expected_wrapper(actual, expected)
+        assert_expected_wrapper(actual, expected, rtol=1e-5, atol=1e-4)
 
 
 def test_sigmoid_linear_unit():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #264
* #257
* #263
* #259
* __->__ #262
* #258
* #256
* #255
* #254

Summary:
- Add support for numerical assertion 
- Add additional criteria for differentiating `tuple` from `namedtuple`
- Add `rtol`, `atol` configurability
- Can take both `Dict` and `NamedTuple` for actual and expected

Test Plan:
```
>>>from collections import namedtuple

>>> Out = namedtuple("Out", "x y")
>>> InnerOut = namedtuple("InnerOut", "z")

>>> actual = Out(x=InnerOut(z=tensor([1])), y=tensor([2]))
>>> expected = Out(x=InnerOut(z=tensor([1])), y=tensor([2]))

>>> assert_expected_wrapper(actual, expected)
```

```
$ python -m pytest test/models/test_gpt.py  -vv
================================================= test session starts ==================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/langong/local/miniconda3/envs/t2v/bin/python
cachedir: .pytest_cache
rootdir: /Users/langong/gpt_attention, configfile: pyproject.toml
plugins: mock-3.8.2, cov-3.0.0
collected 18 items

test/models/test_gpt.py::TestMultimodalGPT::test_bad_tokenizers PASSED                                           [  5%]
test/models/test_gpt.py::TestMultimodalGPT::test_fwd_for_generation PASSED                                       [ 11%]
test/models/test_gpt.py::TestMultimodalGPT::test_forward PASSED                                                  [ 16%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_bad_input PASSED                                 [ 22%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_in_modality PASSED                       [ 27%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_out_modality PASSED                      [ 33%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_two_modality PASSED                      [ 38%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_eval_right_shift_on PASSED               [ 44%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_eval_right_shift_off PASSED              [ 50%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_bad_pos_ids PASSED                               [ 55%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_optional_pos_ids PASSED                          [ 61%]
test/models/test_gpt.py::TestTransformerDecoder::test_forward PASSED                                             [ 66%]
test/models/test_gpt.py::TestTransformerDecoder::test_forward_additional_output PASSED                           [ 72%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward PASSED                                        [ 77%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward_masked PASSED                                 [ 83%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward_additional_output PASSED                      [ 88%]
test/models/test_gpt.py::test_sigmoid_linear_unit PASSED                                                         [ 94%]
test/models/test_gpt.py::test_right_shift PASSED                                                                 [100%]

================================================== 18 passed in 1.42s ========
```

Differential Revision: [D38642045](https://our.internmc.facebook.com/intern/diff/D38642045)