### PR TITLE
[CLIP]Fix bug in resize for clip transform

### DIFF
--- a/tests/transforms/test_clip_transform.py
+++ b/tests/transforms/test_clip_transform.py
@@ -8,7 +8,7 @@ import unittest
 
 import torch
 from tests.test_utils import assert_expected, get_asset_path, set_rng_seed
-from torchmultimodal.transforms.clip_transform import CLIPTransform
+from torchmultimodal.transforms.clip_transform import CLIPImageTransform, CLIPTransform
 from torchvision.transforms import ToPILImage
 
 
@@ -92,3 +92,21 @@ class TestCLIPTransform(unittest.TestCase):
         actual_zero_pad_val = transformed_texts[:-1, self.text1_token_len :].max()
         expected_zero_pad_val = torch.tensor(0)
         assert_expected(actual_zero_pad_val, expected_zero_pad_val)
+
+    def test_clip_image_transform_int_resize(self):
+        image_transform = CLIPImageTransform(is_train=False)
+        # check the first transform which corresponds to the resize
+        transformed_image = image_transform.image_transform.transforms[0](self.image1)
+
+        actual_image_size = transformed_image.size
+        expected_image_size = (373, 224)
+        assert_expected(actual_image_size, expected_image_size)
+
+    def test_clip_image_transform_tuple_resize(self):
+        image_transform = CLIPImageTransform(image_size=(224, 224), is_train=False)
+        # check the first transform which corresponds to the resize
+        transformed_image = image_transform.image_transform.transforms[0](self.image1)
+
+        actual_image_size = transformed_image.size
+        expected_image_size = (224, 224)
+        assert_expected(actual_image_size, expected_image_size)

--- a/torchmultimodal/transforms/clip_transform.py
+++ b/torchmultimodal/transforms/clip_transform.py
@@ -97,7 +97,7 @@ class CLIPImageTransform:
 
     def __init__(
         self,
-        image_size: Union[int, Tuple[int, int]] = (224, 224),
+        image_size: Union[int, Tuple[int, int]] = 224,
         image_interpolation: InterpolationMode = InterpolationMode.BICUBIC,
         image_mean: Tuple[float, float, float] = CLIP_DEFAULT_MEAN,
         image_std: Tuple[float, float, float] = CLIP_DEFAULT_STD,
@@ -108,8 +108,6 @@ class CLIPImageTransform:
             image_transforms.ToTensor(),
             image_transforms.Normalize(image_mean, image_std),
         ]
-        if isinstance(image_size, int):
-            image_size = (image_size, image_size)
         base_transform: List[Callable]
         if is_train:
             base_transform = [
@@ -166,7 +164,7 @@ class CLIPTransform:
 
     def __init__(
         self,
-        image_size: Union[int, Tuple[int, int]] = (224, 224),
+        image_size: Union[int, Tuple[int, int]] = 224,
         image_interpolation: InterpolationMode = InterpolationMode.BICUBIC,
         image_mean: Tuple[float, float, float] = CLIP_DEFAULT_MEAN,
         image_std: Tuple[float, float, float] = CLIP_DEFAULT_STD,


### PR DESCRIPTION
Summary:
Based on original clip implementation, the transform should resize as a int and not tuple. Removing int to tuple conversion in our transform

Test plan:
- on main, the transform output doesnt match the orig implementation https://colab.research.google.com/drive/162vRzEVHXHAeO4uPtqBPr0xEv0blX6DC#scrollTo=nlSthJVx9gor
- on my branch, they match https://colab.research.google.com/drive/1vpZ0-3jgcWL-_785vJ8I19Y6_EeLfL8O#scrollTo=kEWURcxAD8yy

>
