### PR TITLE
[FLAVA]bug fix related to hidden size

### DIFF
--- a/torchmultimodal/models/flava/model.py
+++ b/torchmultimodal/models/flava/model.py
@@ -93,9 +93,7 @@ def flava_multimodal_encoder(
     pooler = Pooler(hidden_size=hidden_size)
 
     return FLAVATransformerWithoutEmbeddings(
-        encoder=encoder,
-        layernorm=layernorm,
-        pooler=pooler,
+        encoder=encoder, layernorm=layernorm, pooler=pooler, hidden_size=hidden_size
     )
 
 
@@ -516,11 +514,11 @@ def flava_model(
 def flava_model_for_pretraining(
     codebook_image_size: int = 112,
     pretrained_model_key: Optional[str] = None,
-    hidden_size: int = 768,
     **flava_model_kwargs: Any,
     # TODO: Add parameters for loss here
 ) -> FLAVAForPreTraining:
     model = flava_model(**flava_model_kwargs)
+    hidden_size = flava_model_kwargs.get("multimodal_hidden_size", 768)
     losses = FLAVAPretrainingLoss(hidden_size=hidden_size)
     codebook = DalleVAEEncoder(image_size=codebook_image_size)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #297
* __->__ #296
* #295

Differential Revision: [D39159707](https://our.internmc.facebook.com/intern/diff/D39159707)

Test plan:
torchrun --master_port=1256 --nproc_per_node=8 -m flava.native.train config=flava/native/configs/pretrain_debug.yaml training.max_steps=1000 model.image_hidden_size=300 model.text_hidden_size=300 model.multimodal_hidden_size=300

sanity check lightning script with local conf
python -m flava.train config=flava/configs/pretraining/vit-lyaml