### PR TITLE
[BE] Fix warnings thrown during testing: FLAVA, SamePadConv

### DIFF
--- a/test/models/flava/test_checkpoint.py
+++ b/test/models/flava/test_checkpoint.py
@@ -99,11 +99,7 @@ class TestFLAVACheckpoint:
 
     def _assert_tensor_dicts_equal(self, dict_actual, dict_expected):
         for key in dict_expected:
-            actual = (
-                torch.zeros(1)
-                if dict_actual[key] is None
-                else dict_actual[key]
-            )
+            actual = torch.zeros(1) if dict_actual[key] is None else dict_actual[key]
             expected = (
                 torch.zeros(1)
                 if dict_expected[key] is None

--- a/test/models/flava/test_checkpoint.py
+++ b/test/models/flava/test_checkpoint.py
@@ -102,7 +102,7 @@ class TestFLAVACheckpoint:
             actual = (
                 torch.zeros(1)
                 if dict_actual[key] is None
-                else torch.tensor(dict_actual[key])
+                else dict_actual[key]
             )
             expected = (
                 torch.zeros(1)

--- a/test/modules/layers/test_conv.py
+++ b/test/modules/layers/test_conv.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from itertools import product
 import warnings
+from itertools import product
 
 import torch
 from test.test_utils import assert_expected
@@ -95,7 +95,7 @@ class TestSamePadConv3d(unittest.TestCase):
 
     def test_samepadconv3d_forward(self):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=UserWarning)
+            warnings.simplefilter("ignore", category=UserWarning)
             for i, (inp, kernel, stride) in enumerate(self.test_cases):
                 conv = SamePadConv3d(1, 1, kernel, stride, padding=0)
                 out = conv(inp)

--- a/test/modules/layers/test_conv.py
+++ b/test/modules/layers/test_conv.py
@@ -6,6 +6,7 @@
 
 import unittest
 from itertools import product
+import warnings
 
 import torch
 from test.test_utils import assert_expected
@@ -93,11 +94,13 @@ class TestSamePadConv3d(unittest.TestCase):
             )
 
     def test_samepadconv3d_forward(self):
-        for i, (inp, kernel, stride) in enumerate(self.test_cases):
-            conv = SamePadConv3d(1, 1, kernel, stride, padding=0)
-            out = conv(inp)
-            out_shape_conv_actual = torch.tensor(out.shape)
-            assert_expected(out_shape_conv_actual, self.out_shape_conv_expected[i])
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=UserWarning)
+            for i, (inp, kernel, stride) in enumerate(self.test_cases):
+                conv = SamePadConv3d(1, 1, kernel, stride, padding=0)
+                out = conv(inp)
+                out_shape_conv_actual = torch.tensor(out.shape)
+                assert_expected(out_shape_conv_actual, self.out_shape_conv_expected[i])
 
     def test_calculate_transpose_padding_assert(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #334
* #326
* #322
* #323
* #333
* #332
* #329
* __->__ #325

Summary:

Fixed the following warnings:

```
test/models/flava/test_checkpoint.py::TestFLAVACheckpoint::test_flava_model_for_pretraining
  /data/home/langong/repos/ci/test/models/flava/test_checkpoint.py:105: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
    else torch.tensor(dict_actual[key])

test/modules/layers/test_conv.py::TestSamePadConv3d::test_samepadconv3d_forward
  /data/home/langong/repos/ci/torchmultimodal/modules/layers/conv.py:49: UserWarning: Padding was specified but will not be used in favor of same padding,                 use Conv3d directly for custom padding
    warnings.warn(
```

Add ignore to `pooling_function` of `mil_encoder.py` to suppress `mypy` error:

```
torchmultimodal/modules/encoders/mil_encoder.py:73:30: error: Argument
Installing missing stub packages:
/usr/share/miniconda3/envs/test/bin/python -m pip install types-setuptools types-tabulate

Found 1 error in 1 file (checked 59 source files)
"pooling_function" has incompatible type "Callable[..., Any]"; expected
"TransformerEncoder"  [arg-type]
                pooling_function=pooling_function,
                                 ^~~~~~~~~~~~~~~~
```

Test Plan:

- `python -m pytest test/modules/layers/test_conv.py`
- `python -m pytest test/models/flava/test_checkpoint.py`