### PR TITLE
Add data_folder info to MUGEN dataset readme

### DIFF
--- a/examples/mugen/data/README.md
+++ b/examples/mugen/data/README.md
@@ -1,8 +1,9 @@
-This folder contains code for interfacing the MUGEN dataset (https://mugen-org.github.io). The MUGEN dataset contains over 300k videos, each with corresponding audio and text, from the game CoinRun.
+This folder contains code for interfacing the [MUGEN dataset](https://mugen-org.github.io). The MUGEN dataset contains over 300k videos, each with corresponding audio and text, from the game CoinRun.
 
 Before using this code,
 
-1. Download the 3.2s-video dataset [here](https://mugen-org.github.io/download) and save as `datasets/coinrun` in your pwd.
+1. Download the 3.2s-video dataset [here](https://mugen-org.github.io/download) and save as `datasets/coinrun` in your working directory.
+    * In each of `datasets/coinrun/coinrun_dataset_jsons/release/{train/val/test}.json`, change the value of `json_object["metadata"]["data_folder"]` to the absolute path of `datasets/coinrun`, e.g. `"/path/to/datasets/coinrun/"`.
 2. Download the MUGEN dataset assets [here](https://github.com/mugen-org/MUGEN_baseline/tree/main/lib/data/coinrun/assets) and save under `datasets/coinrun` as `datasets/coinrun/assets` in your pwd.
     * Downloading the assets from GitHub requires `git clone`-ing the original MUGEN repo and copying the assets directory located at `MUGEN_baseline/lib/data/coinrun/assets`.
 


### PR DESCRIPTION
Summary:
Add instruction for changing the `data_folder` value in the MUGEN dataset jsons. (Forgot I did this step when I first wrote the readme)
