### PR TITLE
[MUGEN][BugFix] Offset generated tokens by num in_modality token states

### DIFF
--- a/test/utils/test_generate.py
+++ b/test/utils/test_generate.py
@@ -135,7 +135,9 @@ class TestGenerationUtil:
                 614,
                 815,
             ]
-        )
+        ).unsqueeze(
+            0
+        )  # (b, out_seq_len)
         assert_expected(actual, expected)
 
     def test_filter_logits(self, generation_model):

--- a/torchmultimodal/models/gpt.py
+++ b/torchmultimodal/models/gpt.py
@@ -43,8 +43,8 @@ class MultimodalGPT(nn.Module):
 
     Attributes:
         d_model (int): Embedding dimension of the transformer decoder.
-        num_in_tokens (int): Number of token states for the input modality.
-        num_out_tokens (int): Number of token states for the output modality.
+        num_in_tokens (int): Number of unique token states for the input modality.
+        num_out_tokens (int): Number of unique token states for the output modality.
         latent_shape ([Tuple[int, ...]): Shape of the latent space of the output modality tokenizer. Used to reshape
             sequence of generated tokens to be decoded back to data.
         in_tokenizer (nn.Module): Tokenizer for the input modality. Must have methods ``encode``, ``lookup``.

--- a/torchmultimodal/utils/generate.py
+++ b/torchmultimodal/utils/generate.py
@@ -15,7 +15,8 @@ from torchmultimodal.utils.attention import get_causal_attention_mask
 
 
 class SampleOutput(NamedTuple):
-    samples: Tensor
+    decoded: Tensor  # generated sample data
+    tokens: Tensor  # generated tokens before being decoded back to data
     model_outputs: Tuple[Any, ...]
 
 
@@ -146,16 +147,18 @@ class GenerationUtil:
             logits_view = logits.view(-1, logits.shape[-1])  # (b, num_tokens)
             logits_view = self._filter_logits(logits_view, top_k=top_k, top_p=top_p)
             probs = F.softmax(logits_view, dim=-1)
-            samples.append(torch.multinomial(probs, 1))  # (b, 1)
+            samples.append(torch.multinomial(probs, 1) - self.num_in_tokens)  # (b, 1)
             model_outputs = model_outputs + (out,)
             idx += 1
 
         samples = torch.cat(
             samples[1:], dim=1
         )  # remove the "sos" token: (b, out_seq_len)
-        samples = self.model.decode(samples)  # type: ignore
+        decoded = self.model.decode(samples)  # type: ignore
 
-        return SampleOutput(samples=samples, model_outputs=model_outputs)
+        return SampleOutput(
+            decoded=decoded, tokens=samples, model_outputs=model_outputs
+        )
 
     def _filter_logits(
         self, logits: Tensor, top_k: Optional[int] = None, top_p: Optional[float] = None

--- a/torchmultimodal/utils/generate.py
+++ b/torchmultimodal/utils/generate.py
@@ -33,8 +33,8 @@ class GenerationUtil:
 
     Attributes:
         model (nn.Module): Model that is wrapped for generation.
-        num_in_tokens (int): Number of input modality tokens.
-        num_out_tokens (int): Number of output modality tokens.
+        num_in_tokens (int): Number of unique token states for the input modality.
+        num_out_tokens (int): Number of unique token states for the output modality.
     """
 
     def __init__(self, model: nn.Module) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #307
* #305
* #304
* #306
* __->__ #303

Summary:
- We should subtract the input token numbers from the result to keep the latter within the range of output token numbers (or codebook size if using VQVAE)
- This is due to the fact that sampling is done in the concatenated token space `(batch, sequence, num_in_tokens + num_out_tokens)`

Test Plan:
```
$ python -m pytest test/utils/test_generate.py -vv

test/utils/test_generate.py::TestLogitsMask::test_normal PASSED                                                  [  6%]
test/utils/test_generate.py::TestLogitsMask::test_zero_dims PASSED                                               [ 13%]
test/utils/test_generate.py::TestLogitsMask::test_in_seq_only PASSED                                             [ 20%]
test/utils/test_generate.py::TestLogitsMask::test_out_seq_only PASSED                                            [ 26%]
test/utils/test_generate.py::TestGenerationUtil::test_model_eval_warning PASSED                                  [ 33%]
test/utils/test_generate.py::TestGenerationUtil::test_sample PASSED                                              [ 40%]
test/utils/test_generate.py::TestGenerationUtil::test_filter_logits PASSED                                       [ 46%]
test/utils/test_generate.py::TestLogitsFilterTopK::test_min_tokens_to_keep PASSED                                [ 53%]
test/utils/test_generate.py::TestLogitsFilterTopK::test_top_k_invalid PASSED                                     [ 60%]
test/utils/test_generate.py::TestLogitsFilterTopK::test_default PASSED                                           [ 66%]
test/utils/test_generate.py::TestLogitsFilterTopK::test_top_k PASSED                                             [ 73%]
test/utils/test_generate.py::TestLogitsFilterTopP::test_min_tokens_to_keep PASSED                                [ 80%]
test/utils/test_generate.py::TestLogitsFilterTopP::test_top_p_invalid PASSED                                     [ 86%]
test/utils/test_generate.py::TestLogitsFilterTopP::test_default PASSED                                           [ 93%]
test/utils/test_generate.py::TestLogitsFilterTopP::test_top_p PASSED                                             [100%]

================================================== 15 passed in 3.48s ==========
```

Differential Revision: [D39266383](https://our.internmc.facebook.com/intern/diff/D39266383)