### PR TITLE
Add missing __init__.py to folders (#329)

### DIFF
--- a/test/models/flava/test_checkpoint.py
+++ b/test/models/flava/test_checkpoint.py
@@ -99,11 +99,7 @@ class TestFLAVACheckpoint:
 
     def _assert_tensor_dicts_equal(self, dict_actual, dict_expected):
         for key in dict_expected:
-            actual = (
-                torch.zeros(1)
-                if dict_actual[key] is None
-                else torch.tensor(dict_actual[key])
-            )
+            actual = torch.zeros(1) if dict_actual[key] is None else dict_actual[key]
             expected = (
                 torch.zeros(1)
                 if dict_expected[key] is None

--- a/test/modules/fusions/__init__.py
+++ b/test/modules/fusions/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/modules/layers/__init__.py
+++ b/test/modules/layers/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/modules/layers/test_conv.py
+++ b/test/modules/layers/test_conv.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+import warnings
 from itertools import product
 
 import torch
@@ -93,11 +94,13 @@ class TestSamePadConv3d(unittest.TestCase):
             )
 
     def test_samepadconv3d_forward(self):
-        for i, (inp, kernel, stride) in enumerate(self.test_cases):
-            conv = SamePadConv3d(1, 1, kernel, stride, padding=0)
-            out = conv(inp)
-            out_shape_conv_actual = torch.tensor(out.shape)
-            assert_expected(out_shape_conv_actual, self.out_shape_conv_expected[i])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            for i, (inp, kernel, stride) in enumerate(self.test_cases):
+                conv = SamePadConv3d(1, 1, kernel, stride, padding=0)
+                out = conv(inp)
+                out_shape_conv_actual = torch.tensor(out.shape)
+                assert_expected(out_shape_conv_actual, self.out_shape_conv_expected[i])
 
     def test_calculate_transpose_padding_assert(self):
         with self.assertRaises(ValueError):

--- a/test/modules/losses/__init__.py
+++ b/test/modules/losses/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/utils/__init__.py
+++ b/test/utils/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/models/albef/__init__.py
+++ b/torchmultimodal/models/albef/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/models/clip/__init__.py
+++ b/torchmultimodal/models/clip/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/modules/encoders/__init__.py
+++ b/torchmultimodal/modules/encoders/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/modules/encoders/mil_encoder.py
+++ b/torchmultimodal/modules/encoders/mil_encoder.py
@@ -70,7 +70,7 @@ class MILEncoder(nn.Module):
         ] = deepset_fusion_cls(
             channel_to_encoder_dim=channel_to_encoder_dim,
             mlp=mlp,
-            pooling_function=pooling_function,
+            pooling_function=pooling_function,  # type: ignore
             apply_attention=apply_attention,
             attention_dim=attention_dim,
             modality_normalize=modality_normalize,

--- a/torchmultimodal/modules/fusions/__init__.py
+++ b/torchmultimodal/modules/fusions/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/modules/losses/__init__.py
+++ b/torchmultimodal/modules/losses/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/multimodal/pull/329

- `__init__.py` is made optional as of python 3.3 due to "impliciate namespace package" [PEP0420](https://peps.python.org/pep-0420/)
- However, that doesn't apply when we import from the wheel
- Out of precaution, also add missing `__init__.py` for the test package.

Test Plan:
```
python -m pip install torchmultimodal-nightly
from torchmultimodal.modules.encoders.bert_text_encoder import BERTTextEncoder
```

Reviewed By: pikapecan

Differential Revision: D39833574

Pulled By: langong347

