### PR TITLE
[Bugfix] Absence of os package import in examples.utils.common.py

### DIFF
--- a/examples/utils/common.py
+++ b/examples/utils/common.py
@@ -6,6 +6,7 @@
 
 import copy
 import hashlib
+import os
 from typing import Optional
 
 import torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #311
* __->__ #310

Summary:
- Added the missing `os` import for the utility `store_model_weights`
- In the previous PR #300 the implementation code was pasted on a colab notebook which had `os` package installed (thus didn't incur the breakage during testing)

Test Plan:
```
from examples.utils.common import store_model_weights

path_renamed = store_model_weights(tmm, "/path/to/model_weight.pt")
```

Differential Revision: [D39489310](https://our.internmc.facebook.com/intern/diff/D39489310)