### PR TITLE
[MUGEN] Remove bias from query, key and value projection

### DIFF
--- a/examples/mugen/test/generation/test_text_video_gpt.py
+++ b/examples/mugen/test/generation/test_text_video_gpt.py
@@ -132,7 +132,7 @@ def test_lookup(model_fn, modality, expected_shape, expected_sum):
 
 
 @pytest.mark.parametrize(
-    "video_seq_len, expected", [(8, 196.8086), (16, 57.3421), (32, -68.7910)]
+    "video_seq_len, expected", [(8, 63.9277), (16, 27.3964), (32, -7.2096)]
 )
 def test_forward(model_fn, video_seq_len, expected):
     test_params = {"video_seq_len": video_seq_len}
@@ -159,7 +159,7 @@ def test_forward(model_fn, video_seq_len, expected):
 # For now it's expected that the results are the same as without the ckpt
 @pytest.mark.parametrize(
     "video_seq_len, expected",
-    [(8, 196.8086), (16, 57.3421), (32, -68.7910)],
+    [(8, 63.9277), (16, 27.3964), (32, -7.2096)],
 )
 def test_forward_checkpoint(model_fn, video_seq_len, expected):
     vqvae_model_key = f"mugen_L{video_seq_len}"

--- a/test/models/test_gpt.py
+++ b/test/models/test_gpt.py
@@ -402,15 +402,15 @@ class TestMultimodalGPT:
             "decoder_output": {
                 "last_hidden_states": (
                     torch.Size([1, 7, 4]),  # (b, seq_len, d_model)
-                    9.4419,
+                    -10.8185,
                 ),
                 "hidden_states": None,
                 "attention_weights": None,
                 "past_key_values": (
                     (
                         {
-                            "k": (torch.Size([1, 2, 7, 2]), -5.5201),
-                            "v": (torch.Size([1, 2, 7, 2]), -6.1666),
+                            "k": (torch.Size([1, 2, 7, 2]), 8.3626),
+                            "v": (torch.Size([1, 2, 7, 2]), 3.4256),
                         }
                     ),
                 ),  # (num_layers, key/value, (b, n_head, seq_len, d_model // n_head)
@@ -474,7 +474,7 @@ class TestMultimodalTransformerDecoder:
         expected = {
             "last_hidden_states": (
                 torch.Size([1, 3, 4]),
-                4.1420,
+                -3.3081,
             ),  # (b, in_seq_len, d_model)
             "hidden_states": None,
             "attention_weights": None,
@@ -489,7 +489,7 @@ class TestMultimodalTransformerDecoder:
         expected = {
             "last_hidden_states": (
                 torch.Size([1, 4, 4]),
-                5.5382,
+                -4.9438,
             ),  # (b, out_seq_len, d_model)
             "hidden_states": None,
             "attention_weights": None,
@@ -507,7 +507,7 @@ class TestMultimodalTransformerDecoder:
         expected = {
             "last_hidden_states": (
                 torch.Size([1, 7, 4]),
-                9.6968,
+                -7.2657,
             ),  # (b, in_seq_len + out_seq_len, d_model)
             "hidden_states": None,
             "attention_weights": None,
@@ -535,7 +535,7 @@ class TestMultimodalTransformerDecoder:
         expected = {
             "last_hidden_states": (
                 torch.Size([1, 7, 4]),
-                9.6968,
+                -7.2657,
             ),  # (b, in_seq_len + out_seq_len, d_model)
             "hidden_states": None,
             "attention_weights": None,
@@ -562,7 +562,7 @@ class TestMultimodalTransformerDecoder:
         expected = {
             "last_hidden_states": (
                 torch.Size([1, 7, 4]),
-                9.7036,
+                -8.0229,
             ),  # (b, in_seq_len + out_seq_len, d_model)
             "hidden_states": None,
             "attention_weights": None,
@@ -623,7 +623,7 @@ class TestTransformerDecoderLayer:
         actual = decoder_layer(decoder_input)
         assert isinstance(actual, TransformerLayerOutput)
         expected = {
-            "hidden_states": (torch.Size([1, 3, 4]), 0.4808),  # (b, seq_len, d_model)
+            "hidden_states": (torch.Size([1, 3, 4]), 2.8170),  # (b, seq_len, d_model)
             "attention_weights": None,
             "past_key_values": None,
         }
@@ -636,7 +636,7 @@ class TestTransformerDecoderLayer:
         actual = decoder_layer(decoder_input, attn_mask, head_mask)
         assert isinstance(actual, TransformerLayerOutput)
         expected = {
-            "hidden_states": (torch.Size([1, 3, 4]), 1.5776),  # (b, seq_len, seq_len)
+            "hidden_states": (torch.Size([1, 3, 4]), 2.8429),  # (b, seq_len, seq_len)
             "attention_weights": None,
             "past_key_values": None,
         }
@@ -646,14 +646,14 @@ class TestTransformerDecoderLayer:
         actual = decoder_layer(decoder_input, use_cache=True, return_attn_weights=True)
         assert isinstance(actual, TransformerLayerOutput)
         expected = {
-            "hidden_states": (torch.Size([1, 3, 4]), 0.4808),  # (b, seq_len, seq_len)
+            "hidden_states": (torch.Size([1, 3, 4]), 2.8170),  # (b, seq_len, seq_len)
             "attention_weights": (
                 torch.Size([1, 2, 3, 3]),
                 6.0,
             ),  # (b, h, seq_len, seq_len)
             "past_key_values": {
-                "k": ([1, 2, 3, 2], -0.3156),
-                "v": ([1, 2, 3, 2], 5.1630),
+                "k": ([1, 2, 3, 2], 4.8075),
+                "v": ([1, 2, 3, 2], -5.6613),
             },  # (b, h, seq_len, d_model//h)
         }
         assert_expected_namedtuple(actual, expected, rtol=1e-5, atol=1e-4)

--- a/test/models/test_video_gpt.py
+++ b/test/models/test_video_gpt.py
@@ -66,7 +66,7 @@ class TestVideoGPT:
 
         actual = model.encode(x, "in")
         assert_expected(actual.shape, (1, 8192))
-        assert_expected(actual.sum().item(), 6678698)
+        assert_expected(actual.sum().item(), 6678187)
 
     def test_decode(self, model_fn, model_params):
         model = model_fn(**model_params)
@@ -77,7 +77,7 @@ class TestVideoGPT:
 
         actual = model.decode(x)
         assert_expected(actual.shape, (1, 3, 16, 64, 64))
-        assert_expected(actual.sum().item(), 14651.1406, rtol=1e-5, atol=1e-4)
+        assert_expected(actual.sum().item(), 14629.2432, rtol=1e-5, atol=1e-4)
 
     @pytest.mark.parametrize(
         "modality, expected_shape, expected_sum",

--- a/torchmultimodal/models/gpt.py
+++ b/torchmultimodal/models/gpt.py
@@ -593,11 +593,14 @@ class TransformerDecoderLayer(nn.Module):
         self.dropout_attn = nn.Dropout(dropout)
         self.dropout_mlp = nn.Dropout(dropout)
 
+        # No bias when projecting q, k, v in GPT model
+        # https://github.com/openai/gpt-2/blob/master/src/model.py#L54
         self.attention = MultiHeadAttention(
             dim_q=d_model,
             dim_kv=d_model,
             n_head=n_head,
             attn_module=attn_module,
+            add_bias=False,
         )
 
         self.mlp = MLP(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #282
* __->__ #292

Summary:
- Switch off `bias` option in `nn.Linear` during projection of query, key and value
- This is a convention for GPT models: https://github.com/openai/gpt-2/blob/master/src/model.py#L54

Test Plan:
```
$ python -m pytest test/models
$ python -m pytest examples/mugen/test/generation
```

Differential Revision: [D39187935](https://our.internmc.facebook.com/intern/diff/D39187935)