### PR TITLE
[Test] Update callsites of test_utils in examples after renaming test to tests

### DIFF
--- a/examples/cnn_lstm/tests/test_cnn_encoder.py
+++ b/examples/cnn_lstm/tests/test_cnn_encoder.py
@@ -8,7 +8,7 @@ import pytest
 
 import torch
 from examples.cnn_lstm.cnn_encoder import CNNEncoder
-from test.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected, set_rng_seed
 from torch import nn, Tensor
 
 

--- a/examples/cnn_lstm/tests/test_cnn_lstm.py
+++ b/examples/cnn_lstm/tests/test_cnn_lstm.py
@@ -8,7 +8,7 @@ import pytest
 
 import torch
 from examples.cnn_lstm.cnn_lstm import cnn_lstm_classifier
-from test.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected, set_rng_seed
 
 
 @pytest.fixture(autouse=True)

--- a/examples/cnn_lstm/tests/test_lstm_encoder.py
+++ b/examples/cnn_lstm/tests/test_lstm_encoder.py
@@ -8,7 +8,7 @@ import pytest
 
 import torch
 from examples.cnn_lstm.lstm_encoder import LSTMEncoder
-from test.test_utils import assert_expected
+from tests.test_utils import assert_expected
 
 
 class TestLSTMEncoder:

--- a/examples/mdetr/tests/test_loss.py
+++ b/examples/mdetr/tests/test_loss.py
@@ -7,7 +7,7 @@
 import pytest
 import torch
 from examples.mdetr.loss import construct_positive_map, contrastive_alignment_loss
-from test.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected, set_rng_seed
 from transformers import RobertaTokenizerFast
 
 

--- a/examples/mdetr/tests/test_matcher.py
+++ b/examples/mdetr/tests/test_matcher.py
@@ -9,7 +9,7 @@ import random
 import pytest
 import torch
 from examples.mdetr.matcher import HungarianMatcher
-from test.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected, set_rng_seed
 from torchvision.ops.boxes import box_convert
 
 

--- a/examples/mdetr/tests/test_postprocessors.py
+++ b/examples/mdetr/tests/test_postprocessors.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import pytest
 import torch
 from examples.mdetr.data.postprocessors import PostProcessFlickr
-from test.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected, set_rng_seed
 
 
 @pytest.fixture(scope="class")

--- a/examples/mugen/tests/generation/test_text_video_gpt.py
+++ b/examples/mugen/tests/generation/test_text_video_gpt.py
@@ -10,7 +10,7 @@ import torch
 
 from examples.mugen.generation.text_video_gpt import text_video_gpt
 
-from test.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected, set_rng_seed
 from torchmultimodal.utils.common import get_current_device
 
 

--- a/examples/mugen/tests/generation/test_video_vqvae.py
+++ b/examples/mugen/tests/generation/test_video_vqvae.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 
 from examples.mugen.generation.video_vqvae import video_vqvae_mugen
-from test.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected, set_rng_seed
 
 
 @pytest.fixture(autouse=True)

--- a/examples/mugen/tests/retrieval/test_video_clip.py
+++ b/examples/mugen/tests/retrieval/test_video_clip.py
@@ -13,7 +13,7 @@ from examples.mugen.retrieval.video_clip import (
     VideoEncoder,
 )
 
-from test.test_utils import assert_expected, get_asset_path, set_rng_seed
+from tests.test_utils import assert_expected, get_asset_path, set_rng_seed
 from torchmultimodal import _PATH_MANAGER
 from torchmultimodal.utils.common import shift_dim
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #345
* #344
* #343

Summary:

As titled

Test Plan:

`python -m pytest examples/<any_example_test_folder>`

However, we cannot fix breakages in this PR as example unit tests are not actively maintained / out of scope of CI.

Differential Revision: [D39994169](https://our.internmc.facebook.com/intern/diff/D39994169)