### PR TITLE
[MUGEN] Rename head to logit_projection in MultimodalGPT

### DIFF
--- a/torchmultimodal/models/gpt.py
+++ b/torchmultimodal/models/gpt.py
@@ -160,7 +160,7 @@ class MultimodalGPT(nn.Module):
         )
 
         hidden_states = decoder_output.last_hidden_states
-        logits = self.head(hidden_states, logits_mask)
+        logits = self.logit_projection(hidden_states, logits_mask)
 
         return MultimodalGPTOutput(decoder_output, logits)
 
@@ -219,7 +219,7 @@ class MultimodalGPT(nn.Module):
             return_hidden_states=return_hidden_states,
         )
 
-    def head(
+    def logit_projection(
         self, hidden_states: Tensor, logits_mask: Optional[Tensor] = None
     ) -> Tensor:
         out = self.norm(hidden_states)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #273
* __->__ #272

Summary:
- Rename `MultimodalGPT.head()` to `logit_projection` to avoid confusion with a finetuning head.

Test Plan:
CI

Differential Revision: [D38788193](https://our.internmc.facebook.com/intern/diff/D38788193)