### PR TITLE
[omnivore]Fix imports in the train script

### DIFF
--- a/examples/omnivore/README.md
+++ b/examples/omnivore/README.md
@@ -105,7 +105,7 @@ root
 
 Example command to run training on ImageNet1K, Kinetics400, and SunRGBD datasets
 ```
-torchrun --nproc_per_node=8 --nnodes=8 train.py \
+torchrun --nproc_per_node=8 --nnodes=8  -m omnivore.train \
     --batch-size=128 --workers=6 --extra-video-dataloader-workers=6 \
     --cache-video-dataset --eval-every-num-epoch=10 --model="omnivore_swin_t" \
     --lr=0.002 --lr-warmup-epochs=25 --lr-warmup-method=linear \
@@ -129,8 +129,8 @@ torchrun --nproc_per_node=8 --nnodes=8 train.py \
 
 Example command to run evaluation on Omnivore with Swin Transformer Tiny variant.
 ```
-torchrun --nproc_per_node=8 --nnodes=1 train.py \
-    --batch-size=128 --workers=6 --mode="omnivore_swin_t" \
+torchrun --nproc_per_node=8 --nnodes=1 -m omnivore.train \
+    --batch-size=128 --workers=6 --model="omnivore_swin_t" \
     --cache-video-dataset \
     --extra-video-dataloader-workers=7 \
     --kinetics-dataset-workers=12 \

--- a/examples/omnivore/data/data_builder.py
+++ b/examples/omnivore/data/data_builder.py
@@ -13,11 +13,11 @@ import logging
 import os
 import time
 
-import examples.omnivore.utils as utils
+import omnivore.utils as utils
 import torch
 import torchvision
 import torchvision.datasets.samplers as video_samplers
-from examples.omnivore.data import datasets, presets, transforms
+from omnivore.data import datasets, presets, transforms
 from torch.utils.data.dataloader import default_collate
 from torchvision.transforms.functional import InterpolationMode
 

--- a/examples/omnivore/data/presets.py
+++ b/examples/omnivore/data/presets.py
@@ -4,10 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import examples.omnivore.data.transforms as CT  # custom transforms
+import omnivore.data.transforms as CT  # custom transforms
 import torch
 import torchvision.transforms as T
-from examples.omnivore.data.rand_aug3d import RandAugment3d
+from omnivore.data.rand_aug3d import RandAugment3d
 from torchvision.transforms.functional import InterpolationMode
 
 

--- a/examples/omnivore/train.py
+++ b/examples/omnivore/train.py
@@ -12,12 +12,12 @@ import logging
 import os
 import time
 
-import examples.omnivore.data.data_builder as data_builder
-import examples.omnivore.utils as utils
+import omnivore.data.data_builder as data_builder
 
 import torch
 import torch.utils.data
 import torchmultimodal.models.omnivore as omnivore
+from omnivore import utils
 from torch import nn
 
 


### PR DESCRIPTION
Summary:
use omnivore directory as the root for imports

Test plan:
torchrun --nproc_per_node=8 --nnodes=1 -m omnivore.train     --batch-size=128 --workers=6 --model="omnivore_swin_t"     --cache-video-dataset     --extra-video-dataloader-workers=7     --kinetics-dataset-workers=12     --val-resize-size=224     --video-grad-accum-iter=32     --modalities image video rgbd     --val-data-sampling-factor 1 1 1     --test-only --pretrained --imagenet-data-path=/datasets01_ontap/imagenet_full_size/061417 --kinetics-data-path=/datasets01_ontap/kinetics/070618/400 --sunrgbd-data-path=/data/home/yosuamichael/datasets/SUN_RGBD

[2022-11-23 04:12:32,122] INFO - Test:  rgbd Acc@1 61.964 rgbd Acc@5 87.822
[2022-11-23 04:12:32,122] INFO - Test:  Video Acc@1 77.985 Video Acc@5 93.462
[2022-11-23 04:12:32,122] INFO - Test:  rgbd Acc@1 61.964 rgbd Acc@5 87.822
