### PR TITLE
[MUGEN][Doc] Fix tutorial links of retrieval example

### DIFF
--- a/examples/mugen/retrieval/README.md
+++ b/examples/mugen/retrieval/README.md
@@ -1,6 +1,6 @@
 # MUGEN Retrieval
 
-This directory contains model components for MUGEN's video-text retrieval model, a tutorial notebook for the model usage (better viewed on [nbviewer](https://nbviewer.org/github/facebookresearch/multimodal/blob/main/examples/mugen/retrieval/evaluation.ipynb)), and training and evaluation scripts.
+This directory contains reference training and evaluation scripts for MUGEN's video-text retrieval model, including a tutorial notebook for the model usage [Colab](https://colab.research.google.com/drive/1gZfz1jsy79CNCK9t2_r43yt3z7v-w4HS?usp=sharing) or [GitHub](https://github.com/facebookresearch/multimodal/blob/main/examples/mugen/retrieval/tutorial.ipynb).
 
 ## Model
 MUGEN's video-text retrieval model follows from [VideoCLIP](https://arxiv.org/abs/2109.14084), a contrastive model for video and text.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #356
* #357
* __->__ #355
* #354

Summary:
As titled.

Test Plan:
Verified that the links would work in the public domain.

Differential Revision: [D40421055](https://our.internmc.facebook.com/intern/diff/D40421055)