### PR TITLE
[BE] Consolidate SiLU for CLIP and GPT: Part 2

### DIFF
--- a/torchmultimodal/models/clip/image_encoder.py
+++ b/torchmultimodal/models/clip/image_encoder.py
@@ -12,14 +12,11 @@ from typing import Tuple
 import torch
 import torch.nn.functional as F
 from torch import nn, Tensor
+from torchmultimodal.modules.layers.activation import SiLU
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
 
-EXPANSION = 4
 
-# Taken from original clip implementation https://github.com/openai/CLIP/blob/main/clip/model.py#L167
-# TODO: unify with the implementation in text encoder
-def quick_gelu(x: Tensor) -> Tensor:
-    return x * torch.sigmoid(1.702 * x)
+EXPANSION = 4
 
 
 class CLIPViTEncoder(nn.Module):
@@ -67,7 +64,7 @@ class CLIPViTEncoder(nn.Module):
             d_model=width,
             nhead=heads,
             dropout=0.0,
-            activation=quick_gelu,
+            activation=SiLU(),
             norm_first=True,
             dim_feedforward=4 * width,
             batch_first=True,

--- a/torchmultimodal/modules/encoders/clip_vit_encoder.py
+++ b/torchmultimodal/modules/encoders/clip_vit_encoder.py
@@ -6,11 +6,7 @@
 
 import torch
 from torch import nn, Tensor
-
-# Taken from original clip implementation https://github.com/openai/CLIP/blob/main/clip/model.py#L167
-# TODO: unify with the implementation in text encoder
-def quick_gelu(x: Tensor) -> Tensor:
-    return x * torch.sigmoid(1.702 * x)
+from torchmultimodal.modules.layers.activation import SiLU
 
 
 class CLIPViTEncoder(nn.Module):
@@ -58,7 +54,7 @@ class CLIPViTEncoder(nn.Module):
             d_model=width,
             nhead=heads,
             dropout=0.0,
-            activation=quick_gelu,
+            activation=SiLU(),
             norm_first=True,
             dim_feedforward=4 * width,
             batch_first=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #276
* __->__ #275

Summary:
- Replace `quick_gelu` with `SiLU` in `clip/image_encoder.py` and `clip_vit_encoder.py`
- Checked that there's no other `quick_gelu` left in the codebase
```
$ grep -r quick_gelu torchmultimodal/
Binary file torchmultimodal//modules/encoders/__pycache__/clip_text_encoder.cpython-38.pyc matches
```

Test Plan:
```
$ python -m pytest test/models/clip/test_image_encoder.py test/modules/encoders/test_clip_vit_encoder.py -vv
================================================= test session starts ==================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/langong/local/miniconda3/envs/t2v/bin/python
cachedir: .pytest_cache
rootdir: /Users/langong/gpt_attention, configfile: pyproject.toml
plugins: mock-3.8.2, cov-3.0.0
collected 5 items

test/models/clip/test_image_encoder.py::TestResnetEncoder::test_resnet PASSED                                    [ 20%]
test/models/clip/test_image_encoder.py::TestCLIPViTEncoder::test_forward PASSED                                  [ 40%]
test/models/clip/test_image_encoder.py::TestCLIPViTEncoder::test_invalid_input PASSED                            [ 60%]
test/modules/encoders/test_clip_vit_encoder.py::TestCLIPViTEncoder::test_forward PASSED                          [ 80%]
test/modules/encoders/test_clip_vit_encoder.py::TestCLIPViTEncoder::test_invalid_input PASSED                    [100%]

=============================== 5 passed in 2.37s ======================
```

Differential Revision: [D38865166](https://our.internmc.facebook.com/intern/diff/D38865166)