### PR TITLE
[BE] Migrate some tests to pytest

### DIFF
--- a/examples/cnn_lstm/test/test_cnn_encoder.py
+++ b/examples/cnn_lstm/test/test_cnn_encoder.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
+import pytest
 
 import torch
 from examples.cnn_lstm.cnn_encoder import CNNEncoder
@@ -12,36 +12,66 @@ from test.test_utils import assert_expected, set_rng_seed
 from torch import nn, Tensor
 
 
-class TestCNNEncoder(unittest.TestCase):
-    def setUp(self):
-        set_rng_seed(0)
-        self.input = Tensor([1, 2, 3, 4, 5, 6, 1, 3, 5, 2, 4, 6]).reshape(2, 1, 2, 3)
-        self.input_dims = [0, 1, 2, 3]
-        self.output_dims = [1, 2, 4, 5]
-        self.kernel_sizes = [6, 7, 8, 9]
+@pytest.fixture(autouse=True)
+def random():
+    set_rng_seed(0)
 
-    def test_invalid_arg_lengths(self):
-        self.assertRaises(
-            AssertionError,
-            CNNEncoder,
-            self.input_dims[1:],
-            self.output_dims,
-            self.kernel_sizes,
-        )
 
-    def test_invalid_output_dims(self):
-        self.assertRaises(
-            AssertionError,
-            CNNEncoder,
-            self.input_dims,
-            self.output_dims,
-            self.kernel_sizes,
-        )
+class TestCNNEncoder:
+    @pytest.fixture()
+    def input(self):
+        return Tensor([1, 2, 3, 4, 5, 6, 1, 3, 5, 2, 4, 6]).reshape(2, 1, 2, 3)
 
-    def test_single_layer(self):
-        input = torch.rand(3, 3, 2, 2)
-        cnn_encoder = CNNEncoder([3], [3], [5])
-        actual = cnn_encoder(input)
+    @pytest.fixture()
+    def input_dims(self):
+        return [0, 1, 2, 3]
+
+    @pytest.fixture()
+    def output_dims(self):
+        return [1, 2, 4, 5]
+
+    @pytest.fixture()
+    def kernel_sizes(self):
+        return [6, 7, 8, 9]
+
+    @pytest.fixture()
+    def single_layer_input(self):
+        return torch.rand(3, 3, 2, 2)
+
+    @pytest.fixture()
+    def single_layer_cnn_encoder(self):
+        return CNNEncoder([3], [3], [5])
+
+    @pytest.fixture()
+    def multiple_layer_input(self):
+        return torch.rand(3, 3, 8, 8)
+
+    @pytest.fixture()
+    def multiple_layer_cnn_encoder(self):
+        return CNNEncoder([3, 2, 1], [2, 1, 2], [3, 5, 7])
+
+    @pytest.fixture()
+    def small_cnn_encoder(self):
+        return CNNEncoder([1], [1], [2])
+
+    def test_invalid_arg_lengths(self, input_dims, output_dims, kernel_sizes):
+        with pytest.raises(AssertionError):
+            CNNEncoder(
+                input_dims[1:],
+                output_dims,
+                kernel_sizes,
+            )
+
+    def test_invalid_output_dims(self, input_dims, output_dims, kernel_sizes):
+        with pytest.raises(AssertionError):
+            CNNEncoder(
+                input_dims,
+                output_dims,
+                kernel_sizes,
+            )
+
+    def test_single_layer(self, single_layer_input, single_layer_cnn_encoder):
+        actual = single_layer_cnn_encoder(single_layer_input)
         expected = Tensor(
             [
                 [-0.452341, 0.680854, -0.557894],
@@ -51,32 +81,28 @@ class TestCNNEncoder(unittest.TestCase):
         )
         assert_expected(actual, expected, rtol=0, atol=1e-4)
 
-    def test_multiple_layer(self):
-        input = torch.rand(3, 3, 8, 8)
-        cnn_encoder = CNNEncoder([3, 2, 1], [2, 1, 2], [3, 5, 7])
-        actual = cnn_encoder(input)
+    def test_multiple_layer(self, multiple_layer_input, multiple_layer_cnn_encoder):
+        actual = multiple_layer_cnn_encoder(multiple_layer_input)
         expected = Tensor(
             [[-0.482730, -0.253406], [1.391524, 1.298026], [-0.908794, -1.044622]]
         )
         assert_expected(actual, expected, rtol=0, atol=1e-4)
 
-    def test_fixed_weight_and_bias(self):
-        cnn_encoder = CNNEncoder([1], [1], [2])
-        cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.5]))
-        cnn_encoder.cnn[0][0].weight = nn.Parameter(
+    def test_fixed_weight_and_bias(self, input, small_cnn_encoder):
+        small_cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.5]))
+        small_cnn_encoder.cnn[0][0].weight = nn.Parameter(
             Tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0).unsqueeze(0)
         )
-        actual = cnn_encoder(self.input)
+        actual = small_cnn_encoder(input)
         expected = Tensor([[-0.434959, 0.807781], [-1.429150, 1.056329]])
         assert_expected(actual, expected, rtol=0, atol=1e-4)
 
-    def test_scripting(self):
-        cnn_encoder = CNNEncoder([1], [1], [2])
-        cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.5]))
-        cnn_encoder.cnn[0][0].weight = nn.Parameter(
+    def test_scripting(self, input, small_cnn_encoder):
+        small_cnn_encoder.cnn[0][0].bias = nn.Parameter(Tensor([0.5]))
+        small_cnn_encoder.cnn[0][0].weight = nn.Parameter(
             Tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0).unsqueeze(0)
         )
-        scripted_encoder = torch.jit.script(cnn_encoder)
-        actual = scripted_encoder(self.input)
+        scripted_encoder = torch.jit.script(small_cnn_encoder)
+        actual = scripted_encoder(input)
         expected = Tensor([[-0.434959, 0.807781], [-1.429150, 1.056329]])
         assert_expected(actual, expected, rtol=0, atol=1e-4)

--- a/examples/cnn_lstm/test/test_cnn_lstm.py
+++ b/examples/cnn_lstm/test/test_cnn_lstm.py
@@ -4,21 +4,30 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
+import pytest
 
 import torch
 from examples.cnn_lstm.cnn_lstm import cnn_lstm_classifier
+from test.test_utils import assert_expected, set_rng_seed
 
 
-class TestCNNLSTMModule(unittest.TestCase):
-    def setUp(self):
-        torch.manual_seed(1234)
-        self.classifier_in_dim = 450
-        self.num_classes = 32
+@pytest.fixture(autouse=True)
+def random():
+    set_rng_seed(1234)
 
-    def test_forward(self):
 
-        cnn_lstm = cnn_lstm_classifier(
+class TestCNNLSTMModule:
+    @pytest.fixture
+    def classifier_in_dim(self):
+        return 450
+
+    @pytest.fixture
+    def num_classes(self):
+        return 32
+
+    @pytest.fixture
+    def cnn_lstm(self, classifier_in_dim, num_classes):
+        return cnn_lstm_classifier(
             text_vocab_size=80,
             text_embedding_dim=20,
             cnn_input_dims=[3, 64, 128, 128, 64, 64],
@@ -28,12 +37,19 @@ class TestCNNLSTMModule(unittest.TestCase):
             lstm_hidden_dim=50,
             lstm_bidirectional=True,
             lstm_batch_first=True,
-            classifier_in_dim=self.classifier_in_dim,
-            num_classes=self.num_classes,
+            classifier_in_dim=classifier_in_dim,
+            num_classes=num_classes,
         )
-        self.assertTrue(isinstance(cnn_lstm, torch.nn.Module))
-        text = torch.randint(1, 79, (10,), dtype=torch.long).unsqueeze(0)
-        image = torch.randn(3, 320, 480).unsqueeze(0)
 
+    @pytest.fixture
+    def text(self):
+        return torch.randint(1, 79, (10,), dtype=torch.long).unsqueeze(0)
+
+    @pytest.fixture
+    def image(self):
+        return torch.randn(3, 320, 480).unsqueeze(0)
+
+    def test_forward(self, text, image, cnn_lstm):
+        assert isinstance(cnn_lstm, torch.nn.Module)
         scores = cnn_lstm({"image": image, "text": text})
-        self.assertEqual(scores.size(), torch.Size((1, 32)))
+        assert_expected(scores.size(), torch.Size((1, 32)))

--- a/examples/cnn_lstm/test/test_lstm_encoder.py
+++ b/examples/cnn_lstm/test/test_lstm_encoder.py
@@ -4,16 +4,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
+import pytest
 
 import torch
 from examples.cnn_lstm.lstm_encoder import LSTMEncoder
+from test.test_utils import assert_expected
 
 
-class TestLSTMEncoder(unittest.TestCase):
-    def test_lstm_encoder(self):
-        input = torch.randint(1, 79, (10,), dtype=torch.long).unsqueeze(0)
-        lstm_encoder = LSTMEncoder(
+class TestLSTMEncoder:
+    @pytest.fixture
+    def input(self):
+        return torch.randint(1, 79, (10,), dtype=torch.long).unsqueeze(0)
+
+    @pytest.fixture
+    def lstm_encoder(self):
+        return LSTMEncoder(
             vocab_size=80,
             embedding_dim=20,
             input_size=20,
@@ -21,5 +26,7 @@ class TestLSTMEncoder(unittest.TestCase):
             bidirectional=True,
             batch_first=True,
         )
+
+    def test_lstm_encoder(self, input, lstm_encoder):
         out = lstm_encoder(input)
-        self.assertEqual(out.size(), torch.Size([1, 100]))
+        assert_expected(out.size(), torch.Size([1, 100]))

--- a/test/models/flava/test_flava.py
+++ b/test/models/flava/test_flava.py
@@ -4,10 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
+import pytest
 
 import torch
-from test.test_utils import assert_expected_namedtuple
+from test.test_utils import assert_expected, assert_expected_namedtuple, set_rng_seed
 from torch import nn
 from torchmultimodal.models.flava.model import (
     flava_image_encoder,
@@ -22,34 +22,21 @@ from torchmultimodal.modules.layers.transformer import TransformerOutput
 NUM_CLASSES = 2
 
 
-class TestFLAVA(unittest.TestCase):
-    def setUp(self):
-        torch.manual_seed(1234)
+@pytest.fixture(autouse=True)
+def random():
+    set_rng_seed(1234)
 
-    @torch.no_grad()
-    def test_forward_classification(self):
+
+class TestFLAVA:
+    @pytest.fixture
+    def classification_inputs(self):
         text = torch.randint(0, 30500, (2, 77), dtype=torch.long)
         image = torch.rand((2, 3, 224, 224))
-
         labels = torch.randint(0, 2, (2,), dtype=torch.long)
+        return text, image, labels
 
-        flava = flava_model_for_classification(NUM_CLASSES, pretrained_model_key=None)
-        flava.eval()
-
-        # Test multimodal scenario
-        output = flava(image, text, "mm", labels)
-        self.assertAlmostEqual(output.loss.item(), 0.7180, places=4)
-
-        # Test unimodal image scenario
-        output = flava(image, text, "image", labels)
-        self.assertAlmostEqual(output.loss.item(), 0.7020, places=4)
-
-        # Test unimodal text scenario
-        output = flava(image, text, "text", labels)
-        self.assertAlmostEqual(output.loss.item(), 0.6663, places=4)
-
-    @torch.no_grad()
-    def test_forward_pretraining(self):
+    @pytest.fixture
+    def pretraining_inputs(self):
         text = torch.randint(0, 30500, (2, 77), dtype=torch.long)
         image = torch.rand((2, 3, 224, 224))
         image_for_codebook = torch.rand(2, 3, 112, 112)
@@ -60,6 +47,46 @@ class TestFLAVA(unittest.TestCase):
         mlm_labels[:, :] = -1
         mlm_labels[:, 1:3] = text[:, 1:3]
         itm_labels = torch.tensor((0, 1), dtype=torch.long)
+        return (
+            text,
+            image,
+            image_for_codebook,
+            image_patches_mask,
+            text_masked,
+            mlm_labels,
+            itm_labels,
+        )
+
+    @torch.no_grad()
+    def test_forward_classification(self, classification_inputs):
+        text, image, labels = classification_inputs
+
+        flava = flava_model_for_classification(NUM_CLASSES, pretrained_model_key=None)
+        flava.eval()
+
+        # Test multimodal scenario
+        output = flava(image, text, "mm", labels)
+        assert_expected(output.loss.item(), 0.7180, rtol=0, atol=1e-4)
+
+        # Test unimodal image scenario
+        output = flava(image, text, "image", labels)
+        assert_expected(output.loss.item(), 0.7020, rtol=0, atol=1e-4)
+
+        # Test unimodal text scenario
+        output = flava(image, text, "text", labels)
+        assert_expected(output.loss.item(), 0.6663, rtol=0, atol=1e-4)
+
+    @torch.no_grad()
+    def test_forward_pretraining(self, pretraining_inputs):
+        (
+            text,
+            image,
+            image_for_codebook,
+            image_patches_mask,
+            text_masked,
+            mlm_labels,
+            itm_labels,
+        ) = pretraining_inputs
         flava = flava_model_for_pretraining()
         flava.eval()
         output = flava(
@@ -72,18 +99,19 @@ class TestFLAVA(unittest.TestCase):
             itm_labels=itm_labels,
             mlm_labels=mlm_labels,
         )
-        self.assertIsNone(output.mlm_output)
-        self.assertIsNone(output.mim_output)
-        self.assertIsNotNone(output.global_contrastive_output)
-        self.assertIsNotNone(output.mmm_text_output)
-        self.assertIsNotNone(output.mmm_image_output)
-        self.assertIsNotNone(output.itm_output)
-        self.assertAlmostEqual(
+        assert output.mlm_output is None
+        assert output.mim_output is None
+        assert output.global_contrastive_output is not None
+        assert output.mmm_text_output is not None
+        assert output.mmm_image_output is not None
+        assert output.itm_output is not None
+        assert_expected(
             sum(
                 value if value is not None else 0 for value in output.losses.values()
             ).item(),
             21.5150,
-            places=4,
+            rtol=0,
+            atol=1e-4,
         )
 
         output = flava(
@@ -96,18 +124,19 @@ class TestFLAVA(unittest.TestCase):
             itm_labels=itm_labels,
             mlm_labels=mlm_labels,
         )
-        self.assertIsNone(output.mlm_output)
-        self.assertIsNotNone(output.mim_output)
-        self.assertIsNone(output.global_contrastive_output)
-        self.assertIsNone(output.mmm_text_output)
-        self.assertIsNone(output.mmm_image_output)
-        self.assertIsNone(output.itm_output)
-        self.assertAlmostEqual(
+        assert output.mlm_output is None
+        assert output.mim_output is not None
+        assert output.global_contrastive_output is None
+        assert output.mmm_text_output is None
+        assert output.mmm_image_output is None
+        assert output.itm_output is None
+        assert_expected(
             sum(
                 value if value is not None else 0 for value in output.losses.values()
             ).item(),
             8.9674,
-            places=4,
+            rtol=0,
+            atol=1e-4,
         )
 
         output = flava(
@@ -120,31 +149,35 @@ class TestFLAVA(unittest.TestCase):
             itm_labels=itm_labels,
             mlm_labels=mlm_labels,
         )
-        self.assertIsNotNone(output.mlm_output)
-        self.assertIsNone(output.mim_output)
-        self.assertIsNone(output.global_contrastive_output)
-        self.assertIsNone(output.mmm_text_output)
-        self.assertIsNone(output.mmm_image_output)
-        self.assertIsNone(output.itm_output)
-
-        self.assertAlmostEqual(
+        assert output.mlm_output is not None
+        assert output.mim_output is None
+        assert output.global_contrastive_output is None
+        assert output.mmm_text_output is None
+        assert output.mmm_image_output is None
+        assert output.itm_output is None
+        assert_expected(
             sum(
                 value if value is not None else 0 for value in output.losses.values()
             ).item(),
             10.0305,
-            places=4,
+            rtol=0,
+            atol=1e-4,
         )
 
 
-class TestFLAVAModel(unittest.TestCase):
-    def setUp(self):
-        self.text_encoder = flava_text_encoder(
+class TestFLAVAModel:
+    @pytest.fixture
+    def text_encoder(self):
+        return flava_text_encoder(
             hidden_size=2,
             num_attention_heads=1,
             num_hidden_layers=1,
             intermediate_size=2,
         )
-        self.image_encoder = flava_image_encoder(
+
+    @pytest.fixture
+    def image_encoder(self):
+        return flava_image_encoder(
             hidden_size=2,
             num_attention_heads=1,
             num_hidden_layers=1,
@@ -155,50 +188,84 @@ class TestFLAVAModel(unittest.TestCase):
             use_image_masking=True,
         )
 
-        mm_encoder = nn.Identity()
-        image_to_mm_projection = nn.Identity()
-        text_to_mm_projection = nn.Identity()
-        self.flava = FLAVAModel(
-            image_encoder=self.image_encoder,
-            text_encoder=self.text_encoder,
+    @pytest.fixture
+    def mm_encoder(self):
+        return nn.Identity()
+
+    @pytest.fixture
+    def image_to_mm_projection(self):
+        return nn.Identity()
+
+    @pytest.fixture
+    def text_to_mm_projection(self):
+        return nn.Identity()
+
+    @pytest.fixture
+    def text_projection(self):
+        return nn.Identity()
+
+    @pytest.fixture
+    def image_projection(self):
+        return nn.Identity()
+
+    @pytest.fixture
+    def flava(
+        self,
+        image_encoder,
+        text_encoder,
+        mm_encoder,
+        image_to_mm_projection,
+        text_to_mm_projection,
+        text_projection,
+        image_projection,
+    ):
+        return FLAVAModel(
+            image_encoder=image_encoder,
+            text_encoder=text_encoder,
             mm_encoder=mm_encoder,
             image_to_mm_projection=image_to_mm_projection,
             text_to_mm_projection=text_to_mm_projection,
-            text_projection=nn.Identity(),
-            image_projection=nn.Identity(),
+            text_projection=text_projection,
+            image_projection=image_projection,
         )
 
-    def test_forward_image_text(self):
-        image = torch.ones(2, 3, 2, 2)
+    @pytest.fixture
+    def inputs(self):
+        image = torch.zeros(2, 3, 2, 2)
+        masked_image = torch.ones(2, 1)
         text = torch.ones(2, 3, dtype=torch.int32)
-        actual = self.flava(image, text)
+        masked_text = torch.ones(2, 3, dtype=torch.int32)
+        return image, masked_image, text, masked_text
+
+    def test_forward_image_text(self, image_encoder, text_encoder, flava, inputs):
+        image, _, text, _ = inputs
+        actual = flava(image, text)
         expected = FLAVAOutput(
             text_masked=TransformerOutput(),
             multimodal_masked=TransformerOutput(),
             multimodal=TransformerOutput(),
-            text=self.text_encoder(
+            text=text_encoder(
                 text, return_attn_weights=True, return_hidden_states=True
             ),
-            image=self.image_encoder(image),
-            image_masked=self.image_encoder(image),
+            image=image_encoder(image),
+            image_masked=image_encoder(image),
             projected_image_embeddings=actual.image.last_hidden_state[:, 0, :],
             projected_text_embeddings=actual.text.last_hidden_state[:, 0, :],
         )
         assert_expected_namedtuple(actual, expected, rtol=0, atol=1e-4)
 
-    def test_forward_masked_image_and_text(self):
-        image = torch.zeros(2, 3, 2, 2)
-        masked_image = torch.ones(2, 1)
-        text = torch.ones(2, 3, dtype=torch.int32)
-        masked_text = torch.ones(2, 3, dtype=torch.int32)
-        actual = self.flava(
+    def test_forward_masked_image_and_text(
+        self, image_encoder, text_encoder, flava, inputs
+    ):
+        image, masked_image, text, masked_text = inputs
+        actual = flava(
             text=text,
             image=image,
             image_patches_mask=masked_image,
             text_masked=masked_text,
         )
         expected = FLAVAOutput(
-            text_masked=self.text_encoder(
+            text_masked=text_encoder(
                 masked_text, return_attn_weights=True, return_hidden_states=True
             ),
             multimodal_masked=torch.cat(
@@ -209,29 +276,30 @@ class TestFLAVAModel(unittest.TestCase):
                 1,
             ),
             multimodal=TransformerOutput(),
-            text=self.text_encoder(
+            text=text_encoder(
                 text, return_attn_weights=True, return_hidden_states=True
             ),
-            image=self.image_encoder(image),
-            image_masked=self.image_encoder(image, masked_image),
+            image=image_encoder(image),
+            image_masked=image_encoder(image, masked_image),
             projected_image_embeddings=actual.image.last_hidden_state[:, 0, :],
             projected_text_embeddings=actual.text.last_hidden_state[:, 0, :],
         )
         assert_expected_namedtuple(actual, expected, rtol=0, atol=1e-4)
 
-    def test_forward_masked_text(self):
+    def test_forward_masked_text(self, text_encoder, flava, inputs):
+        _, _, text, masked_text = inputs
         text = torch.ones(2, 3, dtype=torch.int32)
         masked_text = torch.ones(2, 3, dtype=torch.int32)
-        actual = self.flava(text=text, text_masked=masked_text)
+        actual = flava(text=text, text_masked=masked_text)
         expected = FLAVAOutput(
             multimodal_masked=TransformerOutput(),
             multimodal=TransformerOutput(),
-            text=self.text_encoder(
+            text=text_encoder(
                 text, return_attn_weights=True, return_hidden_states=True
             ),
             image=TransformerOutput(),
             image_masked=TransformerOutput(),
-            text_masked=self.text_encoder(
+            text_masked=text_encoder(
                 masked_text, return_attn_weights=True, return_hidden_states=True
             ),
             projected_image_embeddings=None,
@@ -239,13 +307,13 @@ class TestFLAVAModel(unittest.TestCase):
         )
         assert_expected_namedtuple(actual, expected, rtol=0, atol=1e-4)
 
-    def test_forward_text(self):
-        text = torch.ones(2, 3, dtype=torch.int32)
-        actual = self.flava(text=text)
+    def test_forward_text(self, text_encoder, flava, inputs):
+        _, _, text, _ = inputs
+        actual = flava(text=text)
         expected = FLAVAOutput(
             multimodal_masked=TransformerOutput(),
             multimodal=TransformerOutput(),
-            text=self.text_encoder(
+            text=text_encoder(
                 text, return_attn_weights=True, return_hidden_states=True
             ),
             image=TransformerOutput(),
@@ -256,31 +324,30 @@ class TestFLAVAModel(unittest.TestCase):
         )
         assert_expected_namedtuple(actual, expected, rtol=0, atol=1e-4)
 
-    def test_forward_masked_image(self):
-        image = torch.zeros(2, 3, 2, 2)
-        masked_image = torch.ones(2, 1)
-        actual = self.flava(image=image, image_patches_mask=masked_image)
+    def test_forward_masked_image(self, image_encoder, flava, inputs):
+        image, masked_image, _, _ = inputs
+        actual = flava(image=image, image_patches_mask=masked_image)
         expected = FLAVAOutput(
             multimodal_masked=TransformerOutput(),
             multimodal=TransformerOutput(),
             text=TransformerOutput(),
-            image=self.image_encoder(image),
-            image_masked=self.image_encoder(image, masked_image),
+            image=image_encoder(image),
+            image_masked=image_encoder(image, masked_image),
             text_masked=TransformerOutput(),
             projected_image_embeddings=actual.image.last_hidden_state[:, 0, :],
             projected_text_embeddings=None,
         )
         assert_expected_namedtuple(actual, expected, rtol=0, atol=1e-4)
 
-    def test_forward_image(self):
-        image = torch.zeros(2, 3, 2, 2)
-        actual = self.flava(image=image)
+    def test_forward_image(self, image_encoder, flava, inputs):
+        image, _, _, _ = inputs
+        actual = flava(image=image)
         expected = FLAVAOutput(
             multimodal_masked=TransformerOutput(),
             multimodal=TransformerOutput(),
             text=TransformerOutput(),
-            image=self.image_encoder(image),
-            image_masked=self.image_encoder(image),
+            image=image_encoder(image),
+            image_masked=image_encoder(image),
             text_masked=TransformerOutput(),
             projected_image_embeddings=actual.image.last_hidden_state[:, 0, :],
             projected_text_embeddings=None,

--- a/test/models/flava/test_flava.py
+++ b/test/models/flava/test_flava.py
@@ -219,7 +219,7 @@ class TestFLAVAModel:
         text_projection,
         image_projection,
     ):
-        return FLAVAModel(
+        flava_model = FLAVAModel(
             image_encoder=image_encoder,
             text_encoder=text_encoder,
             mm_encoder=mm_encoder,
@@ -228,6 +228,8 @@ class TestFLAVAModel:
             text_projection=text_projection,
             image_projection=image_projection,
         )
+        flava_model.eval()
+        return flava_model
 
     @pytest.fixture
     def inputs(self):

--- a/test/models/flava/test_flava.py
+++ b/test/models/flava/test_flava.py
@@ -189,44 +189,19 @@ class TestFLAVAModel:
         )
 
     @pytest.fixture
-    def mm_encoder(self):
-        return nn.Identity()
-
-    @pytest.fixture
-    def image_to_mm_projection(self):
-        return nn.Identity()
-
-    @pytest.fixture
-    def text_to_mm_projection(self):
-        return nn.Identity()
-
-    @pytest.fixture
-    def text_projection(self):
-        return nn.Identity()
-
-    @pytest.fixture
-    def image_projection(self):
-        return nn.Identity()
-
-    @pytest.fixture
     def flava(
         self,
         image_encoder,
         text_encoder,
-        mm_encoder,
-        image_to_mm_projection,
-        text_to_mm_projection,
-        text_projection,
-        image_projection,
     ):
         flava_model = FLAVAModel(
             image_encoder=image_encoder,
             text_encoder=text_encoder,
-            mm_encoder=mm_encoder,
-            image_to_mm_projection=image_to_mm_projection,
-            text_to_mm_projection=text_to_mm_projection,
-            text_projection=text_projection,
-            image_projection=image_projection,
+            mm_encoder=nn.Identity(),
+            image_to_mm_projection=nn.Identity(),
+            text_to_mm_projection=nn.Identity(),
+            text_projection=nn.Identity(),
+            image_projection=nn.Identity(),
         )
         flava_model.eval()
         return flava_model

--- a/test/models/test_late_fusion.py
+++ b/test/models/test_late_fusion.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
+import pytest
 
 import torch
 from test.test_utils import assert_expected
@@ -12,21 +12,32 @@ from torchmultimodal.models.late_fusion import LateFusion
 from torchmultimodal.modules.fusions.concat_fusion import ConcatFusionModule
 
 
-class TestLateFusion(unittest.TestCase):
-    def setUp(self):
-        self.encoders = torch.nn.ModuleDict(
+class TestLateFusion:
+    @pytest.fixture
+    def encoders(self):
+        return torch.nn.ModuleDict(
             {"c1": torch.nn.Identity(), "c2": torch.nn.Identity()}
         )
-        self.fusion_module = ConcatFusionModule()
-        self.head_module = torch.nn.Identity()
-        self.late_fusion = LateFusion(
-            self.encoders,
-            self.fusion_module,
-            self.head_module,
+
+    @pytest.fixture
+    def fusion_module(self):
+        return ConcatFusionModule()
+
+    @pytest.fixture
+    def head_module(self):
+        return torch.nn.Identity()
+
+    @pytest.fixture
+    def late_fusion(self, encoders, fusion_module, head_module):
+        return LateFusion(
+            encoders,
+            fusion_module,
+            head_module,
         )
 
-    def test_forward(self):
-        modalities = {
+    @pytest.fixture
+    def modalities_1(self):
+        return {
             "c1": torch.Tensor(
                 [
                     [1, 0, 0.25, 0.75],
@@ -40,15 +51,10 @@ class TestLateFusion(unittest.TestCase):
                 ]
             ),
         }
-        actual = self.late_fusion(modalities)
-        expected = torch.Tensor(
-            [[1, 0, 0.25, 0.75, 3, 1, 0.8, 0.9], [0, 1, 0.6, 0.4, 0.7, 2, 0.6, 0]]
-        )
 
-        assert_expected(actual, expected)
-
-    def test_script(self):
-        modalities = {
+    @pytest.fixture
+    def modalities_2(self):
+        return {
             "c1": torch.Tensor(
                 [
                     [7, 0, 0.65],
@@ -62,13 +68,10 @@ class TestLateFusion(unittest.TestCase):
                 ]
             ),
         }
-        scripted_late_fusion = torch.jit.script(self.late_fusion)
-        actual = scripted_late_fusion(modalities)
-        expected = torch.Tensor([[7, 0, 0.65, 8, 9, 0.8], [88, 5, 0.3, 0.74, 2, 0]])
-        assert_expected(actual, expected)
 
-    def test_missing_key_in_modalities(self):
-        modalities = {
+    @pytest.fixture
+    def modalities_3(self):
+        return {
             "c3": torch.Tensor(
                 [
                     [8, 0, 0.5, 0.7],
@@ -76,5 +79,23 @@ class TestLateFusion(unittest.TestCase):
                 ]
             ),
         }
-        with self.assertRaises(AssertionError):
-            self.late_fusion(modalities)
+
+    def test_forward(self, late_fusion, modalities_1):
+
+        actual = late_fusion(modalities_1)
+        expected = torch.Tensor(
+            [[1, 0, 0.25, 0.75, 3, 1, 0.8, 0.9], [0, 1, 0.6, 0.4, 0.7, 2, 0.6, 0]]
+        )
+
+        assert_expected(actual, expected)
+
+    def test_script(self, late_fusion, modalities_2):
+
+        scripted_late_fusion = torch.jit.script(late_fusion)
+        actual = scripted_late_fusion(modalities_2)
+        expected = torch.Tensor([[7, 0, 0.65, 8, 9, 0.8], [88, 5, 0.3, 0.74, 2, 0]])
+        assert_expected(actual, expected)
+
+    def test_missing_key_in_modalities(self, late_fusion, modalities_3):
+        with pytest.raises(AssertionError):
+            late_fusion(modalities_3)

--- a/test/models/test_two_tower.py
+++ b/test/models/test_two_tower.py
@@ -4,72 +4,91 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
 from typing import List
 
+import pytest
+
 import torch
+from test.test_utils import assert_expected
 from torch import nn, Tensor
 from torchmultimodal.models.late_fusion import LateFusion
 from torchmultimodal.models.two_tower import TwoTower
 from torchmultimodal.modules.fusions.concat_fusion import ConcatFusionModule
 
 
-class Concat(nn.Module):
-    def forward(self, x: List[Tensor]) -> Tensor:
-        return torch.cat(x, dim=-1)
+@pytest.fixture
+def tower_fusion():
+    class Concat(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: List[Tensor]) -> Tensor:
+            return torch.cat(x, dim=-1)
+
+    return Concat()
 
 
-class TestTwoTower(unittest.TestCase):
-    def setUp(self):
-        self.tower_1 = LateFusion(
+class TestTwoTower:
+    @pytest.fixture
+    def tower_1(self):
+        return LateFusion(
             {"c1": nn.Identity(), "c2": nn.Identity()},
             ConcatFusionModule(),
             nn.Identity(),
         )
-        self.tower_2 = LateFusion(
+
+    @pytest.fixture
+    def tower_2(self):
+        return LateFusion(
             {"c3": nn.Identity(), "c4": nn.Identity()},
             ConcatFusionModule(),
             nn.Identity(),
         )
-        self.tower_fusion = Concat()
-        self.batch_size = 3
-        self.data = {
-            "c1": torch.rand(self.batch_size, 8),
-            "c2": torch.rand(self.batch_size, 16),
-            "c3": torch.rand(self.batch_size, 4),
-            "c4": torch.rand(self.batch_size, 12),
+
+    @pytest.fixture
+    def batch_size(self):
+        return 3
+
+    @pytest.fixture
+    def data(self, batch_size):
+        return {
+            "c1": torch.rand(batch_size, 8),
+            "c2": torch.rand(batch_size, 16),
+            "c3": torch.rand(batch_size, 4),
+            "c4": torch.rand(batch_size, 12),
         }
 
-    def test_two_tower(self):
-        two_tower = TwoTower(
-            tower_id_to_tower={"tower_1": self.tower_1, "tower_2": self.tower_2},
-            tower_fusion=self.tower_fusion,
+    @pytest.fixture
+    def two_tower(self, tower_1, tower_2, tower_fusion):
+        return TwoTower(
+            tower_id_to_tower={"tower_1": tower_1, "tower_2": tower_2},
+            tower_fusion=tower_fusion,
         )
-        out = two_tower(self.data)
-        self.assertEqual(out[0].size(), (self.batch_size, 40))
 
-    def test_shared_two_tower(self):
-        two_tower = TwoTower(
-            tower_id_to_tower={"tower_1": self.tower_1, "tower_2": self.tower_1},
-            tower_fusion=self.tower_fusion,
+    @pytest.fixture
+    def shared_two_tower(self, tower_1, tower_fusion):
+        return TwoTower(
+            tower_id_to_tower={"tower_1": tower_1, "tower_2": tower_1},
+            tower_fusion=tower_fusion,
             shared_tower_id_to_channel_mapping={"tower_2": {"c1": "c3", "c2": "c4"}},
         )
-        out = two_tower(self.data)
-        self.assertEqual(out[0].size(), (self.batch_size, 40))
 
-    def test_two_tower_scripting(self):
-        torch.jit.script(
-            TwoTower(
-                tower_id_to_tower={"tower_1": self.tower_1, "tower_2": self.tower_2},
-                tower_fusion=self.tower_fusion,
-            )
+    @pytest.fixture
+    def shared_two_tower_scripting(self, tower_1, tower_fusion):
+        return TwoTower(
+            tower_id_to_tower={"tower_1": tower_1, "tower_2": tower_1},
+            tower_fusion=tower_fusion,
+            shared_tower_id_to_channel_mapping={"tower_2": {"c3": "c1", "c4": "c2"}},
         )
-        torch.jit.script(
-            TwoTower(
-                tower_id_to_tower={"tower_1": self.tower_1, "tower_2": self.tower_1},
-                tower_fusion=self.tower_fusion,
-                shared_tower_id_to_channel_mapping={
-                    "tower_2": {"c3": "c1", "c4": "c2"}
-                },
-            )
-        )
+
+    def test_two_tower(self, two_tower, data, batch_size):
+        out = two_tower(data)
+        assert_expected(out[0].size(), (batch_size, 40))
+
+    def test_shared_two_tower(self, shared_two_tower, data, batch_size):
+        out = shared_two_tower(data)
+        assert_expected(out[0].size(), (batch_size, 40))
+
+    def test_two_tower_scripting(self, two_tower, shared_two_tower_scripting):
+        torch.jit.script(two_tower)
+        torch.jit.script(shared_two_tower_scripting)


### PR DESCRIPTION
Summary: Migrated FLAVA, two tower, late fusion, and CNNLSTM tests from unittest to pytest.
Kept initialization order the same so we don't have to change any expected values in this PR (most relevant for FLAVA tests).

Test plan:
```
python -m pytest -v
```
