### PR TITLE
[Unification] Consolidate SiLU for CLIP and GPT

### DIFF
--- a/test/models/test_gpt.py
+++ b/test/models/test_gpt.py
@@ -15,7 +15,6 @@ from torchmultimodal.models.gpt import (
     MultimodalGPTOutput,
     MultimodalTransformerDecoder,
     RightShift,
-    SiLU,
     TransformerDecoder,
     TransformerDecoderLayer,
     TransformerDecoderOutput,
@@ -646,13 +645,6 @@ class TestTransformerDecoderLayer:
             },  # (b, h, seq_len, d_model//h)
         }
         assert_expected_namedtuple(actual, expected, rtol=1e-5, atol=1e-4)
-
-
-def test_sigmoid_linear_unit():
-    silu = SiLU()
-    actual = silu(torch.ones(3))
-    expected = torch.tensor([0.8458, 0.8458, 0.8458])
-    assert_expected(actual, expected)
 
 
 def test_right_shift(right_shift, d_model):

--- a/test/modules/layers/test_activation.py
+++ b/test/modules/layers/test_activation.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from test.test_utils import assert_expected
+from torchmultimodal.modules.layers.activation import SiLU
+
+
+def test_sigmoid_linear_unit():
+    silu = SiLU()
+    actual = silu(torch.ones(3))
+    expected = torch.tensor([0.8458, 0.8458, 0.8458])
+    assert_expected(actual, expected)

--- a/torchmultimodal/models/gpt.py
+++ b/torchmultimodal/models/gpt.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple, Union
 import torch
 from torch import nn, Tensor
 
+from torchmultimodal.modules.layers.activation import SiLU
 from torchmultimodal.modules.layers.attention import MultiHeadAttention, SelfAttention
 from torchmultimodal.modules.layers.mlp import MLP
 from torchmultimodal.utils.attention import get_extended_attention_mask
@@ -506,22 +507,6 @@ class TransformerDecoder(nn.Module):
             attention_weights=all_attentions,
             past_key_values=all_past_key_values,
         )
-
-
-class SiLU(nn.Module):
-    r"""Sigmoid Linear Unit
-
-    .. math:: \text{SiLU}(x) = x * \sigma(1.702 * x)
-
-    where :math:`\sigma(x)` is the cumulative distribution function for Logistic Distribution.
-
-    Approximation of the exact GeLU for greater forward speed. Note that this is different from
-    ``torch.nn.SiLU`` by the coefficient ``1.702`` from the paper:
-    `"Gaussian error linear units"<https://arxiv.org/pdf/1606.08415.pdf>`_.
-    """
-
-    def forward(self, x: Tensor) -> Tensor:
-        return torch.sigmoid(1.702 * x) * x
 
 
 class TransformerDecoderLayer(nn.Module):

--- a/torchmultimodal/modules/layers/activation.py
+++ b/torchmultimodal/modules/layers/activation.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch import nn, Tensor
+
+
+class SiLU(nn.Module):
+    r"""Sigmoid Linear Unit
+
+    .. math:: \text{SiLU}(x) = x * \sigma(1.702 * x)
+
+    where :math:`\sigma(x)` is the cumulative distribution function for Logistic Distribution.
+
+    Approximation of the exact GeLU for greater forward speed. Note that this is different from
+    ``torch.nn.SiLU`` by the coefficient ``1.702`` from the paper:
+    `"Gaussian error linear units"<https://arxiv.org/pdf/1606.08415.pdf>`_.
+    """
+
+    def forward(self, x: Tensor) -> Tensor:
+        return torch.sigmoid(1.702 * x) * x


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #273
* #272

Summary:
- Unify [Gaussian error linear unit](https://arxiv.org/pdf/1606.08415.pdf) between CLIP text encoder and GPT

Test Plan:

```
$ python -m pytest test/modules/layers/test_activation.py test/models/test_gpt.py test/models/clip/test_text_encoder.py -vv
================================================= test session starts ==================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/langong/local/miniconda3/envs/t2v/bin/python
cachedir: .pytest_cache
rootdir: /Users/langong/gpt_attention, configfile: pyproject.toml
plugins: mock-3.8.2, cov-3.0.0
collected 31 items

test/modules/layers/test_activation.py::test_sigmoid_linear_unit PASSED                                          [  3%]
test/models/test_gpt.py::TestMultimodalGPT::test_tokenizers_missing_methods PASSED                               [  6%]
test/models/test_gpt.py::TestMultimodalGPT::test_encode_invalid_modality PASSED                                  [  9%]
test/models/test_gpt.py::TestMultimodalGPT::test_decode_tokens_wrong_shape PASSED                                [ 12%]
test/models/test_gpt.py::TestMultimodalGPT::test_decode_tokens_reshape PASSED                                    [ 16%]
test/models/test_gpt.py::TestMultimodalGPT::test_lookup_invalid_modality PASSED                                  [ 19%]
test/models/test_gpt.py::TestMultimodalGPT::test_lookup_in_modality PASSED                                       [ 22%]
test/models/test_gpt.py::TestMultimodalGPT::test_lookup_out_modality PASSED                                      [ 25%]
test/models/test_gpt.py::TestMultimodalGPT::test_fwd_bad_input PASSED                                            [ 29%]
test/models/test_gpt.py::TestMultimodalGPT::test_fwd_for_generation PASSED                                       [ 32%]
test/models/test_gpt.py::TestMultimodalGPT::test_forward PASSED                                                  [ 35%]
test/models/test_gpt.py::TestMultimodalGPT::test_forward_logits_mask PASSED                                      [ 38%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_bad_input PASSED                                 [ 41%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_in_modality PASSED                       [ 45%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_out_modality PASSED                      [ 48%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_two_modality PASSED                      [ 51%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_eval_right_shift_on PASSED               [ 54%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_eval_right_shift_off PASSED              [ 58%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_bad_pos_ids PASSED                               [ 61%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_optional_pos_ids PASSED                          [ 64%]
test/models/test_gpt.py::TestTransformerDecoder::test_forward PASSED                                             [ 67%]
test/models/test_gpt.py::TestTransformerDecoder::test_forward_additional_output PASSED                           [ 70%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward PASSED                                        [ 74%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward_masked PASSED                                 [ 77%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward_additional_output PASSED                      [ 80%]
test/models/test_gpt.py::test_right_shift PASSED                                                                 [ 83%]
test/models/clip/test_text_encoder.py::TestCLIPTextEncoder::test_clip_parameters PASSED                          [ 87%]
test/models/clip/test_text_encoder.py::TestCLIPTextEncoder::test_attention_mask PASSED                           [ 90%]
test/models/clip/test_text_encoder.py::TestCLIPTextEncoder::test_forward PASSED                                  [ 93%]
test/models/clip/test_text_encoder.py::TestCLIPTextEncoder::test_forward_over_context_length PASSED              [ 96%]
test/models/clip/test_text_encoder.py::TestCLIPTextEncoder::test_scripting PASSED                                [100%]

=================================================== warnings summary ===================================================
test/models/clip/test_text_encoder.py::TestCLIPTextEncoder::test_scripting
  /Users/langong/local/miniconda3/envs/t2v/lib/python3.8/site-packages/torch/jit/_recursive.py:262: UserWarning: 'batch_first' was found in ScriptModule constants, but was not actually set in __init__. Consider removing it.
    warnings.warn("'{}' was found in ScriptModule constants, "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 31 passed, 1 warning in 5.49s ==========
```

Differential Revision: [D38788194](https://our.internmc.facebook.com/intern/diff/D38788194)