### PR TITLE
[Omnivore] Speedup omnivore test

### DIFF
--- a/test/models/test_omnivore.py
+++ b/test/models/test_omnivore.py
@@ -18,17 +18,17 @@ def device():
     return get_current_device()
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture()
 def omnivore_swin_t_model(device):
     return omnivore.omnivore_swin_t().to(device)
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture()
 def omnivore_swin_s_model(device):
     return omnivore.omnivore_swin_s().to(device)
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture()
 def omnivore_swin_b_model(device):
     return omnivore.omnivore_swin_b().to(device)
 

--- a/test/models/test_omnivore.py
+++ b/test/models/test_omnivore.py
@@ -18,17 +18,17 @@ def device():
     return get_current_device()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)
 def omnivore_swin_t_model(device):
     return omnivore.omnivore_swin_t().to(device)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)
 def omnivore_swin_s_model(device):
     return omnivore.omnivore_swin_s().to(device)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)
 def omnivore_swin_b_model(device):
     return omnivore.omnivore_swin_b().to(device)
 
@@ -41,19 +41,19 @@ def test_omnivore_swin_t_forward(omnivore_swin_t_model):
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
     assert_expected(
-        image_score.abs().sum(), torch.tensor(194.83563), rtol=1e-3, atol=1e-3
+        image_score.abs().sum(), torch.tensor(200.27574), rtol=1e-3, atol=1e-3
     )
 
     rgbd = torch.randn(1, 4, 1, 112, 112)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
-    assert_expected(rgbd_score.abs().sum(), torch.tensor(3.18015), rtol=1e-3, atol=1e-3)
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(3.10466), rtol=1e-3, atol=1e-3)
 
     video = torch.randn(1, 3, 4, 112, 112)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
-        video_score.abs().sum(), torch.tensor(100.87259), rtol=1e-3, atol=1e-3
+        video_score.abs().sum(), torch.tensor(97.57287), rtol=1e-3, atol=1e-3
     )
 
 
@@ -65,19 +65,19 @@ def test_omnivore_swin_s_forward(omnivore_swin_s_model):
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
     assert_expected(
-        image_score.abs().sum(), torch.tensor(240.41123), rtol=1e-3, atol=1e-3
+        image_score.abs().sum(), torch.tensor(238.41870), rtol=1e-3, atol=1e-3
     )
 
     rgbd = torch.randn(1, 4, 1, 112, 112)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
-    assert_expected(rgbd_score.abs().sum(), torch.tensor(5.73624), rtol=1e-3, atol=1e-3)
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(4.05502), rtol=1e-3, atol=1e-3)
 
     video = torch.randn(1, 3, 4, 112, 112)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
-        video_score.abs().sum(), torch.tensor(100.75939), rtol=1e-3, atol=1e-3
+        video_score.abs().sum(), torch.tensor(114.26146), rtol=1e-3, atol=1e-3
     )
 
 
@@ -89,19 +89,19 @@ def test_omnivore_swin_b_forward(omnivore_swin_b_model):
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
     assert_expected(
-        image_score.abs().sum(), torch.tensor(293.43484), rtol=1e-3, atol=1e-3
+        image_score.abs().sum(), torch.tensor(234.38349), rtol=1e-3, atol=1e-3
     )
 
     rgbd = torch.randn(1, 4, 1, 112, 112)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
-    assert_expected(rgbd_score.abs().sum(), torch.tensor(6.76342), rtol=1e-3, atol=1e-3)
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(5.37857), rtol=1e-3, atol=1e-3)
 
     video = torch.randn(1, 3, 4, 112, 112)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
-        video_score.abs().sum(), torch.tensor(131.65342), rtol=1e-3, atol=1e-3
+        video_score.abs().sum(), torch.tensor(128.43623), rtol=1e-3, atol=1e-3
     )
 
 

--- a/test/models/test_omnivore.py
+++ b/test/models/test_omnivore.py
@@ -33,10 +33,10 @@ def omnivore_swin_b_model(device):
     return omnivore.omnivore_swin_b().to(device)
 
 
-def test_omnivore_swin_t_forward(omnivore_swin_t_model):
+def test_omnivore_swin_t_forward(omnivore_swin_t_model, device):
     model = omnivore_swin_t_model
 
-    image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
+    image = torch.randn((1, 3, 1, 112, 112), device=device)  # B C D H W
     image_score = model(image, input_type="image")
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
@@ -44,12 +44,12 @@ def test_omnivore_swin_t_forward(omnivore_swin_t_model):
         image_score.abs().sum(), torch.tensor(200.27574), rtol=1e-3, atol=1e-3
     )
 
-    rgbd = torch.randn(1, 4, 1, 112, 112)
+    rgbd = torch.randn((1, 4, 1, 112, 112), device=device)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
     assert_expected(rgbd_score.abs().sum(), torch.tensor(3.10466), rtol=1e-3, atol=1e-3)
 
-    video = torch.randn(1, 3, 4, 112, 112)
+    video = torch.randn((1, 3, 4, 112, 112), device=device)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
@@ -57,10 +57,10 @@ def test_omnivore_swin_t_forward(omnivore_swin_t_model):
     )
 
 
-def test_omnivore_swin_s_forward(omnivore_swin_s_model):
+def test_omnivore_swin_s_forward(omnivore_swin_s_model, device):
     model = omnivore_swin_s_model
 
-    image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
+    image = torch.randn((1, 3, 1, 112, 112), device=device)  # B C D H W
     image_score = model(image, input_type="image")
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
@@ -68,12 +68,12 @@ def test_omnivore_swin_s_forward(omnivore_swin_s_model):
         image_score.abs().sum(), torch.tensor(238.41870), rtol=1e-3, atol=1e-3
     )
 
-    rgbd = torch.randn(1, 4, 1, 112, 112)
+    rgbd = torch.randn((1, 4, 1, 112, 112), device=device)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
     assert_expected(rgbd_score.abs().sum(), torch.tensor(4.05502), rtol=1e-3, atol=1e-3)
 
-    video = torch.randn(1, 3, 4, 112, 112)
+    video = torch.randn((1, 3, 4, 112, 112), device=device)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
@@ -81,10 +81,10 @@ def test_omnivore_swin_s_forward(omnivore_swin_s_model):
     )
 
 
-def test_omnivore_swin_b_forward(omnivore_swin_b_model):
+def test_omnivore_swin_b_forward(omnivore_swin_b_model, device):
     model = omnivore_swin_b_model
 
-    image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
+    image = torch.randn((1, 3, 1, 112, 112), device=device)  # B C D H W
     image_score = model(image, input_type="image")
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
@@ -92,12 +92,12 @@ def test_omnivore_swin_b_forward(omnivore_swin_b_model):
         image_score.abs().sum(), torch.tensor(234.38349), rtol=1e-3, atol=1e-3
     )
 
-    rgbd = torch.randn(1, 4, 1, 112, 112)
+    rgbd = torch.randn((1, 4, 1, 112, 112), device=device)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
     assert_expected(rgbd_score.abs().sum(), torch.tensor(5.37857), rtol=1e-3, atol=1e-3)
 
-    video = torch.randn(1, 3, 4, 112, 112)
+    video = torch.randn((1, 3, 4, 112, 112), device=device)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
@@ -105,9 +105,9 @@ def test_omnivore_swin_b_forward(omnivore_swin_b_model):
     )
 
 
-def test_omnivore_forward_wrong_input_type(omnivore_swin_t_model):
+def test_omnivore_forward_wrong_input_type(omnivore_swin_t_model, device):
     model = omnivore_swin_t_model
 
-    image = torch.randn(1, 3, 1, 112, 112)  # B C D H W
+    image = torch.randn((1, 3, 1, 112, 112), device=device)  # B C D H W
     with pytest.raises(AssertionError, match="Unsupported input_type: _WRONG_TYPE_.+"):
         _ = model(image, input_type="_WRONG_TYPE_")


### PR DESCRIPTION
Summary:
Change the fixture on the models for omnivore to use `autouse=False` in order to speedup the test since the models are not always used on all test.

Also set the input into explicitly to correct device.

