### PR TITLE
Re-enable torchmultimodal's transformer decoder test

### DIFF
--- a/tests/models/mdetr/test_transformer.py
+++ b/tests/models/mdetr/test_transformer.py
@@ -82,7 +82,6 @@ class TestMDETRTransformer:
         batch_size,
         embedding_dim,
     ):
-        pytest.skip("temp skip for PT side fixing")
         actual = transformer.encoder(
             src=src, src_key_padding_mask=src_key_padding_mask, pos=pos
         )
@@ -103,7 +102,6 @@ class TestMDETRTransformer:
         batch_size,
         embedding_dim,
     ):
-        pytest.skip("temp skip for PT side fixing")
         actual = transformer.decoder(
             tgt=tgt,
             memory=memory,


### PR DESCRIPTION
Summary: enabled a skipped test which fixed by D40157046 (https://github.com/facebookresearch/multimodal/commit/4d2236877467ff8f56aa1935dd92d7782751b135)

Reviewed By: mikekgfb

Differential Revision: D40159681

