### PR TITLE
Fix postnorm transformer encoder layer

### DIFF
--- a/test/models/albef/test_albef.py
+++ b/test/models/albef/test_albef.py
@@ -99,8 +99,8 @@ def test_albef_image_embeddings_momentum(albef_model_output):
 def test_albef_text_embeddings(albef_model_output):
     expected = Tensor(
         [
-            [[-0.332726, 1.356729, -1.024002], [1.050448, -1.345235, 0.294787]],
-            [[-1.098961, -0.221372, 1.320333], [1.304645, -1.125002, -0.179644]],
+            [[-0.317956, 1.352367, -1.034411], [1.064044, -1.338780, 0.274735]],
+            [[-1.320019, 0.220507, 1.099512], [1.411497, -0.781628, -0.629869]],
         ]
     )
     assert_expected(albef_model_output.text_embeddings, expected, rtol=0, atol=1e-4)
@@ -109,8 +109,8 @@ def test_albef_text_embeddings(albef_model_output):
 def test_albef_text_embeddings_momentum(albef_model_output):
     expected = Tensor(
         [
-            [[-0.332726, 1.356729, -1.024002], [1.050448, -1.345235, 0.294787]],
-            [[-1.098961, -0.221372, 1.320333], [1.304645, -1.125002, -0.179644]],
+            [[-0.317956, 1.352367, -1.034411], [1.064044, -1.338780, 0.274735]],
+            [[-1.320019, 0.220507, 1.099512], [1.411497, -0.781628, -0.629869]],
         ]
     )
     assert_expected(albef_model_output.text_embeddings_m, expected, rtol=0, atol=1e-4)
@@ -119,8 +119,8 @@ def test_albef_text_embeddings_momentum(albef_model_output):
 def test_albef_multimodal_embeddings(albef_model_output):
     expected = Tensor(
         [
-            [[-0.100506, 1.271901, -1.171395], [1.410639, -0.618296, -0.792343]],
-            [[-1.393961, 0.490451, 0.903510], [0.606909, -1.409685, 0.802776]],
+            [[-0.068738, 1.257666, -1.188928], [1.409873, -0.609056, -0.800817]],
+            [[-1.402520, 0.544084, 0.858435], [1.202279, -1.246038, 0.043760]],
         ]
     )
     assert_expected(
@@ -131,8 +131,8 @@ def test_albef_multimodal_embeddings(albef_model_output):
 def test_albef_multimodal_embeddings_momentum(albef_model_output):
     expected = Tensor(
         [
-            [[-0.100506, 1.271901, -1.171395], [1.410639, -0.618296, -0.792343]],
-            [[-1.393961, 0.490451, 0.903510], [0.606909, -1.409685, 0.802776]],
+            [[-0.068738, 1.257666, -1.188928], [1.409873, -0.609056, -0.800817]],
+            [[-1.402520, 0.544084, 0.858435], [1.202279, -1.246038, 0.043760]],
         ]
     )
     assert_expected(

--- a/test/modules/encoders/test_bert_text_encoder.py
+++ b/test/modules/encoders/test_bert_text_encoder.py
@@ -27,8 +27,8 @@ class TestBERTTextEncoder:
         output = encoder(input_ids, text_atts)
         expected = Tensor(
             [
-                [[-0.7098, -0.7044, 1.4142], [-0.5453, -0.8574, 1.4027]],
-                [[-0.2194, -1.1002, 1.3196], [0.3886, -1.3719, 0.9833]],
+                [[-0.658658, -0.754473, 1.413131], [-0.501156, -0.894687, 1.395843]],
+                [[-0.148285, -1.143851, 1.292136], [0.424911, -1.380611, 0.955700]],
             ]
         )
         assert_expected(output.last_hidden_state, expected, rtol=0, atol=1e-4)

--- a/torchmultimodal/modules/layers/transformer.py
+++ b/torchmultimodal/modules/layers/transformer.py
@@ -302,9 +302,8 @@ class TransformerEncoderLayer(nn.Module):
             head_mask=head_mask,
         )
         attn_residual = attn_output + x
-        ff_residual = attn_residual + self._feedforward_block(
-            self.attention_layernorm(attn_residual)
-        )
+        attn_residual = self.attention_layernorm(attn_residual)
+        ff_residual = attn_residual + self._feedforward_block(attn_residual)
         outputs = self.feedforward_layernorm(ff_residual)
         if return_attn_weights:
             return outputs, attn_weights


### PR DESCRIPTION
Summary:
In the transformer encoder layer with postnorm we were applying the attention layer norm to the FFN inputs but not to the residual connection. The fix is to apply the attention layer norm beforehand and not inside of the feedforward block.

Test plan:
CI

Note that the unit test expected values are updated to match the pre-unification results (see [this change](https://github.com/facebookresearch/multimodal/commit/1da49cf4481eb2177607f5f4e05262303758507f)).
