### PR TITLE
[FLAVA]Use the ckpt loading helper function instead of PretrainedMixin

### DIFF
--- a/torchmultimodal/models/flava/model.py
+++ b/torchmultimodal/models/flava/model.py
@@ -29,7 +29,7 @@ from torchmultimodal.modules.losses.flava import (
     FLAVAPretrainingLossOutput,
     Pooler,
 )
-from torchmultimodal.utils.common import ModelOutput, PretrainedMixin
+from torchmultimodal.utils.common import load_module_from_url, ModelOutput
 from typing_extensions import Literal
 
 
@@ -103,7 +103,7 @@ class FLAVAForClassificationOutput(ModelOutput):
     loss: Tensor
 
 
-class FLAVAModel(nn.Module, PretrainedMixin):
+class FLAVAModel(nn.Module):
     def __init__(
         self,
         image_encoder: nn.Module,
@@ -290,7 +290,7 @@ class FLAVAModel(nn.Module, PretrainedMixin):
         return self.mm_encoder(fused_state)
 
 
-class FLAVAForPreTraining(nn.Module, PretrainedMixin):
+class FLAVAForPreTraining(nn.Module):
     # TODOs:
     # 1. Expose logit scale
     # 2. For FLAVA model, allow interpolating the embeddings to
@@ -367,7 +367,7 @@ class FLAVAForPreTraining(nn.Module, PretrainedMixin):
         )
 
 
-class FLAVAForClassification(nn.Module, PretrainedMixin):
+class FLAVAForClassification(nn.Module):
     def __init__(
         self,
         model: FLAVAModel,
@@ -506,7 +506,8 @@ def flava_model(
     )
 
     if pretrained:
-        flava.load_model(FLAVA_MODEL_MAPPING["flava_full"])
+        load_module_from_url(flava, FLAVA_MODEL_MAPPING["flava_full"])
+        # flava.load_model(FLAVA_MODEL_MAPPING["flava_full"])
 
     return flava
 
@@ -529,7 +530,8 @@ def flava_model_for_pretraining(
     )
 
     if pretrained:
-        flava.load_model(FLAVA_FOR_PRETRAINED_MAPPING["flava_full"])
+        load_module_from_url(flava, FLAVA_FOR_PRETRAINED_MAPPING["flava_full"])
+        # flava.load_model(FLAVA_FOR_PRETRAINED_MAPPING["flava_full"])
 
     return flava
 
@@ -563,8 +565,13 @@ def flava_model_for_classification(
     )
 
     if pretrained:
-        classification_model.load_model(
-            FLAVA_FOR_PRETRAINED_MAPPING["flava_full"], strict=False
+        # classification_model.load_model(
+        #     FLAVA_FOR_PRETRAINED_MAPPING["flava_full"], strict=False
+        # )
+        load_module_from_url(
+            classification_model,
+            FLAVA_FOR_PRETRAINED_MAPPING["flava_full"],
+            strict=False,
         )
     return classification_model
 
@@ -702,7 +709,7 @@ class DalleEncoder(nn.Module):
         return self.blocks(x)
 
 
-class DalleVAEEncoder(nn.Module, PretrainedMixin):
+class DalleVAEEncoder(nn.Module):
     def __init__(
         self, image_size: Union[int, Tuple[int, int]] = 112, pretrained: bool = True
     ):
@@ -714,10 +721,11 @@ class DalleVAEEncoder(nn.Module, PretrainedMixin):
 
     def load_model(self) -> Any:  # type: ignore
         # TODO (T116682215): Network error due to FLAVA model relying on access to openAI
-        encoder = super().load_model(
-            "https://cdn.openai.com/dall-e/encoder.pkl", load_state_dict=False
+
+        encoder_state_dict = torch.hub.load_state_dict_from_url(
+            "https://cdn.openai.com/dall-e/encoder.pkl"
         )
-        self.encoder.load_state_dict(encoder.state_dict())  # type: ignore
+        self.encoder.load_state_dict(encoder_state_dict.state_dict())  # type: ignore
         return self.state_dict()
 
     def get_codebook_indices(self, images: Tensor) -> Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #368
* __->__ #366
* #365

Every class has to start inheriting PretrainedMixin. Instead its easier to just call the helper function 

Test plan
1. Pretrain debug
python -m flava.train config=flava/configs/pretraining/debug.yaml training.lightning.gpus=0 training.lightning.strategy=null
Epoch 0: : 50it [05:00,  6.01s/it, loss=12.1, v_num=5, train/losses/mmm_text_loss=9.870, train/losses/mmm_image_loss=9.100, train/losses/itm_loss=0.383, train/losses/global_contrastive_loss=2.100, train/losses/mlm_loss=10.20, train/losses/mim_loss=9.190]

2. Finetune 
python -m flava.finetune config=flava/configs/finetuning/qnli.yaml training.lightning.accelerator=cpu training.lightning.gpus=0 training.lightning.strategy=null
Epoch 0:   1%|▊                                                                 | 50/3787 [31:28<39:11:53, 37.76s/it, loss=0.713, v_num=6, train/losses/classification=0.697, train/accuracy/classification=0.469]

3. zero shot
python -m flava.coco_zero_shot --data_root /datasets01/COCO/022719/val2017 --annotations /datasets01/COCO/022719/annotations/captions_val2017.json

Differential Revision: [D41142482](https://our.internmc.facebook.com/intern/diff/D41142482)