### PR TITLE
Remove pyproject config that modifies pythonpath during testing (#332)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,2 @@
 [tool.usort]
 first_party_detection = false
-
-[tool.pytest.ini_options]
-pythonpath = [
-  "."
-]

--- a/test/models/flava/test_checkpoint.py
+++ b/test/models/flava/test_checkpoint.py
@@ -99,11 +99,7 @@ class TestFLAVACheckpoint:
 
     def _assert_tensor_dicts_equal(self, dict_actual, dict_expected):
         for key in dict_expected:
-            actual = (
-                torch.zeros(1)
-                if dict_actual[key] is None
-                else torch.tensor(dict_actual[key])
-            )
+            actual = torch.zeros(1) if dict_actual[key] is None else dict_actual[key]
             expected = (
                 torch.zeros(1)
                 if dict_expected[key] is None

--- a/test/modules/fusions/__init__.py
+++ b/test/modules/fusions/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/modules/layers/__init__.py
+++ b/test/modules/layers/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/modules/layers/test_conv.py
+++ b/test/modules/layers/test_conv.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+import warnings
 from itertools import product
 
 import torch
@@ -93,11 +94,13 @@ class TestSamePadConv3d(unittest.TestCase):
             )
 
     def test_samepadconv3d_forward(self):
-        for i, (inp, kernel, stride) in enumerate(self.test_cases):
-            conv = SamePadConv3d(1, 1, kernel, stride, padding=0)
-            out = conv(inp)
-            out_shape_conv_actual = torch.tensor(out.shape)
-            assert_expected(out_shape_conv_actual, self.out_shape_conv_expected[i])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            for i, (inp, kernel, stride) in enumerate(self.test_cases):
+                conv = SamePadConv3d(1, 1, kernel, stride, padding=0)
+                out = conv(inp)
+                out_shape_conv_actual = torch.tensor(out.shape)
+                assert_expected(out_shape_conv_actual, self.out_shape_conv_expected[i])
 
     def test_calculate_transpose_padding_assert(self):
         with self.assertRaises(ValueError):

--- a/test/modules/losses/__init__.py
+++ b/test/modules/losses/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/utils/__init__.py
+++ b/test/utils/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/models/albef/__init__.py
+++ b/torchmultimodal/models/albef/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/models/clip/__init__.py
+++ b/torchmultimodal/models/clip/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/modules/encoders/__init__.py
+++ b/torchmultimodal/modules/encoders/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/modules/encoders/mil_encoder.py
+++ b/torchmultimodal/modules/encoders/mil_encoder.py
@@ -70,7 +70,7 @@ class MILEncoder(nn.Module):
         ] = deepset_fusion_cls(
             channel_to_encoder_dim=channel_to_encoder_dim,
             mlp=mlp,
-            pooling_function=pooling_function,
+            pooling_function=pooling_function,  # type: ignore
             apply_attention=apply_attention,
             attention_dim=attention_dim,
             modality_normalize=modality_normalize,

--- a/torchmultimodal/modules/fusions/__init__.py
+++ b/torchmultimodal/modules/fusions/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/modules/losses/__init__.py
+++ b/torchmultimodal/modules/losses/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/multimodal/pull/332

- Remove config in `pyproject.toml` that defaults pythonpath to the source code directory during test execution
- We should not maniuplate `pythonpath` implicitly anywhere in the codebase as it could lead to many pitfalls down the road.
- Specifically, it makes setting pytest `import-mode=append` futile and consequently the tests won't run against the installed package.

Test Plan: CI

Reviewed By: pikapecan

Differential Revision: D39833573

Pulled By: langong347

