### PR TITLE
[MUGEN][BugFix] MultimodalGPT layer norm output

### DIFF
--- a/torchmultimodal/models/gpt.py
+++ b/torchmultimodal/models/gpt.py
@@ -249,7 +249,7 @@ class MultimodalGPT(nn.Module):
                 0
             )  # (seq_len, num_tokens) -> (1, seq_len, num_tokens)
 
-        out = self.norm(hidden_states)
+        hidden_states = self.norm(hidden_states)
         logits = self.to_logit(hidden_states)
         max_neg_value = -torch.finfo(logits.dtype).max
         if logits_mask is not None:

--- a/torchmultimodal/models/gpt.py
+++ b/torchmultimodal/models/gpt.py
@@ -60,9 +60,9 @@ class MultimodalGPT(nn.Module):
         use_gpt_init (bool): Whether to use GPT model specific initialization. Defaults to ``True``.
 
     Args:
-        in_tokens (Tensor, optional): Tensor of dimension ``(b, in_seq_len, c)`` containing tokens
+        in_tokens (Tensor, optional): Tensor of dimension ``(b, in_seq_len)`` containing tokens
             for the input modality. Defaults to ``None``.
-        out_tokens (Tensor, optional): Tensor of dimension ``(b, out_seq_len, c')`` containing tokens
+        out_tokens (Tensor, optional): Tensor of dimension ``(b, out_seq_len)`` containing tokens
             for the output modality. Defaults to ``None``.
         in_pos_ids (Tensor, optional): Tensor of dimension ``(b, in_seq_len)`` containing indices for the
             input modality position embeddings. Defaults to ``None``.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #307
* #305
* __->__ #304
* #306
* #303

Summary:
Output of layer norm previously was not passed to the logit projection layer.

Test Plan:
CI

Differential Revision: [D39420774](https://our.internmc.facebook.com/intern/diff/D39420774)