### PR TITLE
[FLAVA] add configs for larger models

### DIFF
--- a/examples/flava/native/configs/1.8b.yaml
+++ b/examples/flava/native/configs/1.8b.yaml
@@ -1,5 +1,5 @@
 training:
-  strategy: ddp # can be changed to ddp or fsdp
+  strategy: fsdp # can be changed to ddp or fsdp
   seed: 1337
 
   batch_size: 8
@@ -62,3 +62,19 @@ datasets:
           - ["caption", "text"]
         split_key_mapping:
           validation: train
+
+model:
+  image_num_hidden_layers: 32
+  image_hidden_size: 1280
+  image_intermediate_size: 5120
+  image_num_attention_heads: 16
+
+  text_num_hidden_layers: 32
+  text_hidden_size: 1280
+  text_intermediate_size: 5120
+  text_num_attention_heads: 16
+
+  multimodal_num_hidden_layers: 16
+  multimodal_hidden_size: 1280
+  multimodal_intermediate_size: 5120
+  multimodal_num_attention_heads: 16

--- a/examples/flava/native/configs/2.7b.yaml
+++ b/examples/flava/native/configs/2.7b.yaml
@@ -1,5 +1,5 @@
 training:
-  strategy: ddp # can be changed to ddp or fsdp
+  strategy: fsdp # can be changed to ddp or fsdp
   seed: 1337
 
   batch_size: 8
@@ -23,7 +23,7 @@ training:
   half_precision_format: "bfloat16"  # or float16
   enable_half_reduce_in_fsdp: True  # handles the reduction across devices in half precision
 
-  activation_checkpointing: False
+  activation_checkpointing: True
   activation_checkpointing_reentrant: False # false for non-reentrant
 
 datasets:
@@ -62,3 +62,19 @@ datasets:
           - ["caption", "text"]
         split_key_mapping:
           validation: train
+
+model:
+  image_num_hidden_layers: 40
+  image_hidden_size: 1408
+  image_intermediate_size: 6144
+  image_num_attention_heads: 16
+
+  text_num_hidden_layers: 40
+  text_hidden_size: 1408
+  text_intermediate_size: 6144
+  text_num_attention_heads: 16
+
+  multimodal_num_hidden_layers: 20
+  multimodal_hidden_size: 1408
+  multimodal_intermediate_size: 6144
+  multimodal_num_attention_heads: 16

--- a/examples/flava/native/configs/900m.yaml
+++ b/examples/flava/native/configs/900m.yaml
@@ -62,3 +62,19 @@ datasets:
           - ["caption", "text"]
         split_key_mapping:
           validation: train
+
+model:
+  image_num_hidden_layers: 24
+  image_hidden_size: 1024
+  image_intermediate_size: 4096
+  image_num_attention_heads: 16
+
+  text_num_hidden_layers: 24
+  text_hidden_size: 1024
+  text_intermediate_size: 4096
+  text_num_attention_heads: 16
+
+  multimodal_num_hidden_layers: 12
+  multimodal_hidden_size: 1024
+  multimodal_intermediate_size: 4096
+  multimodal_num_attention_heads: 16


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #297
* #296
* #295

defaulting to minimum settings needed for each configuration for 1 node, bsz 8.
so ddp for 900m, fsdp (no ac) for 1.8b, fsdp w/ ac for 2.7b
patch size is not configurable due to the dependency on dall e encoder so leaving it out for now
cant get bigger models to work, so will check in those configs later
Test plan
torchrun --master_port=1256 --nproc_per_node=8 -m flava.native.train config=flava/native/configs/900m.yaml training.max_steps=1000

torchrun --master_port=1256 --nproc_per_node=8 -m flava.native.train config=flava/native/configs/1.8b.yaml training.max_steps=1000

torchrun --master_port=1256 --nproc_per_node=8 -m flava.native.train config=flava/native/configs/2.7b.yaml training.max_steps=1000

Differential Revision: [D39159703](https://our.internmc.facebook.com/intern/diff/D39159703)