### PR TITLE
Refactor shuffle argument in MUGENDataModule

### DIFF
--- a/examples/mugen/data/CHANGELOG.md
+++ b/examples/mugen/data/CHANGELOG.md
@@ -15,6 +15,7 @@ Changes are noted with respect to the [original MUGEN dataset API](https://githu
 - Renamed `data.py` --> `mugen_datamodules.py` and renamed `VideoData` class to `MUGENDataModule`.
 - Renamed `mugen_data.py` --> `mugen_dataset.py`.
 - Replaced dependencies on OpenAI's `jukebox` and MUGEN's `audio_vqvae` by placing relevant functionality in `audio_utils.py`.
+- Move `shuffle` as an argument to `MUGENDataModule::{train/val/eval}_dataloader()` instead of the constructor to `MUGENDataModule`.
 
 ### Removed
 - Removed `data/coinrun/assets` folder.

--- a/examples/mugen/retrieval/configs/eval.yaml
+++ b/examples/mugen/retrieval/configs/eval.yaml
@@ -23,7 +23,6 @@ datamodule_args:
   _target_: examples.mugen.retrieval.definitions.DataModuleArgs
   batch_size: 16
   num_workers: 4
-  shuffle: False
   bert_text_transform:
     _target_: examples.mugen.retrieval.definitions.BertTextTransformArgs
   video_transform:
@@ -44,5 +43,6 @@ videoclip_args:
   video_pretrain_path: "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/S3D_kinetics400.pt"
   proj_out_dim: 256
   proj_dropout: 0.1
+shuffle_test: False
 checkpoint_path: "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/videoclip_lightning_mugen.pt"
 accelerator: "auto"

--- a/examples/mugen/retrieval/configs/train.yaml
+++ b/examples/mugen/retrieval/configs/train.yaml
@@ -23,7 +23,6 @@ datamodule_args:
   _target_: examples.mugen.retrieval.definitions.DataModuleArgs
   batch_size: 16
   num_workers: 4
-  shuffle: False
   bert_text_transform:
     _target_: examples.mugen.retrieval.definitions.BertTextTransformArgs
   video_transform:
@@ -46,6 +45,8 @@ videoclip_args:
   video_pretrain_path: "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/S3D_kinetics400.pt"
   proj_out_dim: 256
   proj_dropout: 0.1
+shuffle_train: True
+shuffle_val: False
 accelerator: "auto"
 devices: 4
 max_epochs: 20

--- a/examples/mugen/retrieval/definitions.py
+++ b/examples/mugen/retrieval/definitions.py
@@ -38,7 +38,6 @@ class VideoTransformArgs:
 class DataModuleArgs:
     batch_size: int = 16
     num_workers: int = 4
-    shuffle: bool = False
     bert_text_transform: BertTextTransformArgs = BertTextTransformArgs()
     video_transform: VideoTransformArgs = VideoTransformArgs()
 
@@ -81,6 +80,7 @@ class EvaluationArgs:
     datamodule_args: DataModuleArgs = DataModuleArgs()
     lightningmodule_args: LightningModuleArgs = LightningModuleArgs()
     videoclip_args: VideoCLIPArgs = VideoCLIPArgs()
+    shuffle_test: bool = False
     checkpoint_path: str = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/videoclip_lightning_mugen.pt"
     accelerator: str = "auto"
 
@@ -98,6 +98,8 @@ class TrainingArgs:
     datamodule_args: DataModuleArgs = DataModuleArgs()
     lightningmodule_args: LightningModuleArgs = LightningModuleArgs()
     videoclip_args: VideoCLIPArgs = VideoCLIPArgs()
+    shuffle_train: bool = True
+    shuffle_val: bool = False
     accelerator: str = "auto"
     devices: int = 4
     max_epochs: int = 1000

--- a/examples/mugen/retrieval/eval.py
+++ b/examples/mugen/retrieval/eval.py
@@ -37,7 +37,6 @@ def evaluate():
         video_transform=VideoTransform(**vars(args.datamodule_args.video_transform)),
         batch_size=args.datamodule_args.batch_size,
         num_workers=args.datamodule_args.num_workers,
-        shuffle=args.datamodule_args.shuffle,
     )
 
     model = VideoCLIPLightningModule.load_from_checkpoint(
@@ -47,7 +46,7 @@ def evaluate():
     )
 
     trainer = Trainer(accelerator=args.accelerator, devices=1)
-    trainer.test(model, dataloaders=datamodule.test_dataloader())
+    trainer.test(model, dataloaders=datamodule.test_dataloader(args.shuffle_test))
 
 
 if __name__ == "__main__":

--- a/examples/mugen/retrieval/train.py
+++ b/examples/mugen/retrieval/train.py
@@ -38,7 +38,6 @@ def train():
         video_transform=VideoTransform(**vars(args.datamodule_args.video_transform)),
         batch_size=args.datamodule_args.batch_size,
         num_workers=args.datamodule_args.num_workers,
-        shuffle=args.datamodule_args.shuffle,
     )
 
     model = VideoCLIPLightningModule(
@@ -58,8 +57,8 @@ def train():
     )
     trainer.fit(
         model=model,
-        train_dataloaders=datamodule.train_dataloader(),
-        val_dataloaders=datamodule.val_dataloader(),
+        train_dataloaders=datamodule.train_dataloader(args.shuffle_train),
+        val_dataloaders=datamodule.val_dataloader(args.shuffle_test),
     )
 
 

--- a/examples/mugen/retrieval/tutorial.ipynb
+++ b/examples/mugen/retrieval/tutorial.ipynb
@@ -139,7 +139,6 @@
     "datamodule = MUGENDataModule(\n",
     "    mugen_args, \n",
     "    batch_size=8,\n",
-    "    shuffle=False,\n",
     ")"
    ]
   },


### PR DESCRIPTION
Summary:
Refactor `shuffle` argument in `MUGENDataModule` so each data split can have a different shuffle value. Followup to #247.

Test plan:
(!! not yet tested, do not merge)
test by running eval and training scripts. Look for similar metrics as paper for eval using AWS weights, and likewise for eval using the weights from running the training script
```
# 1)
python eval.py config=configs/eval.yaml
# 2)
python train.py config=configs/train.yaml
# change `checkpoint_path` in eval.yaml to best checkpoint from training
python eval.py config=configs/eval.yaml
```
