### PR TITLE
Upgrade HF Datasets Library for Flava Example

### DIFF
--- a/examples/flava/requirements.txt
+++ b/examples/flava/requirements.txt
@@ -1,6 +1,6 @@
 Pillow==9.0.1
 pytorch-lightning==1.6.0
-datasets==2.0.0
+datasets==2.6.1
 requests==2.27.1
 DALL-E==0.1
 omegaconf==2.1.2


### PR DESCRIPTION
Summary:
Updated Hugging Face datasets library version in examples/flava. The older version can no longer interface with the HF online API and therefore cannot pull requested datasets.

Test plan:
I created a new conda env and built the dependencies using the new requirement. From there I ran the flava train.py script where it successfully pulled the Imagenet dataset as it's supposed to do and successfully started training.
