### PR TITLE
[MUGEN] Add weight init to MultimodalGPT

### DIFF
--- a/test/models/test_gpt.py
+++ b/test/models/test_gpt.py
@@ -216,7 +216,7 @@ def gpt(
     in_projection,
     out_projection,
 ):
-    def _gpt(in_tokenizer=tokenizer, out_tokenizer=tokenizer):
+    def _gpt(in_tokenizer=tokenizer, out_tokenizer=tokenizer, use_gpt_init=False):
         return MultimodalGPT(
             d_model=d_model,
             num_in_tokens=num_in_tokens,
@@ -227,6 +227,8 @@ def gpt(
             mm_decoder=mm_decoder,
             in_projection=in_projection,
             out_projection=out_projection,
+            norm_layer=None,
+            use_gpt_init=use_gpt_init,
         ).eval()
 
     return _gpt
@@ -249,6 +251,14 @@ class TestMultimodalGPT:
 
         with pytest.raises(AttributeError):
             gpt(out_tokenizer=BadTokenizer())
+
+    def test_initialize_parameters(self, gpt, mocker):
+        # Testing mean and std of the initialized weights data requires a large
+        # amount samples to be statistically stable. Here we just test whether
+        # the method in question has been called to avoid test flakiness.
+        mock_init = mocker.patch("torchmultimodal.models.gpt.Tensor.normal_")
+        gpt = gpt(use_gpt_init=True)
+        mock_init.assert_called()
 
     def test_encode_invalid_modality(self, gpt):
         gpt = gpt()

--- a/torchmultimodal/models/gpt.py
+++ b/torchmultimodal/models/gpt.py
@@ -57,6 +57,7 @@ class MultimodalGPT(nn.Module):
             transformer decoder. Defaults to ``None``.
         norm_layer (Callable[..., nn.Module], optional): Which normalization layer to use. Supports ``nn.Module`` or
             partial. If ``None``, ``nn.LayerNorm`` will be used as the default.
+        use_gpt_init (bool): Whether to use GPT model specific initialization. Defaults to ``True``.
 
     Args:
         in_tokens (Tensor, optional): Tensor of dimension ``(b, in_seq_len, c)`` containing tokens
@@ -70,8 +71,9 @@ class MultimodalGPT(nn.Module):
         attn_mask (Tensor, optional): Tensor of dimension ``(q_seq_len, k_seq_len)`` or ``(b, q_seq_len, k_seq_len)``
             where prefixes ``q`` and ``k`` stand for query and key. Contains 1s for positions to attend to and 0s
             for masked positions. Defaults to ``None``.
-        head_mask (Tensor, optional): Tensor of dimension ``(h, q_seq_len, k_seq_len)`` or ``(b, h, q_seq_len, k_seq_len)``.
-            Masks need to be specified for each attention head. Defaults to ``None``.
+        head_mask (Tensor, optional): Tensor of dimension ``(h, q_seq_len, k_seq_len)`` or
+            ``(b, h, q_seq_len, k_seq_len)``. Masks need to be specified for each attention head.
+            Defaults to ``None``.
         logits_mask (Tensor, optional): Tensor of dimension ``(seq_len, num_tokens)`` or ``(b, seq_len, num_tokens)``
             to ensure we only calculate probabilities from tokens of the corresponding modality sequence.
         use_cache (bool, optional): If ``True``, caches past key/value tensors for faster decoding. If ``False``,
@@ -101,6 +103,7 @@ class MultimodalGPT(nn.Module):
         in_projection: Optional[nn.Module] = None,
         out_projection: Optional[nn.Module] = None,
         norm_layer: Optional[Callable[..., nn.Module]] = None,
+        use_gpt_init: bool = True,
     ) -> None:
         super().__init__()
         if not all(
@@ -136,6 +139,18 @@ class MultimodalGPT(nn.Module):
         # This will give us equal probabilities after the soft max layer initially to avoid biasing
         # towards any particular prediction category
         self.to_logit.weight.data.copy_(torch.zeros(num_tokens, d_model))
+
+        if use_gpt_init:
+            self.initialize_parameters()
+
+    def initialize_parameters(self) -> None:
+        # Initialize weights of the layers in question, e.g.,  after loading checkpoints
+        # Only do this when the layers have weights data, e.g., for text tokenizer the projection
+        # layer is dummy (nn.Identity)
+        if hasattr(self.in_projection, "weight"):
+            self.in_projection.weight.data.normal_(std=0.02)  # type: ignore
+        if hasattr(self.out_projection, "weight"):
+            self.out_projection.weight.data.normal_(std=0.02)  # type: ignore
 
     def forward(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #282
* #281
* #276
* __->__ #283

Summary:
Add this as a separate PR in regard to [comment](https://github.com/facebookresearch/multimodal/pull/276#discussion_r954040023) in #276

Test Plan:
```
$ python -m pytest test/models/test_gpt.py -vv
================================================= test session starts ==================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/langong/local/miniconda3/envs/torchmm38/bin/python
cachedir: .pytest_cache
rootdir: /Users/langong/gpt_attention, configfile: pyproject.toml
plugins: mock-3.8.2, cov-3.0.0
collected 27 items

test/models/test_gpt.py::TestMultimodalGPT::test_tokenizers_missing_methods PASSED                               [  3%]
test/models/test_gpt.py::TestMultimodalGPT::test_initialize_parameters PASSED                                    [  7%]
test/models/test_gpt.py::TestMultimodalGPT::test_encode_invalid_modality PASSED                                  [ 11%]
test/models/test_gpt.py::TestMultimodalGPT::test_decode_tokens_wrong_shape PASSED                                [ 14%]
test/models/test_gpt.py::TestMultimodalGPT::test_decode_tokens_reshape PASSED                                    [ 18%]
test/models/test_gpt.py::TestMultimodalGPT::test_lookup_invalid_modality PASSED                                  [ 22%]
test/models/test_gpt.py::TestMultimodalGPT::test_lookup_in_modality PASSED                                       [ 25%]
test/models/test_gpt.py::TestMultimodalGPT::test_lookup_out_modality PASSED                                      [ 29%]
test/models/test_gpt.py::TestMultimodalGPT::test_fwd_bad_input PASSED                                            [ 33%]
test/models/test_gpt.py::TestMultimodalGPT::test_fwd_for_generation PASSED                                       [ 37%]
test/models/test_gpt.py::TestMultimodalGPT::test_forward PASSED                                                  [ 40%]
test/models/test_gpt.py::TestMultimodalGPT::test_forward_logits_mask PASSED                                      [ 44%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_bad_input PASSED                                 [ 48%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_in_modality PASSED                       [ 51%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_out_modality PASSED                      [ 55%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_two_modality PASSED                      [ 59%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_eval_right_shift_on PASSED               [ 62%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_forward_eval_right_shift_off PASSED              [ 66%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_bad_pos_ids PASSED                               [ 70%]
test/models/test_gpt.py::TestMultimodalTransformerDecoder::test_optional_pos_ids PASSED                          [ 74%]
test/models/test_gpt.py::TestTransformerDecoder::test_forward_mask_extended PASSED                               [ 77%]
test/models/test_gpt.py::TestTransformerDecoder::test_forward PASSED                                             [ 81%]
test/models/test_gpt.py::TestTransformerDecoder::test_forward_additional_output PASSED                           [ 85%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward PASSED                                        [ 88%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward_masked PASSED                                 [ 92%]
test/models/test_gpt.py::TestTransformerDecoderLayer::test_forward_additional_output PASSED                      [ 96%]
test/models/test_gpt.py::test_right_shift PASSED                                                                 [100%]

============================ 27 passed in 1.64s ===============================
```

Differential Revision: [D39030361](https://our.internmc.facebook.com/intern/diff/D39030361)