### PR TITLE
[BE] Prevent parameter defaults to be a function call: MDETR

### DIFF
--- a/torchmultimodal/models/mdetr/model.py
+++ b/torchmultimodal/models/mdetr/model.py
@@ -333,9 +333,12 @@ def mdetr_for_vqa(
     transformer_dim_feedforward: int = 2048,
     transformer_dropout: float = 0.1,
     return_intermediate_dec: bool = True,
-    vqa_heads: nn.ModuleDict = mdetr_gqa_heads(),
+    vqa_heads: Optional[nn.ModuleDict] = None,
     contrastive_dim: int = 64,
 ) -> MDETRForVQA:
+    if vqa_heads is None:
+        vqa_heads = mdetr_gqa_heads()
+
     hidden_dim = transformer_d_model
     num_heads = len(vqa_heads.keys())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #316
* #311
* #315
* __->__ #314

Summary:
Set the parameter in question to be `None` and defer the function call

Test Plan:
CI

Differential Revision: [D39523375](https://our.internmc.facebook.com/intern/diff/D39523375)