### PR TITLE
[CI] Add schedule event trigger to binary build workflow

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,6 +1,9 @@
 name: Build/Push Nightly Binary
 
 on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 0 * * *' 
   # manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #345
* #344
* __->__ #343

Summary:

Add schedule event trigger to automate the nightly binary build.

Test Plan:

Can't really test this as it's a scheduled event.
Ran a manual trigger on this PR as a proxy for correctness though -- find the latest successful run [here](https://github.com/facebookresearch/multimodal/actions/workflows/test_build.yml).

Differential Revision: [D39993621](https://our.internmc.facebook.com/intern/diff/D39993621)