### PR TITLE
Migrate tokenizer

### DIFF
--- a/examples/mugen/generation/text_video_gpt.py
+++ b/examples/mugen/generation/text_video_gpt.py
@@ -28,9 +28,7 @@ from torchmultimodal.utils.common import load_module_from_url
 from torchtext.transforms import CharBPETokenizer
 
 
-PRETRAINED_BPE_TOKENIZER_ENCODER_URL = (
-    "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_encoder.json"
-)
+PRETRAINED_BPE_TOKENIZER_ENCODER_URL = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_encoder.json"
 PRETRAINED_BPE_TOKENIZER_MERGES_URL = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_merges.txt"
 PRETRAINED_TEXT_VIDEO_GPT_URL_MAPPING = {
     "mugen_L32": "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/text_video_gpt_L32_weights-17db9549.pth",
@@ -110,7 +108,7 @@ def text_video_gpt(
         bpe_encoder_path=text_tokenizer_encoder_local_path,
         bpe_merges_path=text_tokenizer_merges_local_path,
         unk_token="[UNK]",
-        special_tokens=["[PAD]", "[CLS]", "[SEP]", "[UNK]", "[MASK]"]
+        special_tokens=["[PAD]", "[CLS]", "[SEP]", "[UNK]", "[MASK]"],
     )
 
     # builds text tokenizer

--- a/examples/mugen/generation/text_video_gpt.py
+++ b/examples/mugen/generation/text_video_gpt.py
@@ -28,7 +28,9 @@ from torchmultimodal.utils.common import load_module_from_url
 from torchtext.transforms import CharBPETokenizer
 
 
-PRETRAINED_BPE_TOKENIZER_ENCODER_URL = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_encoder.json"
+PRETRAINED_BPE_TOKENIZER_ENCODER_URL = (
+    "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_encoder.json"
+)
 PRETRAINED_BPE_TOKENIZER_MERGES_URL = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_merges.txt"
 PRETRAINED_TEXT_VIDEO_GPT_URL_MAPPING = {
     "mugen_L32": "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/text_video_gpt_L32_weights-17db9549.pth",
@@ -49,7 +51,7 @@ def text_video_gpt(
     num_decoder_layers: int = 12,
     use_gpt_init: bool = True,
     pretrained_text_tokenizer_encoder_url: str = PRETRAINED_BPE_TOKENIZER_ENCODER_URL,
-    pretrained_text_tokenizer_merged_url: str = PRETRAINED_BPE_TOKENIZER_MERGES_URL,
+    pretrained_text_tokenizer_merges_url: str = PRETRAINED_BPE_TOKENIZER_MERGES_URL,
     pretrained_video_vqvae_model_key: Optional[str] = None,
     pretrained_text_video_gpt_model_key: Optional[str] = None,
 ) -> MultimodalGPT:
@@ -108,7 +110,7 @@ def text_video_gpt(
         bpe_encoder_path=text_tokenizer_encoder_local_path,
         bpe_merges_path=text_tokenizer_merges_local_path,
         unk_token="[UNK]",
-        special_tokens=["[PAD]","[CLS]","[SEP]","[UNK]","[MASK]"]
+        special_tokens=["[PAD]", "[CLS]", "[SEP]", "[UNK]", "[MASK]"]
     )
 
     # builds text tokenizer
@@ -214,8 +216,8 @@ class TextTokenizer(nn.Module):
     ) -> None:
         super().__init__()
         self.tokenizer = tokenizer
-        self.pad_id = self.tokenizer.encode("[PAD]").ids[0]  # type: ignore
-        self.vocab_size = self.tokenizer.get_vocab_size()  # type: ignore
+        self.pad_id = self.tokenizer.encode("[PAD]")[0]  # type: ignore
+        self.vocab_size = self.tokenizer.vocab_size  # type: ignore
         self.context_len = context_len
         # MUGEN treats padding as unique ids so adding them to the total text tokens
         # https://github.com/mugen-org/MUGEN_baseline/blob/main/lib/models/gpt/gpt.py#L44
@@ -228,7 +230,7 @@ class TextTokenizer(nn.Module):
             self.tokenizer.encode(sentence.strip().lower() + " [SEP]")  # type: ignore
             for sentence in sentences
         ]
-        token_ids = [t.ids[: self.context_len] for t in tokens]
+        token_ids = [t[: self.context_len] for t in tokens]
         # pad each sentence to be of length `context_len`
         for i, t in enumerate(token_ids):
             t += [self.pad_id] * (self.context_len - len(t))

--- a/examples/mugen/generation/text_video_gpt.py
+++ b/examples/mugen/generation/text_video_gpt.py
@@ -11,7 +11,6 @@ import torch
 from examples.mugen.generation.video_vqvae import video_vqvae_mugen
 
 from torch import nn, Tensor
-from torchmultimodal import _PATH_MANAGER
 
 from torchmultimodal.models.gpt import (
     MultimodalGPT,
@@ -28,8 +27,8 @@ from torchmultimodal.utils.common import load_module_from_url
 from torchtext.transforms import CharBPETokenizer
 
 
-PRETRAINED_BPE_TOKENIZER_ENCODER_URL = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_encoder.json"
-PRETRAINED_BPE_TOKENIZER_MERGES_URL = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_merges.txt"
+PRETRAINED_TOKENIZER_ENCODER_URL = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_encoder.json"
+PRETRAINED_TOKENIZER_MERGES_URL = "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/tokenizer-coinrun_1024_merges.txt"
 PRETRAINED_TEXT_VIDEO_GPT_URL_MAPPING = {
     "mugen_L32": "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/text_video_gpt_L32_weights-17db9549.pth",
     "mugen_L16": "https://pytorch.s3.amazonaws.com/models/multimodal/mugen/text_video_gpt_L16_weights-5dfc5a0a.pth",
@@ -48,8 +47,8 @@ def text_video_gpt(
     attn_dropout: float = 0.3,
     num_decoder_layers: int = 12,
     use_gpt_init: bool = True,
-    pretrained_text_tokenizer_encoder_url: str = PRETRAINED_BPE_TOKENIZER_ENCODER_URL,
-    pretrained_text_tokenizer_merges_url: str = PRETRAINED_BPE_TOKENIZER_MERGES_URL,
+    pretrained_text_tokenizer_encoder_url: str = PRETRAINED_TOKENIZER_ENCODER_URL,
+    pretrained_text_tokenizer_merges_url: str = PRETRAINED_TOKENIZER_MERGES_URL,
     pretrained_video_vqvae_model_key: Optional[str] = None,
     pretrained_text_video_gpt_model_key: Optional[str] = None,
 ) -> MultimodalGPT:
@@ -98,15 +97,9 @@ def text_video_gpt(
     """
 
     # builds text tokenizer from pre-trained
-    text_tokenizer_encoder_local_path = _PATH_MANAGER.get_local_path(
-        pretrained_text_tokenizer_encoder_url
-    )
-    text_tokenizer_merges_local_path = _PATH_MANAGER.get_local_path(
-        pretrained_text_tokenizer_merges_url
-    )
     tokenizer = CharBPETokenizer(
-        bpe_encoder_path=text_tokenizer_encoder_local_path,
-        bpe_merges_path=text_tokenizer_merges_local_path,
+        bpe_encoder_path=pretrained_text_tokenizer_encoder_url,
+        bpe_merges_path=pretrained_text_tokenizer_merges_url,
         unk_token="[UNK]",
         special_tokens=["[PAD]", "[CLS]", "[SEP]", "[UNK]", "[MASK]"],
     )


### PR DESCRIPTION
Summary:
This change moves MUGEN from using a hugging face tokenizer to using torch text's CharBPETokenizer

Test plan:
```
python3 -m pytest examples/mugen/tests/generation/test_text_video_gpt.py -vv

============================================================================== test session starts ==============================================================================
platform darwin -- Python 3.10.8, pytest-7.1.3, pluggy-1.0.0 -- /Library/Frameworks/Python.framework/Versions/3.10/bin/python3
cachedir: .pytest_cache
rootdir: /Users/rshraga/git/torchmultimodal
collected 21 items                                                                                                                                                              

examples/mugen/tests/generation/test_text_video_gpt.py::test_encode_text PASSED                                                                                           [  4%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_encode_video[8-expected0] PASSED                                                                             [  9%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_encode_video[16-expected1] PASSED                                                                            [ 14%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_encode_video[32-expected2] PASSED                                                                            [ 19%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_decode_video[8-55462.1719] PASSED                                                                            [ 23%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_decode_video[16-112028.1719] PASSED                                                                          [ 28%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_decode_video[32-225157.7656] PASSED                                                                          [ 33%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_decode_video_checkpoint[8-116013.4766] PASSED                                                                [ 38%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_decode_video_checkpoint[16-237488.625] PASSED                                                                [ 42%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_decode_video_checkpoint[32-536481.4375] PASSED                                                               [ 47%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_lookup[in-expected_shape0--53.7916] PASSED                                                                   [ 52%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_lookup[out-expected_shape1-42.4742] PASSED                                                                   [ 57%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_no_pretrained[8-782.1641] PASSED                                                                     [ 61%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_no_pretrained[16--442.4437] PASSED                                                                   [ 66%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_no_pretrained[32-585.2963] PASSED                                                                    [ 71%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_vqvae_pretrained[8-431.3439] PASSED                                                                  [ 76%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_vqvae_pretrained[16--180.2783] PASSED                                                                [ 80%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_vqvae_pretrained[32-462.27] PASSED                                                                   [ 85%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_gpt_pretrained[8-1520.8452] PASSED                                                                   [ 90%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_gpt_pretrained[16--2085.2417] PASSED                                                                 [ 95%]
examples/mugen/tests/generation/test_text_video_gpt.py::test_forward_gpt_pretrained[32--5190.5591] PASSED                                                                 [100%]

============================================================================== 21 passed in 51.24s ==============================================================================
```
