### PR TITLE
[MDETR] Fix phrase grounding example and add README

### DIFF
--- a/examples/mdetr/README.md
+++ b/examples/mdetr/README.md
@@ -1,0 +1,72 @@
+# MDETR
+
+[MDETR](https://arxiv.org/abs/2104.12763) (Kamath et al., 2021) is a multimodal reasoning model to detect objects in an image conditioned on a text query. TorchMultimodal provides example scripts for MDETR on phrase grounding and visual question answering tasks.
+
+## Prerequisites
+
+Prior to running any of the MDETR tasks, you should
+1) follow the TorchMultimodal installation instructions in the [README](https://github.com/facebookresearch/multimodal/blob/main/README.md).
+2) install MDETR requirements via `pip install -r examples/mdetr/requirements.txt`.
+
+## Phrase grounding
+
+In phrase grounding, the objective is to associate noun phrases in the caption of an `(image, text)` pair to regions in the image. Phrase grounding tasks are not straightforward to evaluate in the case where a single phrase refers to multiple distinct boxes in the image, and different papers handle this case differently. One protocol, referred to as the Any-Box Protocol, considers the prediction to be correct based on the maximal IoU value over all ground truth boxes. In this protocol, the pretrained MDETR checkpoint can be evaluated directly on the holdout set without further fine-tuning. We provide a script for evaluation of MDETR on the phrase grounding task using this protocol. For additional details, see Appendix D of the MDETR paper.
+
+### Instructions
+
+First, make sure you have followed the TorchMultimodal installation instructions in the [README](https://github.com/facebookresearch/multimodal/blob/main/README.md).
+
+To run the evaluation script, you will need to download the Flickr30k dataset. This includes images, standard annotations, and additional annotations used by MDETR.
+
+1) Download the Flickr30k images [here](http://shannon.cs.illinois.edu/DenotationGraph/). You will need to fill out the form to request access before receiving the download link in your e-mail.
+
+```
+# Download Flickr30k images following the link above, then
+tar -xvzf flickr30k-images.tar.gz
+
+# Note that MDETR will expect separate directories for each dataset split, but you can just create symlinks.
+ln -s flickr30k-images flickr30k-images/train
+ln -s flickr30k-images flickr30k-images/val
+ln -s flickr30k-images flickr30k-images/test
+```
+
+2) Download the annotations and split mappings from [flickr30k_entities](https://github.com/BryanPlummer/flickr30k_entities).
+
+```
+wget https://github.com/BryanPlummer/flickr30k_entities/blob/master/annotations.zip
+unzip annotations.zip
+wget https://github.com/BryanPlummer/flickr30k_entities/blob/master/train.txt
+wget https://github.com/BryanPlummer/flickr30k_entities/blob/master/val.txt
+wget https://github.com/BryanPlummer/flickr30k_entities/blob/master/test.txt
+```
+
+3) Download and unzip the MDETR custom annotations.
+
+```
+wget https://zenodo.org/record/4729015/files/mdetr_annotations.tar.gz?download=1
+tar -xvzf 'mdetr_annotations.tar.gz?download=1'
+```
+
+4) Modify the fields in `phrase_grounding.json` based on the locations of the files in (1) - (3). E.g. if root directory for (1)-(3) is /data, you should use
+
+```
+{
+    "combine_datasets": ["flickr"],
+    "combine_datasets_val": ["flickr"],
+    "GT_type" : "separate",
+    "flickr_img_path" : "/data/flickr30k-images",
+   "flickr_dataset_path" : "/data/flickr30k/",
+   "flickr_ann_path" : "/data/OpenSource"
+  }
+```
+
+5) Run the evaluation script:
+
+```
+# From REPO_ROOT/examples/mdetr
+CUBLAS_WORKSPACE_CONFIG=:4096:8 torchrun --nproc_per_node=2 phrase_grounding.py --resume https://pytorch.s3.amazonaws.com/models/multimodal/mdetr/pretrained_resnet101_checkpoint.pth --ema --eval --dataset_config phrase_grounding.json
+```
+
+## VQA
+
+Coming soon

--- a/examples/mdetr/README.md
+++ b/examples/mdetr/README.md
@@ -14,7 +14,7 @@ In phrase grounding, the objective is to associate noun phrases in the caption o
 
 ### Instructions
 
-First, make sure you have followed the TorchMultimodal installation instructions in the [README](https://github.com/facebookresearch/multimodal/blob/main/README.md).
+First, make sure you have followed the [prerequisites](#prerequisites).
 
 To run the evaluation script, you will need to download the Flickr30k dataset. This includes images, standard annotations, and additional annotations used by MDETR.
 
@@ -47,7 +47,7 @@ wget https://zenodo.org/record/4729015/files/mdetr_annotations.tar.gz?download=1
 tar -xvzf 'mdetr_annotations.tar.gz?download=1'
 ```
 
-4) Modify the fields in `phrase_grounding.json` based on the locations of the files in (1) - (3). E.g. if root directory for (1)-(3) is /data, you should use
+4) Modify the fields in `phrase_grounding.json` based on the locations of the files in (1) - (3). E.g. if root directory for (1)-(3) is `/data`, you should use
 
 ```
 {
@@ -60,10 +60,15 @@ tar -xvzf 'mdetr_annotations.tar.gz?download=1'
   }
 ```
 
-5) Run the evaluation script:
+5) Run the evaluation script.
 
 ```
-# From REPO_ROOT/examples/mdetr
+cd examples/mdetr
+
+# Run on CPU
+python phrase_grounding.py --resume https://pytorch.s3.amazonaws.com/models/multimodal/mdetr/pretrained_resnet101_checkpoint.pth --ema --eval --dataset_config phrase_grounding.json
+
+# Run on two GPUs
 CUBLAS_WORKSPACE_CONFIG=:4096:8 torchrun --nproc_per_node=2 phrase_grounding.py --resume https://pytorch.s3.amazonaws.com/models/multimodal/mdetr/pretrained_resnet101_checkpoint.pth --ema --eval --dataset_config phrase_grounding.json
 ```
 

--- a/examples/mdetr/data/datamodule.py
+++ b/examples/mdetr/data/datamodule.py
@@ -8,8 +8,8 @@ from functools import partial
 from typing import Callable, Optional
 
 import torch
-from examples.mdetr.data.dataset import build_flickr, build_gqa, collate_fn
-from examples.mdetr.data.transforms import MDETRTransform
+from data.dataset import build_flickr, build_gqa, collate_fn
+from data.transforms import MDETRTransform
 from pytorch_lightning import LightningDataModule
 from torch.utils.data import DataLoader, DistributedSampler
 from transformers import RobertaTokenizerFast

--- a/examples/mdetr/data/dataset.py
+++ b/examples/mdetr/data/dataset.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import torch
 
-from examples.mdetr.data.transforms import ConvertCocoPolysToMask, create_positive_map
+from data.transforms import ConvertCocoPolysToMask, create_positive_map
 from torchvision.datasets import CocoDetection
 
 

--- a/examples/mdetr/data/flickr_eval.py
+++ b/examples/mdetr/data/flickr_eval.py
@@ -13,10 +13,10 @@ import numpy as np
 
 import torch
 import utils.dist as dist
-from examples.mdetr.utils.metrics import RecallTracker
 from prettytable import PrettyTable
 from torch import Tensor
 from torchvision.ops.boxes import box_iou
+from utils.metrics import RecallTracker
 
 
 def get_sentence_data(filename) -> List[Dict[str, Any]]:

--- a/examples/mdetr/data/transforms.py
+++ b/examples/mdetr/data/transforms.py
@@ -10,10 +10,10 @@ from typing import Any, Callable, Dict, Iterable, Union
 import PIL
 import torch
 import torchvision.transforms.functional as F
-from examples.mdetr.utils.misc import interpolate
 from PIL.Image import Image
 from torchvision import transforms as T
 from torchvision.ops.boxes import box_convert
+from utils.misc import interpolate
 
 
 def crop(image, target, region):

--- a/examples/mdetr/phrase_grounding.py
+++ b/examples/mdetr/phrase_grounding.py
@@ -10,16 +10,17 @@ import random
 from copy import deepcopy
 from pathlib import Path
 
-import examples.mdetr.utils.dist as dist
 import numpy as np
 import torch
-from examples.mdetr.data.datamodule import FlickrDataModule
-from examples.mdetr.data.flickr_eval import FlickrEvaluator
-from examples.mdetr.data.postprocessors import PostProcessFlickr
-from examples.mdetr.utils.args_parse import get_args_parser
-from examples.mdetr.utils.metrics import MetricLogger
-from examples.mdetr.utils.misc import targets_to
+
+import utils.dist as dist
+from data.datamodule import FlickrDataModule
+from data.flickr_eval import FlickrEvaluator
+from data.postprocessors import PostProcessFlickr
 from torchmultimodal.models.mdetr.model import mdetr_for_phrase_grounding
+from utils.args_parse import get_args_parser
+from utils.metrics import MetricLogger
+from utils.misc import targets_to
 
 
 @torch.no_grad()
@@ -100,7 +101,7 @@ def main(args):
     torch.manual_seed(seed)
     np.random.seed(seed)
     random.seed(seed)
-    torch.use_deterministic_algorithms(True)
+    torch.use_deterministic_algorithms(True, warn_only=True)
 
     # Set up datamodule
     datamodule = FlickrDataModule(args)

--- a/examples/mdetr/vqa_eval.py
+++ b/examples/mdetr/vqa_eval.py
@@ -10,16 +10,17 @@ import random
 from copy import deepcopy
 from pathlib import Path
 
-import examples.mdetr.utils.dist as dist
 import numpy as np
 import torch
-from examples.mdetr.data.datamodule import GQADataModule
-from examples.mdetr.loss import build_mdetr_loss, build_weight_dict
-from examples.mdetr.matcher import HungarianMatcher
-from examples.mdetr.utils.args_parse import get_args_parser
-from examples.mdetr.utils.metrics import MetricLogger
-from examples.mdetr.utils.misc import targets_to
+
+import utils.dist as dist
+from data.datamodule import GQADataModule
+from loss import build_mdetr_loss, build_weight_dict
+from matcher import HungarianMatcher
 from torchmultimodal.models.mdetr.model import mdetr_for_vqa
+from utils.args_parse import get_args_parser
+from utils.metrics import MetricLogger
+from utils.misc import targets_to
 
 
 @torch.no_grad()

--- a/examples/mdetr/vqa_finetune.py
+++ b/examples/mdetr/vqa_finetune.py
@@ -15,18 +15,19 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Iterable, Optional
 
-import examples.mdetr.utils.dist as dist
 import numpy as np
 import torch
-from examples.mdetr.data.datamodule import GQADataModule
-from examples.mdetr.loss import build_mdetr_loss, build_weight_dict
-from examples.mdetr.matcher import HungarianMatcher
-from examples.mdetr.optimizer import adjust_learning_rate, build_optimizer, update_ema
-from examples.mdetr.utils.args_parse import get_args_parser
-from examples.mdetr.utils.metrics import MetricLogger, SmoothedValue
-from examples.mdetr.utils.misc import targets_to
-from examples.mdetr.vqa_eval import evaluate
+
+import utils.dist as dist
+from data.datamodule import GQADataModule
+from loss import build_mdetr_loss, build_weight_dict
+from matcher import HungarianMatcher
+from optimizer import adjust_learning_rate, build_optimizer, update_ema
 from torchmultimodal.models.mdetr.model import mdetr_for_vqa
+from utils.args_parse import get_args_parser
+from utils.metrics import MetricLogger, SmoothedValue
+from utils.misc import targets_to
+from vqa_eval import evaluate
 
 
 def train_one_epoch(

--- a/torchmultimodal/models/mdetr/text_encoder.py
+++ b/torchmultimodal/models/mdetr/text_encoder.py
@@ -69,6 +69,8 @@ class ModifiedTransformerEncoder(nn.Module):
     ) -> TransformerOutput:
         encoded = embeddings
         mask = torch.squeeze(attention_mask.to(dtype=torch.bool))
+        if mask.dim() == 1:
+            mask = mask.unsqueeze(0)
         # Do this in a loop because otherwise it can cause OOM
         for layer in self.layers.layers:
             encoded = layer(encoded, src_key_padding_mask=mask)

--- a/torchmultimodal/models/mdetr/text_encoder.py
+++ b/torchmultimodal/models/mdetr/text_encoder.py
@@ -68,9 +68,9 @@ class ModifiedTransformerEncoder(nn.Module):
         return_hidden_states: bool = False,
     ) -> TransformerOutput:
         encoded = embeddings
-        mask = torch.squeeze(attention_mask.to(dtype=torch.bool))
-        if mask.dim() == 1:
-            mask = mask.unsqueeze(0)
+        batch_size, seq_len = embeddings.size()[:2]
+        mask = attention_mask.reshape(batch_size, seq_len)
+
         # Do this in a loop because otherwise it can cause OOM
         for layer in self.layers.layers:
             encoded = layer(encoded, src_key_padding_mask=mask)


### PR DESCRIPTION
Summary:

A few changes to get phrase grounding eval for MDETR up and running again.

1) Move to relative imports inside MDETR example so that phrase_grounding.py script is runnable without any hacks to sys.path.
2) Set torch.use_deterministic_algorithms to warn_only mode (due to upstream changes in cumsum)
3) Fix issue with batch_size = 1 by manually reshaping mask inside text encoder

Finally add a README so users can run more easily.

Test plan:
See the repro in examples/mdetr/README.md. Gives the same results as the test plan in #231.

Also unit tests 
