### PR TITLE
Generalize contrastive loss by renaming variables to be inclusive of any input modalities

### DIFF
--- a/tests/modules/losses/test_contrastive_loss_with_temperature.py
+++ b/tests/modules/losses/test_contrastive_loss_with_temperature.py
@@ -74,11 +74,9 @@ class TestContrastiveLossWithTemperature:
         torch.manual_seed(1234)
         clip_loss = ContrastiveLossWithTemperature()
         clip_loss = clip_loss.to(get_current_device())
-        image_embeddings = torch.randn(3, 5)
-        text_embeddings = torch.randn(3, 5)
-        loss = clip_loss(
-            image_embeddings=image_embeddings, text_embeddings=text_embeddings
-        )
+        embeddings_a = torch.randn(3, 5)
+        embeddings_b = torch.randn(3, 5)
+        loss = clip_loss(embeddings_a=embeddings_a, embeddings_b=embeddings_b)
 
         assert_expected(loss.item(), 9.8753, rtol=0, atol=1e-3)
 
@@ -90,10 +88,10 @@ class TestContrastiveLossWithTemperature:
         clip_loss_above_max = ContrastiveLossWithTemperature(
             logit_scale=3, logit_scale_max=2
         ).to(get_current_device())
-        image_embeddings = torch.randn(3, 5)
-        text_embeddings = torch.randn(3, 5)
-        loss_at_max = clip_loss_at_max(image_embeddings, text_embeddings).item()
-        loss_above_max = clip_loss_above_max(image_embeddings, text_embeddings).item()
+        embeddings_a = torch.randn(3, 5)
+        embeddings_b = torch.randn(3, 5)
+        loss_at_max = clip_loss_at_max(embeddings_a, embeddings_b).item()
+        loss_above_max = clip_loss_above_max(embeddings_a, embeddings_b).item()
         assert_expected(loss_above_max, loss_at_max, rtol=0, atol=1e-3)
 
     def test_temperature_clamp_min(self):
@@ -104,21 +102,21 @@ class TestContrastiveLossWithTemperature:
         clip_loss_below_min = ContrastiveLossWithTemperature(
             logit_scale=1, logit_scale_min=2
         ).to(get_current_device())
-        image_embeddings = torch.randn(3, 5)
-        text_embeddings = torch.randn(3, 5)
-        loss_at_min = clip_loss_at_min(image_embeddings, text_embeddings).item()
-        loss_below_min = clip_loss_below_min(image_embeddings, text_embeddings).item()
+        embeddings_a = torch.randn(3, 5)
+        embeddings_b = torch.randn(3, 5)
+        loss_at_min = clip_loss_at_min(embeddings_a, embeddings_b).item()
+        loss_below_min = clip_loss_below_min(embeddings_a, embeddings_b).item()
         assert_expected(loss_below_min, loss_at_min, rtol=0, atol=1e-3)
 
     def test_loss_with_ce_kwargs(self):
         torch.manual_seed(1234)
         clip_loss = ContrastiveLossWithTemperature()
         clip_loss = clip_loss.to(get_current_device())
-        image_embeddings = torch.randn(3, 5)
-        text_embeddings = torch.randn(3, 5)
+        embeddings_a = torch.randn(3, 5)
+        embeddings_b = torch.randn(3, 5)
         loss = clip_loss(
-            image_embeddings=image_embeddings,
-            text_embeddings=text_embeddings,
+            embeddings_a=embeddings_a,
+            embeddings_b=embeddings_b,
             cross_entropy_kwargs={"label_smoothing": 0.1},
         )
 

--- a/torchmultimodal/modules/losses/contrastive_loss_with_temperature.py
+++ b/torchmultimodal/modules/losses/contrastive_loss_with_temperature.py
@@ -167,9 +167,9 @@ class ContrastiveLossWithTemperature(nn.Module):
             If ``None``, then temperature will not be clamped to a maximum value.
             Defaults to ``ln(100)``, as in the CLIP paper.
 
-    Inputs: image_embeddings (Tensor): Tensor containing image features.
+    Inputs: embeddings_a (Tensor): Tensor containing features from the first input or modality.
                 (In the CLIP model, these are the outputs of the image encoder.)
-            text_embeddings (Tensor): Tensor containing text features.
+            embeddings_b (Tensor): Tensor containing features from the second input or modality.
                 (In the CLIP model, these are the outputs of the text encoder.)
             backprop_in_gather (bool): Whether to backpropagate the gradients from
                 all_gather to all workers (versus just the local worker).

--- a/torchmultimodal/modules/losses/contrastive_loss_with_temperature.py
+++ b/torchmultimodal/modules/losses/contrastive_loss_with_temperature.py
@@ -18,59 +18,59 @@ from torch.distributed.nn.functional import all_gather as all_gather_with_backpr
 @dataclass
 class ContrastiveLossOutput(OrderedDict):
     loss: Tensor
-    image_logits: Tensor
-    text_logits: Tensor
-    image_loss: Tensor
-    text_loss: Tensor
+    logits_a: Tensor
+    logits_b: Tensor
+    loss_a: Tensor
+    loss_b: Tensor
 
 
 def _gather_embeddings_and_labels(
-    image_embeddings: Tensor,
-    text_embeddings: Tensor,
+    embeddings_a: Tensor,
+    embeddings_b: Tensor,
     backprop_in_gather: bool = True,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     if not torch.distributed.is_available() or not torch.distributed.is_initialized():
-        labels = torch.arange(image_embeddings.size(0), device=image_embeddings.device)
-        return image_embeddings, text_embeddings, labels
+        labels = torch.arange(embeddings_a.size(0), device=embeddings_a.device)
+        return embeddings_a, embeddings_b, labels
 
-    # image_embeddings has shape [local_batch_size, embedding_dim]
-    local_batch_size = image_embeddings.size(0)
+    # embeddings_a has shape [local_batch_size, embedding_dim]
+    local_batch_size = embeddings_a.size(0)
 
     world_size = torch.distributed.get_world_size()
 
     # This uses the all_gather from torch.distributed.nn.functional,
     # which backpropagates gradients to all workers
     if backprop_in_gather:
-        img_embeddings_all_gpus = all_gather_with_backprop(image_embeddings)
-        text_embeddings_all_gpus = all_gather_with_backprop(text_embeddings)
+        embeddings_a_all_gpus = all_gather_with_backprop(embeddings_a)
+        embeddings_b_all_gpus = all_gather_with_backprop(embeddings_b)
 
     # Otherwise just backprop to the current worker
     # This means that the image gradients on a given worker will only
     # consider the text samples from the same worker
     else:
-        text_embeddings_all_gpus = [
-            torch.zeros_like(text_embeddings) for _ in range(world_size)
+        embeddings_a_all_gpus = [
+            torch.zeros_like(embeddings_a) for _ in range(world_size)
         ]
-        img_embeddings_all_gpus = [
-            torch.zeros_like(image_embeddings) for _ in range(world_size)
+        embeddings_b_all_gpus = [
+            torch.zeros_like(embeddings_b) for _ in range(world_size)
         ]
-        all_gather_no_backprop(img_embeddings_all_gpus, image_embeddings)
-        all_gather_no_backprop(text_embeddings_all_gpus, text_embeddings)
+        all_gather_no_backprop(embeddings_a_all_gpus, embeddings_a)
+        all_gather_no_backprop(embeddings_b_all_gpus, embeddings_b)
 
     labels = local_batch_size * torch.distributed.get_rank() + torch.arange(
-        local_batch_size, device=image_embeddings.device
+        local_batch_size, device=embeddings_a.device
     )
 
     return (
-        torch.cat(img_embeddings_all_gpus),
-        torch.cat(text_embeddings_all_gpus),
+        torch.cat(embeddings_a_all_gpus),
+        torch.cat(embeddings_b_all_gpus),
         labels,
     )
 
 
 def contrastive_loss_with_temperature(
-    image_embeddings: Tensor,
-    text_embeddings: Tensor,
+    embeddings_a: Tensor,
+    embeddings_b: Tensor,
     logit_scale: nn.Parameter,
     mask: Optional[Tensor] = None,
     backprop_in_gather: bool = True,
@@ -80,9 +80,9 @@ def contrastive_loss_with_temperature(
     check the class for more details
 
     Args:
-        image_embeddings (Tensor): Tensor containing image features.
+        embeddings_a (Tensor): Tensor containing features from the first input or modality.
             (In the CLIP model, these are the outputs of the image encoder.)
-        text_embeddings (Tensor): Tensor containing text features.
+        embeddings_b (Tensor): Tensor containing features from the second input or modality.
             (In the CLIP model, these are the outputs of the text encoder.)
         logit_scale (nn.Parameter): Parameter with value of log of the learned temperature
         mask (Optional[Tensor], optional): If certain elements of the inputs shouldn't
@@ -101,41 +101,37 @@ def contrastive_loss_with_temperature(
     temperature = torch.exp(logit_scale)
 
     (
-        img_embeddings_all_gpus,
-        text_embeddings_all_gpus,
+        embeddings_a_all_gpus,
+        embeddings_b_all_gpus,
         labels,
-    ) = _gather_embeddings_and_labels(
-        image_embeddings, text_embeddings, backprop_in_gather
-    )
+    ) = _gather_embeddings_and_labels(embeddings_a, embeddings_b, backprop_in_gather)
 
     # logits_per_image has shape [local_batch_size, global_batch_size]
-    logits_per_image = (
-        torch.matmul(image_embeddings, text_embeddings_all_gpus.transpose(0, 1))
-        * temperature
+    logits_per_input_a = (
+        torch.matmul(embeddings_a, embeddings_b_all_gpus.transpose(0, 1)) * temperature
     )
-    logits_per_text = (
-        torch.matmul(text_embeddings, img_embeddings_all_gpus.transpose(0, 1))
-        * temperature
+    logits_per_input_b = (
+        torch.matmul(embeddings_b, embeddings_a_all_gpus.transpose(0, 1)) * temperature
     )
 
     if mask is not None:
-        logits_per_image = logits_per_image[mask]
-        logits_per_text = logits_per_text[mask]
+        logits_per_input_a = logits_per_input_a[mask]
+        logits_per_input_b = logits_per_input_b[mask]
         labels = labels[mask]
 
     if cross_entropy_kwargs is None:
         cross_entropy_kwargs = {}
 
-    loss_i = F.cross_entropy(logits_per_image, labels, **cross_entropy_kwargs)
-    loss_t = F.cross_entropy(logits_per_text, labels, **cross_entropy_kwargs)
-    loss = (loss_i + loss_t) / 2
+    loss_a = F.cross_entropy(logits_per_input_a, labels, **cross_entropy_kwargs)
+    loss_b = F.cross_entropy(logits_per_input_b, labels, **cross_entropy_kwargs)
+    loss = (loss_a + loss_b) / 2
 
     return ContrastiveLossOutput(
         loss=loss,
-        image_logits=logits_per_image,
-        text_logits=logits_per_text,
-        image_loss=loss_i,
-        text_loss=loss_t,
+        logits_a=logits_per_input_a,
+        logits_b=logits_per_input_b,
+        loss_a=loss_a,
+        loss_b=loss_b,
     )
 
 
@@ -148,11 +144,11 @@ class ContrastiveLossWithTemperature(nn.Module):
     FLAVA: https://arxiv.org/pdf/2112.04482.pdf
 
 
-    A contrastive loss over pairs of image and text embeddings. For each image
-    embedding, we compute a weighted cosine similarity with all text embeddings,
-    then calculate the cross entropy loss against the true (image, text) pairing.
-    Each text embedding is evaluated against all image embeddings similarly.
-    The batch's loss is the average cross entropy over all image and text embeddings
+    A contrastive loss over pairs of input embeddings a and b. For each input_a
+    embedding, we compute a weighted cosine similarity with all input_b embeddings,
+    then calculate the cross entropy loss against the true (input_a, input_b) pairing.
+    Each input_b embedding is evaluated against all input_a embeddings similarly.
+    The batch's loss is the average cross entropy over all input_a and input_b embeddings
     in the batch.
 
     Temperature is a learned parameter clamped to ``[1, 100]`` and
@@ -203,16 +199,16 @@ class ContrastiveLossWithTemperature(nn.Module):
 
     def forward(
         self,
-        image_embeddings: Tensor,
-        text_embeddings: Tensor,
+        embeddings_a: Tensor,
+        embeddings_b: Tensor,
         backprop_in_gather: bool = True,
         cross_entropy_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Tensor:
 
         self.logit_scale.data.clamp_(self.logit_scale_min, self.logit_scale_max)
         return contrastive_loss_with_temperature(
-            image_embeddings=image_embeddings,
-            text_embeddings=text_embeddings,
+            embeddings_a=embeddings_a,
+            embeddings_b=embeddings_b,
             logit_scale=self.logit_scale,
             backprop_in_gather=backprop_in_gather,
             cross_entropy_kwargs=cross_entropy_kwargs,


### PR DESCRIPTION
Summary:

This change refactors Contrastive Learning classes and methods to use generic inputs and outputs instead of hardcoding image and text everywhere. The motivation behind this is that contrastive loss is a generic technique that can be applied to any pairs of input representations irrespective of modality.

Test plan:

The PR mostly refactors existing code, so testing can be done by just testing the existing unit tests.

```
pytest tests -vv
```