### PR TITLE
[Packaging] Remove pyproject config that modifies pythonpath during testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,2 @@
 [tool.usort]
 first_party_detection = false
-
-[tool.pytest.ini_options]
-pythonpath = [
-  "."
-]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Summary:

- Remove config in `pyproject.toml` that defaults pythonpath to the source code directory during test execution
- We should not maniuplate `pythonpath` implicitly anywhere in the codebase as it could lead to many pitfalls down the road.
- Specifically, it makes setting pytest `import-mode=append` futile and consequently the tests won't run against the installed package.

Test Plan:

CI