### PR TITLE
[CLIP]Fix gpu tests

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, NamedTuple, Optional, Tuple, Union
 
+import pytest
 import torch
 import torch.distributed as dist
 from torch import Tensor
@@ -21,10 +22,8 @@ def gpu_test(gpu_count: int = 1):
     Annotation for GPU tests, skipping the test if the
     required amount of GPU is not available
     """
-    import unittest
-
     message = f"Not enough GPUs to run the test: required {gpu_count}"
-    return unittest.skipIf(torch.cuda.device_count() < gpu_count, message)
+    return pytest.mark.skipif(torch.cuda.device_count() < gpu_count, reason=message)
 
 
 def init_distributed_on_file(world_size: int, gpu_id: int, sync_file: str):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #291
* __->__ #290
* #288

Differential Revision: [D39106446](https://our.internmc.facebook.com/intern/diff/D39106446)

- Fix the gpu test. They were failing because spawn needs global or static functions afaic
- Move test and context manager to pytest

Test plan : 
on gpu 

pytest test/modules/losses/test_contrastive_loss_with_temperature.py -vv
======================================================================== test session starts =========================================================================
platform linux -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /data/home/deankita/miniconda/envs/tmm2/bin/python
cachedir: .pytest_cache
rootdir: /data/home/deankita/tmm2, configfile: pyproject.toml
plugins: hydra-core-1.1.2, mock-3.8.2, cov-3.0.0
collected 7 items                                                                                                                                                    

test/modules/losses/test_contrastive_loss_with_temperature.py::TestContrastiveLossWithTemperature::test_local_loss PASSED                                      [ 14%]
test/modules/losses/test_contrastive_loss_with_temperature.py::TestContrastiveLossWithTemperature::test_temperature_clamp_max PASSED                           [ 28%]
test/modules/losses/test_contrastive_loss_with_temperature.py::TestContrastiveLossWithTemperature::test_temperature_clamp_min PASSED                           [ 42%]
test/modules/losses/test_contrastive_loss_with_temperature.py::TestContrastiveLossWithTemperature::test_loss_with_ce_kwargs PASSED                             [ 57%]
test/modules/losses/test_contrastive_loss_with_temperature.py::TestContrastiveLossWithTemperature::test_temperature_clamp_invalid PASSED                       [ 71%]
test/modules/losses/test_contrastive_loss_with_temperature.py::TestContrastiveLossWithTemperature::test_single_gpu_loss PASSED                                 [ 85%]
test/modules/losses/test_contrastive_loss_with_temperature.py::TestContrastiveLossWithTemperature::test_multi_gpu_loss PASSED                                  [100%]

========================================================================= 7 passed in 17.50s =========================================================================


