### PR TITLE
[FLAVA]Fix activation ckpting api name

### DIFF
--- a/examples/flava/native/configs/pretrain_debug.yaml
+++ b/examples/flava/native/configs/pretrain_debug.yaml
@@ -24,7 +24,6 @@ training:
   enable_half_reduce_in_fsdp: True  # handles the reduction across devices in half precision
 
   activation_checkpointing: False
-  activation_checkpointing_reentrant: False # false for non-reentrant
 
 datasets:
   _target_: flava.definitions.TrainingDatasetsInfo

--- a/examples/flava/native/train.py
+++ b/examples/flava/native/train.py
@@ -41,7 +41,7 @@ from flava.utils import build_datamodule_kwargs
 
 from omegaconf import DictConfig, OmegaConf
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    apply_activation_checkpointing_wrapper,
+    apply_activation_checkpointing,
     checkpoint_wrapper,
     CheckpointImpl,
 )
@@ -53,6 +53,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.tensorboard import SummaryWriter
 from torchmultimodal.models.flava.image_encoder import ImageTransformer
 from torchmultimodal.models.flava.text_encoder import BERTTextEncoder
+from torchmultimodal.models.flava.transformer import FLAVATransformerWithoutEmbeddings
 from torchmultimodal.modules.layers.transformer import TransformerEncoderLayer
 from torchmultimodal.modules.losses.flava import FLAVAPretrainingLossOutput
 
@@ -151,7 +152,7 @@ class Trainer:
                 offload_to_cpu=False,
                 checkpoint_impl=CheckpointImpl.REENTRANT,
             )
-            apply_activation_checkpointing_wrapper(
+            apply_activation_checkpointing(
                 model,
                 checkpoint_wrapper_fn=non_reentrant_wrapper,
                 check_fn=check_fn,
@@ -192,6 +193,7 @@ class Trainer:
                         TransformerEncoderLayer,
                         ImageTransformer,
                         BERTTextEncoder,
+                        FLAVATransformerWithoutEmbeddings,
                     },
                 ),
             )


### PR DESCRIPTION
Summary:
1. with recent nightly, the name of the api for ac  changed, fixing it
2. Adding mm encoder also to the wrapping module. since its more intuitive for user to wrap all encoders separately and also doesnt seem to impact performance.

Test plan:
torchrun --master_port=1256 --nproc_per_node=8 -m flava.native.train config=flava/native/configs/pretrain_debug.yaml training.max_steps=1000 training.activation_checkpointing=True training.strategy=fsdp
