### PR TITLE
[CI] Upload Nightly Build to PyPI

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -9,7 +9,7 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  build_wheel:
+  build_and_upload_wheel:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -77,3 +77,12 @@ jobs:
           python -m pip install pytest pytest-mock pytest-cov
           python -m pytest --junitxml=junit/test-results.xml \
             --cov-report=xml --cov-report=html --cov=. test -vv
+      - name: Push wheel to PyPI
+        run: |
+          set -eux
+          python -m pip install twine
+          python -m twine upload dist/torchmultimodal_nightly-*.whl \
+            --repository testpypi \
+            --username __token__ --password "$TESTPYPI_API_TOKEN" \
+            --skip-existing \
+            --verbose

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TorchMultimodal (Alpha Release)
+# TorchMultimodal (Beta Release)
 
 ## Introduction
 TorchMultimodal is a PyTorch library for training state-of-the-art multimodal multi-task models at scale. It provides:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #324
* #322
* #323
* #325

Summary:

- Create a PyPI API token and store it amongst the repo's credentials
- Add the step in `test_buil.yml` to publish the wheel
- Update `README.md` with new installation instructions

Test Plan:

- Verify the manually dispatched workflow is successful: [link](https://github.com/facebookresearch/multimodal/actions/runs/3093601005)
- `python -m pip install torchmultimodal_nightly`