### PR TITLE
[Unification] Generalized vision transformer

### DIFF
--- a/test/modules/encoders/test_image_encoder.py
+++ b/test/modules/encoders/test_image_encoder.py
@@ -1,0 +1,145 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torch import nn
+from torchmultimodal.modules.encoders.image_encoder import VisionTransformer
+from torchmultimodal.modules.layers.image_embedding import ImageEmbeddings
+from torchmultimodal.modules.layers.transformer import TransformerEncoder
+
+
+@pytest.fixture(autouse=True)
+def random():
+    set_rng_seed(0)
+
+
+@pytest.fixture
+def inputs():
+    return torch.ones(2, 3, 2, 2)
+
+
+class TestVisionTransformer:
+    @pytest.fixture
+    def vit(self):
+        embedding = ImageEmbeddings(image_size=2, patch_size=1, hidden_size=2)
+        encoder = TransformerEncoder(
+            n_layer=1,
+            d_model=2,
+            n_head=1,
+            dim_feedforward=1,
+            activation=nn.GELU,
+            norm_first=True,
+        )
+        image_encoder = VisionTransformer(
+            embeddings=embedding,
+            encoder=encoder,
+            layernorm=nn.LayerNorm(2),
+            pooler=nn.Identity(),
+        )
+        image_encoder.eval()
+        return image_encoder
+
+    def test_image_encoder(self, inputs, vit):
+        out = vit(inputs)
+        assert_expected(
+            out.last_hidden_state,
+            torch.Tensor(
+                [
+                    [
+                        [-0.9999, 0.9999],
+                        [-1.0000, 1.0000],
+                        [-1.0000, 1.0000],
+                        [-1.0000, 1.0000],
+                        [-1.0000, 1.0000],
+                    ],
+                    [
+                        [-0.9999, 0.9999],
+                        [-1.0000, 1.0000],
+                        [-1.0000, 1.0000],
+                        [-1.0000, 1.0000],
+                        [-1.0000, 1.0000],
+                    ],
+                ]
+            ),
+            atol=1e-4,
+            rtol=0,
+        )
+        assert_expected(out.pooler_output, out.last_hidden_state)
+        assert_expected(
+            out.hidden_states,
+            (
+                torch.Tensor(
+                    [
+                        [
+                            [0.0000, 0.0000],
+                            [-0.1812, -0.0347],
+                            [-0.1812, -0.0347],
+                            [-0.1812, -0.0347],
+                            [-0.1812, -0.0347],
+                        ],
+                        [
+                            [0.0000, 0.0000],
+                            [-0.1812, -0.0347],
+                            [-0.1812, -0.0347],
+                            [-0.1812, -0.0347],
+                            [-0.1812, -0.0347],
+                        ],
+                    ]
+                ),
+                torch.Tensor(
+                    [
+                        [
+                            [0.4063, 0.9650],
+                            [0.2225, 0.9273],
+                            [0.2225, 0.9273],
+                            [0.2225, 0.9273],
+                            [0.2225, 0.9273],
+                        ],
+                        [
+                            [0.4063, 0.9650],
+                            [0.2225, 0.9273],
+                            [0.2225, 0.9273],
+                            [0.2225, 0.9273],
+                            [0.2225, 0.9273],
+                        ],
+                    ]
+                ),
+            ),
+            atol=1e-4,
+            rtol=0,
+        )
+        assert_expected(
+            out.attentions,
+            (
+                torch.Tensor(
+                    [
+                        [
+                            [
+                                [0.2339, 0.1915, 0.1915, 0.1915, 0.1915],
+                                [0.2226, 0.1943, 0.1943, 0.1943, 0.1943],
+                                [0.2226, 0.1943, 0.1943, 0.1943, 0.1943],
+                                [0.2226, 0.1943, 0.1943, 0.1943, 0.1943],
+                                [0.2226, 0.1943, 0.1943, 0.1943, 0.1943],
+                            ]
+                        ],
+                        [
+                            [
+                                [0.2339, 0.1915, 0.1915, 0.1915, 0.1915],
+                                [0.2226, 0.1943, 0.1943, 0.1943, 0.1943],
+                                [0.2226, 0.1943, 0.1943, 0.1943, 0.1943],
+                                [0.2226, 0.1943, 0.1943, 0.1943, 0.1943],
+                                [0.2226, 0.1943, 0.1943, 0.1943, 0.1943],
+                            ]
+                        ],
+                    ]
+                ),
+            ),
+            atol=1e-4,
+            rtol=0,
+        )

--- a/test/modules/layers/test_image_embedding.py
+++ b/test/modules/layers/test_image_embedding.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+import torch
+from test.test_utils import assert_expected, set_rng_seed
+from torch import nn
+from torchmultimodal.modules.layers.image_embedding import (
+    ImageEmbeddings,
+    PatchEmbeddings,
+)
+
+
+@pytest.fixture(autouse=True)
+def random():
+    set_rng_seed(0)
+
+
+@pytest.fixture
+def inputs():
+    return torch.ones(2, 3, 2, 2)
+
+
+@pytest.fixture
+def hi_res_inputs():
+    return torch.ones(1, 3, 4, 4)
+
+
+@pytest.fixture
+def mask():
+    return torch.tensor([[1, 1, 0, 1], [0, 1, 1, 0]])
+
+
+@pytest.fixture
+def patch_embedding():
+    model = PatchEmbeddings(image_size=2, patch_size=1, embed_dim=2)
+    model.projection.weight = nn.Parameter(
+        torch.tensor([[[[0.0]], [[1.0]], [[2.0]]], [[[3.0]], [[4.0]], [[5.0]]]])
+    )
+    model.projection.bias = nn.Parameter(torch.tensor([0.0, 0.0]))
+    model.eval()
+    return model
+
+
+class TestPatchEmbeddings:
+    def test_forward(self, inputs, patch_embedding):
+        actual = patch_embedding(inputs)
+        expected = torch.Tensor(
+            [
+                [[3.0, 12.0], [3.0, 12.0], [3.0, 12.0], [3.0, 12.0]],
+                [[3.0, 12.0], [3.0, 12.0], [3.0, 12.0], [3.0, 12.0]],
+            ]
+        )
+        assert_expected(actual, expected, atol=1e-4, rtol=0)
+
+
+class TestImageEmbeddings:
+    @pytest.fixture
+    def embedding(self, patch_embedding):
+        model = ImageEmbeddings(image_size=2, patch_size=1, hidden_size=2)
+        model.patch_embeddings = patch_embedding
+        model.eval()
+        return model
+
+    def test_forward(self, inputs, embedding):
+        actual = embedding(inputs)
+        expected = torch.Tensor(
+            [
+                [[0.0, 0.0], [3.0, 12.0], [3.0, 12.0], [3.0, 12.0], [3.0, 12.0]],
+                [[0.0, 0.0], [3.0, 12.0], [3.0, 12.0], [3.0, 12.0], [3.0, 12.0]],
+            ]
+        )
+        assert_expected(actual, expected, atol=1e-4, rtol=0)
+
+    def test_forward_interpolate_pos_encoding(self, hi_res_inputs, embedding):
+        actual = embedding(hi_res_inputs, interpolate_pos_encoding=True)
+        expected = torch.Tensor(
+            [
+                [
+                    [0.0, 0.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                    [3.0, 12.0],
+                ]
+            ]
+        )
+        assert_expected(actual, expected, atol=1e-4, rtol=0)
+
+    def test_forward_masked(self, inputs, mask, embedding):
+        actual = embedding(inputs, image_patches_mask=mask)
+        expected = torch.Tensor(
+            [
+                [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [3.0, 12.0], [0.0, 0.0]],
+                [[0.0, 0.0], [3.0, 12.0], [0.0, 0.0], [0.0, 0.0], [3.0, 12.0]],
+            ]
+        )
+        assert_expected(actual, expected, atol=1e-4, rtol=0)

--- a/torchmultimodal/modules/encoders/image_encoder.py
+++ b/torchmultimodal/modules/encoders/image_encoder.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, Optional
+
+from torch import nn, Tensor
+from torchmultimodal.modules.layers.transformer import TransformerOutput
+
+
+class VisionTransformer(nn.Module):
+    """
+    General image transformer encoder with embeddings. Similar to ``VisionTransformer`` in torchvision,
+    but more composable. Can be constructed with any user-provided embeddings, encoder, and task head.
+
+    Attributes:
+        embeddings (nn.Module): Module that projects image pixels into embeddings.
+            ``forward()`` should follow interface:
+                images: Optional[Tensor], input data
+                image_patches_mask: Optional[Tensor], mask for patch embeddings
+        encoder (nn.Module): Module for transformer encoder. ``forward()`` should follow interface:
+            Inputs:
+                hidden_states: Tensor, input for encoder
+                attention_mask: Optional[Tensor], shape ``(b, num_heads, query_seq_len, key_seq_len)``
+                return_attn_weights: bool. See ``TransformerEncoder``.
+                return_hidden_states: bool. See ``TransformerEncoder``.
+            Returns:
+                ``TransformerOutput``
+        layernorm (nn.Module, optional): Module for layernorm to be applied after encoder, if provided.
+        pooler (nn.Module, optional): Module for head to be applied after layernorm, if provided.
+
+    Args:
+        images (Tensor): Tensor of input images of shape ``(b, c, h, w)``.
+        image_patches_mask (Tensor, optional): Tensor indicating which patches to replace with mask tokens,
+            shape ``(b, seq_len)``, where seq_len = (image_size // patch_size) ** 2
+        attention_mask (Tensor, optional): Tensor indicating which tokens to attend to, shape ``(b, seq_len + 1)``.
+            Concatenating class_token adds 1 to seq_len.
+    """
+
+    def __init__(
+        self,
+        embeddings: nn.Module,
+        encoder: nn.Module,
+        layernorm: Optional[nn.Module] = None,
+        pooler: Optional[nn.Module] = None,
+        weight_init_fn: Optional[Callable] = None,
+    ) -> None:
+        super().__init__()
+
+        self.embeddings = embeddings
+        self.encoder = encoder
+        self.layernorm = layernorm
+        self.pooler = pooler
+
+        if weight_init_fn:
+            self.apply(weight_init_fn)
+
+    def forward(
+        self,
+        images: Tensor,
+        image_patches_mask: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+    ) -> TransformerOutput:
+
+        embedding_output = self.embeddings(
+            images, image_patches_mask=image_patches_mask
+        )
+
+        encoder_output = self.encoder(
+            embedding_output,
+            attention_mask=attention_mask,
+            return_attn_weights=True,
+            return_hidden_states=True,
+        )
+        sequence_output = encoder_output.last_hidden_state
+        sequence_output = self.layernorm(sequence_output)
+        pooled_output = (
+            self.pooler(sequence_output) if self.pooler is not None else None
+        )
+
+        return TransformerOutput(
+            last_hidden_state=sequence_output,
+            pooler_output=pooled_output,
+            hidden_states=encoder_output.hidden_states,
+            attentions=encoder_output.attentions,
+        )

--- a/torchmultimodal/modules/layers/image_embedding.py
+++ b/torchmultimodal/modules/layers/image_embedding.py
@@ -1,0 +1,163 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import warnings
+from typing import Optional
+
+import torch
+from torch import nn, Tensor
+
+
+# Based on timm implementation, which can be found here:
+# https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
+class PatchEmbeddings(nn.Module):
+    """
+    Image to Patch Embedding.
+    """
+
+    def __init__(
+        self,
+        image_size: int = 224,
+        patch_size: int = 16,
+        num_channels: int = 3,
+        embed_dim: int = 768,
+    ) -> None:
+        super().__init__()
+        image_size = (image_size, image_size)
+        patch_size = (patch_size, patch_size)
+        num_patches = (image_size[1] // patch_size[1]) * (
+            image_size[0] // patch_size[0]
+        )
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.num_patches = num_patches
+
+        self.projection = nn.Conv2d(
+            num_channels, embed_dim, kernel_size=self.patch_size, stride=self.patch_size
+        )
+
+    def forward(
+        self, pixel_values: Tensor, interpolate_pos_encoding: bool = False
+    ) -> Tensor:
+        _, _, height, width = pixel_values.shape
+        if not interpolate_pos_encoding:
+            if height != self.image_size[0] or width != self.image_size[1]:
+                raise ValueError(
+                    f"Input image size ({height}*{width}) doesn't match model ({self.image_size[0]}*{self.image_size[1]})."
+                )
+        x = self.projection(pixel_values).flatten(2).transpose(1, 2)
+        return x
+
+
+class ImageEmbeddings(nn.Module):
+    """
+    Construct the CLS token, position and patch embeddings.
+    """
+
+    def __init__(
+        self,
+        image_size: int = 224,
+        patch_size: int = 16,
+        num_channels: int = 3,
+        hidden_size: int = 768,
+        hidden_dropout_prob: float = 0.0,
+        use_image_masking: bool = True,
+    ) -> None:
+        super().__init__()
+
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.patch_embeddings = PatchEmbeddings(
+            image_size=image_size,
+            patch_size=patch_size,
+            num_channels=num_channels,
+            embed_dim=hidden_size,
+        )
+        num_patches = self.patch_embeddings.num_patches
+        self.position_embeddings = nn.Parameter(
+            torch.zeros(1, num_patches + 1, hidden_size)
+        )
+        self.dropout = nn.Dropout(hidden_dropout_prob)
+
+        if use_image_masking:
+            self.mask_token = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        else:
+            self.mask_token = None
+
+    def interpolate_pos_encoding(
+        self, embeddings: Tensor, height: int, width: int
+    ) -> Tensor:
+        """
+        This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher
+        resolution images.
+        Source:
+        https://github.com/facebookresearch/dino/blob/de9ee3df6cf39fac952ab558447af1fa1365362a/vision_transformer.py#L174
+        """
+
+        npatch = embeddings.shape[1] - 1
+        n = self.position_embeddings.shape[1] - 1
+        if npatch == n and height == width:
+            return self.position_embeddings
+        class_pos_embed = self.position_embeddings[:, 0]
+        patch_pos_embed = self.position_embeddings[:, 1:]
+        dim = embeddings.shape[-1]
+        h0 = height // self.patch_embeddings.patch_size[0]
+        w0 = width // self.patch_embeddings.patch_size[1]
+        # we add a small number to avoid floating point error in the interpolation
+        # see discussion at https://github.com/facebookresearch/dino/issues/8
+        h0, w0 = h0 + 0.1, w0 + 0.1
+        patch_pos_embed = nn.functional.interpolate(
+            patch_pos_embed.reshape(
+                1, int(math.sqrt(n)), int(math.sqrt(n)), dim
+            ).permute(0, 3, 1, 2),
+            scale_factor=(h0 / math.sqrt(n), w0 / math.sqrt(n)),
+            mode="bicubic",
+            align_corners=False,
+        )
+        assert (
+            int(h0) == patch_pos_embed.shape[-2]
+            and int(w0) == patch_pos_embed.shape[-1]
+        )
+        patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
+        return torch.cat((class_pos_embed.unsqueeze(0), patch_pos_embed), dim=1)
+
+    def forward(
+        self,
+        pixel_values: Tensor,
+        image_patches_mask: Optional[Tensor] = None,
+        interpolate_pos_encoding: bool = False,
+    ) -> Tensor:
+        batch_size, num_channels, height, width = pixel_values.shape
+        embeddings = self.patch_embeddings(
+            pixel_values, interpolate_pos_encoding=interpolate_pos_encoding
+        )
+
+        _, seq_len, _ = embeddings.size()
+        if image_patches_mask is not None:
+            if self.mask_token is not None:
+                mask_tokens = self.mask_token.expand(batch_size, seq_len, -1)
+                # replace the masked visual tokens by mask_tokens
+                w = image_patches_mask.unsqueeze(-1).type_as(mask_tokens)
+                embeddings = embeddings * (1 - w) + mask_tokens * w
+            else:
+                warnings.warn(
+                    "image_patches_mask passed but use_image_masking in init was false. Ignoring."
+                )
+        # add the [CLS] token to the embedded patch tokens
+        cls_tokens = self.cls_token.expand(batch_size, -1, -1)
+        embeddings = torch.cat((cls_tokens, embeddings), dim=1)
+
+        # add positional encoding to each token
+        if interpolate_pos_encoding:
+            embeddings = embeddings + self.interpolate_pos_encoding(
+                embeddings, height, width
+            )
+        else:
+            embeddings = embeddings + self.position_embeddings
+
+        embeddings = self.dropout(embeddings)
+
+        return embeddings


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #269
* #268
* __->__ #267
* #270
* #253
* #249

## Summary
- Repurpose FLAVA's `ImageEmbeddings`, `PatchEmbeddings` and `ImageTransformer` as generic classes for unified image encoder
- Add tests for embeddings and image encoder

## Test plan
`pytest test/models/flava -vv`
`pytest test/modules/encoders/test_image_encoder.py -vv`
`pytest test/modules/layers/test_image_embedding.py -vv`

Verify that `torchvision.models.VisionTransformer` has the same output as our `VisionTransformer` with the same weights loaded. Ran on a local notebook and got identical outputs. (The FLAVA head has an additional tanh that I had to apply on top on torchvision's vision transformer)

![image](https://user-images.githubusercontent.com/33648637/184703336-414dc3f3-a57b-4382-87b0-6f1089b91adf.png)

