### PR TITLE
[MUGEN][Bugfix] Stop enforcing position id batch size the same as input

### DIFF
--- a/tests/models/test_gpt.py
+++ b/tests/models/test_gpt.py
@@ -238,7 +238,7 @@ def gpt(
 def get_pos_ids(x):
     b, seq_len, _ = x.shape
     pos_ids = torch.arange(seq_len, dtype=torch.long, device=x.device)
-    return pos_ids[None, :]  # (b, seq_len)
+    return pos_ids[None, :]  # (1, seq_len)
 
 
 class TestMultimodalGPT:

--- a/torchmultimodal/models/gpt.py
+++ b/torchmultimodal/models/gpt.py
@@ -502,15 +502,15 @@ class MultimodalTransformerDecoder(nn.Module):
         )
 
     def _norm_pos_ids(self, x: Tensor, pos_ids: Optional[Tensor] = None) -> Tensor:
-        b, seq_len, _ = x.shape
+        _, seq_len, _ = x.shape
         if pos_ids is None:
             pos_ids = torch.arange(seq_len, dtype=torch.long, device=x.device)[
                 None, :
-            ]  # (b, seq_len)
+            ]  # (1, seq_len)
 
-        if pos_ids.shape != (b, seq_len):
+        if pos_ids.shape[1] != seq_len:
             raise ValueError(
-                "input sequence and position ids must be equal in batch size and length"
+                f"Input sequence and position ids must be equal in length: {pos_ids.shape[1]} != {seq_len}"
             )
 
         return pos_ids


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #356
* #357
* #355
* __->__ #354

Summary:

Position IDs are broadcastable so it's unnecessary to force the first
dim to be of batch size

Test Plan:

`pytest tests/models/test_gpt.py`

Differential Revision: [D40421056](https://our.internmc.facebook.com/intern/diff/D40421056)