### PR TITLE
Refactor contrastive loss to make tensor gathering a util

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,12 +76,14 @@ def assert_expected(
     expected: Any,
     rtol: Optional[float] = None,
     atol: Optional[float] = None,
+    check_device=True,
 ):
     torch.testing.assert_close(
         actual,
         expected,
         rtol=rtol,
         atol=atol,
+        check_device=check_device,
         msg=f"actual: {actual}, expected: {expected}",
     )
 

--- a/tests/utils/test_distributed.py
+++ b/tests/utils/test_distributed.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+from tests.test_utils import (
+    assert_expected,
+    gpu_test,
+    init_distributed_on_file,
+    set_rng_seed,
+    with_temp_files,
+)
+from torch import Tensor
+from torchmultimodal.utils.distributed import gather_tensor
+
+BATCH_SIZE = 4
+EMBEDDING_DIM = 8
+
+
+class TestGatherTensor:
+    """
+    Test gather_tensor method with backprop_in_gather param
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        set_rng_seed(1234)
+
+    @pytest.fixture
+    def input_tensor(self):
+        return torch.randn(BATCH_SIZE, EMBEDDING_DIM)
+
+    @staticmethod
+    def _worker(
+        gpu_id: int,
+        world_size: int,
+        sync_file: str,
+        input_tensor: Tensor,
+        backprop_in_gather: bool,
+    ):
+        init_distributed_on_file(
+            world_size=world_size, gpu_id=gpu_id, sync_file=sync_file
+        )
+        gpu_tensor = input_tensor.clone().requires_grad_().to(gpu_id) + gpu_id
+        expected_output = [input_tensor + i for i in range(world_size)]
+        gathered_output = gather_tensor(gpu_tensor, backprop_in_gather)
+        assert_expected(len(expected_output), len(gathered_output))
+        for i, tensor in enumerate(gathered_output):
+            assert_expected(tensor, expected_output[i], check_device=False)
+            if i == gpu_id or backprop_in_gather:
+                assert tensor.grad_fn is not None
+            else:
+                assert tensor.grad_fn is None
+
+    @gpu_test(gpu_count=1)
+    @pytest.mark.parametrize("backprop_in_gather", [True, False])
+    def test_single_gpu_gather(self, input_tensor: Tensor, backprop_in_gather: bool):
+        world_size = 1
+        with with_temp_files(count=1) as sync_file:
+            mp.spawn(
+                TestGatherTensor._worker,
+                (
+                    world_size,
+                    sync_file,
+                    input_tensor,
+                    backprop_in_gather,
+                ),
+                nprocs=world_size,
+            )
+
+    @gpu_test(gpu_count=2)
+    @pytest.mark.parametrize("backprop_in_gather", [True, False])
+    def test_multi_gpu_gather(self, input_tensor: Tensor, backprop_in_gather: bool):
+        world_size = 2
+        with with_temp_files(count=1) as sync_file:
+            mp.spawn(
+                TestGatherTensor._worker,
+                (
+                    world_size,
+                    sync_file,
+                    input_tensor,
+                    backprop_in_gather,
+                ),
+                nprocs=world_size,
+            )

--- a/torchmultimodal/utils/distributed.py
+++ b/torchmultimodal/utils/distributed.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List
+
+import torch
+from torch import Tensor
+from torch.distributed import all_gather as all_gather_no_backprop
+from torch.distributed.nn.functional import all_gather as all_gather_with_backprop
+
+
+def gather_tensor(tensor: Tensor, backprop_in_gather: bool = True) -> List[Tensor]:
+    """Gathers a tensor across all GPUs.
+
+    Args:
+        tensor (Tensor): Tensors that need to be gathered.
+        backprop_in_gather (bool): Whether to backpropagate the gradients from
+            all_gather to all workers (versus just the local worker). Defaults
+            to {\\double back-quote}True{\\double quote}.
+
+    Returns:
+        List[Tensor]: List of gathered tensors across all GPUs.
+    """
+    world_size = torch.distributed.get_world_size()
+
+    # This uses the all_gather from torch.distributed.nn.functional,
+    # which backpropagates gradients to all workers
+    if backprop_in_gather:
+        return all_gather_with_backprop(tensor)
+
+    # Otherwise just backprop to the current worker
+    # This means that the image gradients on a given worker will only
+    # consider the text samples from the same worker
+    else:
+        tensor_all_gpus = [torch.zeros_like(tensor) for _ in range(world_size)]
+        all_gather_no_backprop(tensor_all_gpus, tensor)
+        tensor_all_gpus[torch.distributed.get_rank()] = tensor
+        return tensor_all_gpus


### PR DESCRIPTION
Summary:
This diff refactors Contrastive Loss to make tensor gathering a util so that it can be used with other losses.

This diff also fixes an existing bug in the previous logic of gather tensors, that prevents backpropagating to the local rank when `backprop_in_gather` is set to `False`

Differential Revision: D40598601

