### PR TITLE
[CLIP] Fix transform bug related to text truncation

### DIFF
--- a/test/transforms/test_clip_transform.py
+++ b/test/transforms/test_clip_transform.py
@@ -81,9 +81,11 @@ class TestCLIPTransform(unittest.TestCase):
         # Check encoding of long text
         actual_long_text = transformed_texts[-1]
         expected_long_text = torch.tensor(
-            [self.bos_token] + self.text1_tokens[1:-1] * 20 + [self.eos_token],
+            [self.bos_token]
+            + (self.text1_tokens[1:-1] * 20)[: self.context_length - 2]
+            + [self.eos_token],
             dtype=torch.long,
-        )[: self.context_length]
+        )
         assert_expected(actual_long_text, expected_long_text)
 
         # Check zero padding for short texts

--- a/torchmultimodal/transforms/clip_transform.py
+++ b/torchmultimodal/transforms/clip_transform.py
@@ -62,9 +62,9 @@ class CLIPTextTransform:
         self.text_transform = text_transforms.Sequential(
             *[
                 tokenizer,
+                text_transforms.Truncate(text_max_length - 2),
                 text_transforms.AddToken(text_start_token, begin=True),
                 text_transforms.AddToken(text_end_token, begin=False),
-                text_transforms.Truncate(text_max_length),
                 text_transforms.StrToIntTransform(),
                 text_transforms.ToTensor(padding_value=0),
                 text_transforms.PadTransform(max_length=text_max_length, pad_value=0),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #291
* #290
* #288

Differential Revision: [D39106445](https://our.internmc.facebook.com/intern/diff/D39106445)

If text is longer than the context length, it needs to get truncated before adding the eos token else the eos token also gets removed

Test plan
Fixed the expected value in test and ran pytest. Also running E2E training on internal infra