### PR TITLE
[omnivore] Using Upstreamed SwinTransformer3d in TorchVision

### DIFF
--- a/examples/omnivore/omnivore_inference_demo.ipynb
+++ b/examples/omnivore/omnivore_inference_demo.ipynb
@@ -29,6 +29,7 @@
     "import torchvision.transforms as T\n",
     "\n",
     "import sys\n",
+    "# We add the folder: \"<torchmultimodal_repo>/examples\" to path to import the presets\n",
     "sys.path.append(os.path.dirname(os.path.abspath(\"\")))\n",
     "\n",
     "import torchmultimodal.models.omnivore as omnivore\n",

--- a/examples/omnivore/omnivore_inference_demo.ipynb
+++ b/examples/omnivore/omnivore_inference_demo.ipynb
@@ -28,8 +28,11 @@
     "from torchvision.io import read_video, _read_video_from_file\n",
     "import torchvision.transforms as T\n",
     "\n",
+    "import sys\n",
+    "sys.path.append(os.path.dirname(os.path.abspath(\"\")))\n",
+    "\n",
     "import torchmultimodal.models.omnivore as omnivore\n",
-    "from examples.omnivore.data import presets\n",
+    "from omnivore.data import presets\n",
     "\n",
     "from IPython.display import Video\n",
     "from matplotlib import pyplot as plt"
@@ -338,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/tests/models/test_omnivore.py
+++ b/tests/models/test_omnivore.py
@@ -41,19 +41,19 @@ def test_omnivore_swin_t_forward(omnivore_swin_t_model, device):
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
     assert_expected(
-        image_score.abs().sum(), torch.tensor(200.27574), rtol=1e-3, atol=1e-3
+        image_score.abs().sum(), torch.tensor(184.01417), rtol=1e-3, atol=1e-3
     )
 
     rgbd = torch.randn((1, 4, 1, 112, 112), device=device)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
-    assert_expected(rgbd_score.abs().sum(), torch.tensor(3.10466), rtol=1e-3, atol=1e-3)
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(3.60813), rtol=1e-3, atol=1e-3)
 
     video = torch.randn((1, 3, 4, 112, 112), device=device)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
-        video_score.abs().sum(), torch.tensor(97.57287), rtol=1e-3, atol=1e-3
+        video_score.abs().sum(), torch.tensor(110.70048), rtol=1e-3, atol=1e-3
     )
 
 
@@ -65,19 +65,19 @@ def test_omnivore_swin_s_forward(omnivore_swin_s_model, device):
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
     assert_expected(
-        image_score.abs().sum(), torch.tensor(238.41870), rtol=1e-3, atol=1e-3
+        image_score.abs().sum(), torch.tensor(239.73104), rtol=1e-3, atol=1e-3
     )
 
     rgbd = torch.randn((1, 4, 1, 112, 112), device=device)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
-    assert_expected(rgbd_score.abs().sum(), torch.tensor(4.05502), rtol=1e-3, atol=1e-3)
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(5.80919), rtol=1e-3, atol=1e-3)
 
     video = torch.randn((1, 3, 4, 112, 112), device=device)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
-        video_score.abs().sum(), torch.tensor(114.26146), rtol=1e-3, atol=1e-3
+        video_score.abs().sum(), torch.tensor(136.49894), rtol=1e-3, atol=1e-3
     )
 
 
@@ -89,19 +89,19 @@ def test_omnivore_swin_b_forward(omnivore_swin_b_model, device):
 
     assert_expected(image_score.size(), torch.Size((1, 1000)))
     assert_expected(
-        image_score.abs().sum(), torch.tensor(234.38349), rtol=1e-3, atol=1e-3
+        image_score.abs().sum(), torch.tensor(278.06488), rtol=1e-3, atol=1e-3
     )
 
     rgbd = torch.randn((1, 4, 1, 112, 112), device=device)
     rgbd_score = model(rgbd, input_type="rgbd")
     assert_expected(rgbd_score.size(), torch.Size((1, 19)))
-    assert_expected(rgbd_score.abs().sum(), torch.tensor(5.37857), rtol=1e-3, atol=1e-3)
+    assert_expected(rgbd_score.abs().sum(), torch.tensor(4.52186), rtol=1e-3, atol=1e-3)
 
     video = torch.randn((1, 3, 4, 112, 112), device=device)
     video_score = model(video, input_type="video")
     assert_expected(video_score.size(), torch.Size((1, 400)))
     assert_expected(
-        video_score.abs().sum(), torch.tensor(128.43623), rtol=1e-3, atol=1e-3
+        video_score.abs().sum(), torch.tensor(138.22859), rtol=1e-3, atol=1e-3
     )
 
 

--- a/tests/modules/encoders/test_swin_transformer_3d_encoder.py
+++ b/tests/modules/encoders/test_swin_transformer_3d_encoder.py
@@ -10,10 +10,10 @@ import torch
 
 from tests.test_utils import set_rng_seed
 from torchmultimodal.modules.encoders.swin_transformer_3d_encoder import (
-    PatchEmbed3d,
     SwinTransformer3d,
 )
 from torchmultimodal.utils.common import get_current_device
+from torchvision.models.video.swin_transformer import PatchEmbed3d
 
 
 class TestSwinTransformer3d(unittest.TestCase):

--- a/tests/modules/encoders/test_swin_transformer_3d_encoder.py
+++ b/tests/modules/encoders/test_swin_transformer_3d_encoder.py
@@ -11,8 +11,6 @@ import torch
 from tests.test_utils import set_rng_seed
 from torchmultimodal.modules.encoders.swin_transformer_3d_encoder import (
     PatchEmbed3d,
-    PatchMerging,
-    ShiftedWindowAttention3d,
     SwinTransformer3d,
 )
 from torchmultimodal.utils.common import get_current_device
@@ -41,41 +39,7 @@ class TestSwinTransformer3d(unittest.TestCase):
 
         scores = self.encoder(image)
         self.assertEqual(scores.size(), torch.Size([1, 768]))
-        self.assertAlmostEqual(scores.abs().sum().item(), 277.63833, 2)
+        self.assertAlmostEqual(scores.abs().sum().item(), 247.14674, 2)
 
     def test_swin_transformer_3d_scripting(self):
         torch.jit.script(self.encoder)
-
-
-class TestSwinTransformer3dComponents(unittest.TestCase):
-    def setUp(self):
-        set_rng_seed(42)
-        self.device = get_current_device()
-
-    def test_patch_merging_3d(self):
-        module = PatchMerging(dim=12, norm_layer=torch.nn.LayerNorm).to(self.device)
-        x_in = torch.randn(1, 1, 56, 56, 12)
-        x_out = module(x_in)
-
-        self.assertEqual(x_out.size(), torch.Size([1, 1, 28, 28, 24]))
-        self.assertAlmostEqual(x_out.abs().sum().item(), 8705.25390, 1)
-
-    def test_shifted_window_attention_3d(self):
-        module = ShiftedWindowAttention3d(
-            dim=12, window_size=[8, 7, 7], shift_size=[4, 3, 3], num_heads=3
-        ).to(self.device)
-        x_in = torch.randn(1, 1, 56, 56, 12)
-        x_out = module(x_in)
-
-        self.assertEqual(x_out.size(), torch.Size([1, 1, 56, 56, 12]))
-        self.assertAlmostEqual(x_out.abs().sum().item(), 6189.71777, 1)
-
-    def test_shifted_window_attention_3d_zero_shift(self):
-        module = ShiftedWindowAttention3d(
-            dim=12, window_size=[8, 7, 7], shift_size=[0, 0, 0], num_heads=3
-        ).to(self.device)
-        x_in = torch.randn(1, 1, 56, 56, 12)
-        x_out = module(x_in)
-
-        self.assertEqual(x_out.size(), torch.Size([1, 1, 56, 56, 12]))
-        self.assertAlmostEqual(x_out.abs().sum().item(), 6131.83691, 1)

--- a/torchmultimodal/models/omnivore.py
+++ b/torchmultimodal/models/omnivore.py
@@ -11,9 +11,10 @@ import torch
 import torchmultimodal.utils.common as common_utils
 from torch import nn
 from torchmultimodal.modules.encoders.swin_transformer_3d_encoder import (
-    PatchEmbed3d,
     SwinTransformer3d,
 )
+from torchvision.models.video.swin_transformer import PatchEmbed3d
+
 
 _OMNIVORE_PRETRAINED_URLS = {
     "swin_t_encoder": "https://download.pytorch.org/models/omnivore_swin_t_encoder-b7e39400.pth",

--- a/torchmultimodal/modules/encoders/swin_transformer_3d_encoder.py
+++ b/torchmultimodal/modules/encoders/swin_transformer_3d_encoder.py
@@ -12,14 +12,9 @@ from typing import Callable, List, Optional
 
 from torch import nn
 from torchvision.models.video.swin_transformer import (
-    PatchEmbed3d as TVPatchEmbed3d,
-    PatchMerging as TVPatchMerging,
+    PatchMerging,
     SwinTransformer3d as TVSwinTransformer3d,
 )
-
-# We redefine this because they are imported on other script
-PatchMerging = TVPatchMerging
-PatchEmbed3d = TVPatchEmbed3d
 
 
 class SwinTransformer3d(TVSwinTransformer3d):

--- a/torchmultimodal/modules/encoders/swin_transformer_3d_encoder.py
+++ b/torchmultimodal/modules/encoders/swin_transformer_3d_encoder.py
@@ -8,338 +8,24 @@
 # https://github.com/pytorch/vision/blob/main/torchvision/models/swin_transformer.py
 
 
-from functools import partial
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional
 
-import torch
-import torch.nn.functional as F
 from torch import nn, Tensor
-from torchvision.models.swin_transformer import PatchMerging, SwinTransformerBlock
+from torchvision.models.video.swin_transformer import (
+    SwinTransformer3d as TVSwinTransformer3d,
+    PatchMerging as TVPatchMerging,
+    PatchEmbed3d as TVPatchEmbed3d
+)
+
+# We redefine this because they are imported on other script
+PatchMerging = TVPatchMerging
+PatchEmbed3d = TVPatchEmbed3d
 
 
-def _compute_pad_size_3d(
-    size_dhw: Tuple[int, int, int], patch_size: Tuple[int, int, int]
-) -> Tuple[int, int, int]:
-    pad_size = [
-        (patch_size[i] - size_dhw[i] % patch_size[i]) % patch_size[i] for i in range(3)
-    ]
-    return (pad_size[0], pad_size[1], pad_size[2])
-
-
-def _compute_attention_mask_3d(
-    x: Tensor,
-    size_dhw: Tuple[int, int, int],
-    window_size: Tuple[int, int, int],
-    shift_size: Tuple[int, int, int],
-) -> Tensor:
-    # generate attention mask
-    attn_mask = x.new_zeros(*size_dhw)
-    num_windows = (
-        (size_dhw[0] // window_size[0])
-        * (size_dhw[1] // window_size[1])
-        * (size_dhw[2] // window_size[2])
-    )
-    slices = [
-        (
-            (0, -window_size[i]),
-            (-window_size[i], -shift_size[i]),
-            (-shift_size[i], None),
-        )
-        for i in range(3)
-    ]
-    count = 0
-    for d in slices[0]:
-        for h in slices[1]:
-            for w in slices[2]:
-                attn_mask[d[0] : d[1], h[0] : h[1], w[0] : w[1]] = count
-                count += 1
-
-    # Partition window on attn_mask
-    attn_mask = attn_mask.view(
-        size_dhw[0] // window_size[0],
-        window_size[0],
-        size_dhw[1] // window_size[1],
-        window_size[1],
-        size_dhw[2] // window_size[2],
-        window_size[2],
-    )
-    attn_mask = attn_mask.permute(0, 2, 4, 1, 3, 5).reshape(
-        num_windows, window_size[0] * window_size[1] * window_size[2]
-    )
-    attn_mask = attn_mask.unsqueeze(1) - attn_mask.unsqueeze(2)
-    attn_mask = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(
-        attn_mask == 0, float(0.0)
-    )
-    return attn_mask
-
-
-def shifted_window_attention_3d(
-    input: Tensor,
-    qkv_weight: Tensor,
-    proj_weight: Tensor,
-    relative_position_bias: Tensor,
-    window_size: List[int],
-    num_heads: int,
-    shift_size: List[int],
-    attention_dropout: float = 0.0,
-    dropout: float = 0.0,
-    qkv_bias: Optional[Tensor] = None,
-    proj_bias: Optional[Tensor] = None,
-) -> Tensor:
-    """
-    Window based multi-head self attention (W-MSA) module with relative position bias.
-    It supports both of shifted and non-shifted window.
-    Args:
-        input (Tensor[B, D, H, W, C]): The input tensor, 5-dimensions.
-        qkv_weight (Tensor[in_dim, out_dim]): The weight tensor of query, key, value.
-        proj_weight (Tensor[out_dim, out_dim]): The weight tensor of projection.
-        relative_position_bias (Tensor): The learned relative position bias added to attention.
-        window_size (List[int]): 3-dimensions window size, D, H, W .
-        num_heads (int): Number of attention heads.
-        shift_size (List[int]): Shift size for shifted window attention (D, H, W).
-        attention_dropout (float): Dropout ratio of attention weight. Default: 0.0.
-        dropout (float): Dropout ratio of output. Default: 0.0.
-        qkv_bias (Tensor[out_dim], optional): The bias tensor of query, key, value. Default: None.
-        proj_bias (Tensor[out_dim], optional): The bias tensor of projection. Default: None.
-    Returns:
-        Tensor[B, D, H, W, C]: The output tensor after shifted window attention.
-    """
-    b, d, h, w, c = input.shape
-    # pad feature maps to multiples of window size
-    pad_size = _compute_pad_size_3d(
-        (d, h, w), (window_size[0], window_size[1], window_size[2])
-    )
-    x = F.pad(input, (0, 0, 0, pad_size[2], 0, pad_size[1], 0, pad_size[0]))
-    _, dp, hp, wp, _ = x.shape
-    padded_size = (dp, hp, wp)
-
-    # cyclic shift
-    if sum(shift_size) > 0:
-        x = torch.roll(
-            x, shifts=(-shift_size[0], -shift_size[1], -shift_size[2]), dims=(1, 2, 3)
-        )
-
-    # partition windows
-    num_windows = (
-        (padded_size[0] // window_size[0])
-        * (padded_size[1] // window_size[1])
-        * (padded_size[2] // window_size[2])
-    )
-    x = x.view(
-        b,
-        padded_size[0] // window_size[0],
-        window_size[0],
-        padded_size[1] // window_size[1],
-        window_size[1],
-        padded_size[2] // window_size[2],
-        window_size[2],
-        c,
-    )
-    x = x.permute(0, 1, 3, 5, 2, 4, 6, 7).reshape(
-        b * num_windows, window_size[0] * window_size[1] * window_size[2], c
-    )  # B*nW, Wd*Wh*Ww, C
-
-    # multi-head attention
-    qkv = F.linear(x, qkv_weight, qkv_bias)
-    qkv = qkv.reshape(x.size(0), x.size(1), 3, num_heads, c // num_heads).permute(
-        2, 0, 3, 1, 4
-    )
-    q, k, v = qkv[0], qkv[1], qkv[2]
-    q = q * (c // num_heads) ** -0.5
-    attn = q.matmul(k.transpose(-2, -1))
-    # add relative position bias
-    attn = attn + relative_position_bias
-
-    if sum(shift_size) > 0:
-        # generate attention mask to handle shifted windows with varying size
-        attn_mask = _compute_attention_mask_3d(
-            x,
-            (padded_size[0], padded_size[1], padded_size[2]),
-            (window_size[0], window_size[1], window_size[2]),
-            (shift_size[0], shift_size[1], shift_size[2]),
-        )
-        attn = attn.view(
-            x.size(0) // num_windows, num_windows, num_heads, x.size(1), x.size(1)
-        )
-        attn = attn + attn_mask.unsqueeze(1).unsqueeze(0)
-        attn = attn.view(-1, num_heads, x.size(1), x.size(1))
-
-    attn = F.softmax(attn, dim=-1)
-    attn = F.dropout(attn, p=attention_dropout)
-
-    x = attn.matmul(v).transpose(1, 2).reshape(x.size(0), x.size(1), c)
-    x = F.linear(x, proj_weight, proj_bias)
-    x = F.dropout(x, p=dropout)
-
-    # reverse windows
-    x = x.view(
-        b,
-        padded_size[0] // window_size[0],
-        padded_size[1] // window_size[1],
-        padded_size[2] // window_size[2],
-        window_size[0],
-        window_size[1],
-        window_size[2],
-        c,
-    )
-    x = x.permute(0, 1, 4, 2, 5, 3, 6, 7).reshape(b, dp, hp, wp, c)
-
-    # reverse cyclic shift
-    if sum(shift_size) > 0:
-        x = torch.roll(
-            x, shifts=(shift_size[0], shift_size[1], shift_size[2]), dims=(1, 2, 3)
-        )
-
-    # unpad features
-    x = x[:, :d, :h, :w, :].contiguous()
-    return x
-
-
-class ShiftedWindowAttention3d(nn.Module):
-    """
-    See :func:`shifted_window_attention_3d`.
-    """
-
-    def __init__(
-        self,
-        dim: int,
-        window_size: List[int],
-        shift_size: List[int],
-        num_heads: int,
-        qkv_bias: bool = True,
-        proj_bias: bool = True,
-        attention_dropout: float = 0.0,
-        dropout: float = 0.0,
-    ):
-        super().__init__()
-        self.window_size = window_size  # Wd, Wh, Ww
-        self.shift_size = shift_size
-        self.num_heads = num_heads
-        self.attention_dropout = attention_dropout
-        self.dropout = dropout
-
-        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
-        self.proj = nn.Linear(dim, dim, bias=proj_bias)
-
-        # define a parameter table of relative position bias
-        self.relative_position_bias_table = nn.Parameter(
-            torch.zeros(
-                (2 * window_size[0] - 1)
-                * (2 * window_size[1] - 1)
-                * (2 * window_size[2] - 1),
-                num_heads,
-            )
-        )  # 2*Wd-1 * 2*Wh-1 * 2*Ww-1, nH
-
-        # get pair-wise relative position index for each token inside the window
-        coords_dhw = [torch.arange(self.window_size[i]) for i in range(3)]
-        coords = torch.stack(
-            torch.meshgrid(coords_dhw[0], coords_dhw[1], coords_dhw[2], indexing="ij")
-        )  # 3, Wd, Wh, Ww
-        coords_flatten = torch.flatten(coords, 1)  # 3, Wd*Wh*Ww
-        relative_coords = (
-            coords_flatten[:, :, None] - coords_flatten[:, None, :]
-        )  # 3, Wd*Wh*Ww, Wd*Wh*Ww
-        relative_coords = relative_coords.permute(
-            1, 2, 0
-        ).contiguous()  # Wd*Wh*Ww, Wd*Wh*Ww, 3
-        relative_coords[:, :, 0] += self.window_size[0] - 1  # shift to start from 0
-        relative_coords[:, :, 1] += self.window_size[1] - 1
-        relative_coords[:, :, 2] += self.window_size[2] - 1
-
-        relative_coords[:, :, 0] *= (2 * self.window_size[1] - 1) * (
-            2 * self.window_size[2] - 1
-        )
-        relative_coords[:, :, 1] *= 2 * self.window_size[2] - 1
-        relative_position_index = relative_coords.sum(-1)  # Wd*Wh*Ww, Wd*Wh*Ww
-        self.register_buffer("relative_position_index", relative_position_index)
-
-        nn.init.trunc_normal_(self.relative_position_bias_table, std=0.02)
-
-    def forward(self, x: Tensor) -> Tensor:
-        _, d, h, w, _ = x.shape
-        size_dhw = (d, h, w)
-        window_size, shift_size = self.window_size.copy(), self.shift_size.copy()
-        # Handle case where window_size is larger than the input tensor
-        for i in range(3):
-            if size_dhw[i] <= window_size[i]:
-                # In this case, window_size will adapt to the input size, and no need to shift
-                window_size[i] = size_dhw[i]
-                shift_size[i] = 0
-
-        window_vol = window_size[0] * window_size[1] * window_size[2]
-        relative_position_bias = self.relative_position_bias_table[
-            self.relative_position_index[:window_vol, :window_vol].flatten()  # type: ignore[index]
-        ]
-        relative_position_bias = relative_position_bias.view(window_vol, window_vol, -1)
-        relative_position_bias = (
-            relative_position_bias.permute(2, 0, 1).contiguous().unsqueeze(0)
-        )
-
-        return shifted_window_attention_3d(
-            x,
-            self.qkv.weight,
-            self.proj.weight,
-            relative_position_bias,
-            window_size,
-            self.num_heads,
-            shift_size=shift_size,
-            attention_dropout=self.attention_dropout,
-            dropout=self.dropout,
-            qkv_bias=self.qkv.bias,
-            proj_bias=self.proj.bias,
-        )
-
-
-# Modified from:
-# https://github.com/SwinTransformer/Video-Swin-Transformer/blob/master/mmaction/models/backbones/swin_transformer.py
-class PatchEmbed3d(nn.Module):
-    """Video to Patch Embedding.
-
-    Args:
-        patch_size (List[int]): Patch token size.
-        in_channels (int): Number of input channels. Default: 3
-        embed_dim (int): Number of linear projection output channels. Default: 96.
-        norm_layer (nn.Module, optional): Normalization layer. Default: None
-    """
-
-    def __init__(
-        self,
-        patch_size: List[int],
-        in_channels: int = 3,
-        embed_dim: int = 96,
-        norm_layer: Optional[Callable[..., nn.Module]] = None,
-    ):
-        super().__init__()
-        self.tuple_patch_size = (patch_size[0], patch_size[1], patch_size[2])
-
-        self.proj = nn.Conv3d(
-            in_channels,
-            embed_dim,
-            kernel_size=self.tuple_patch_size,
-            stride=self.tuple_patch_size,
-        )
-        if norm_layer is not None:
-            self.norm = norm_layer(embed_dim)
-        else:
-            self.norm = None
-
-    def forward(self, x: Tensor) -> Tensor:
-        """Forward function."""
-        # padding
-        _, _, d, h, w = x.size()
-        pad_size = _compute_pad_size_3d((d, h, w), self.tuple_patch_size)
-        x = F.pad(x, (0, pad_size[2], 0, pad_size[1], 0, pad_size[0]))
-        x = self.proj(x)  # B C D Wh Ww
-        x = x.permute(0, 2, 3, 4, 1)  # B D Wh Ww C
-        if self.norm is not None:
-            x = self.norm(x)
-        return x
-
-
-class SwinTransformer3d(nn.Module):
+class SwinTransformer3d(TVSwinTransformer3d):
     """
     Implements 3D Swin Transformer from the `"Video Swin Transformer" <https://arxiv.org/abs/2106.13230>`_ paper.
+    We upstream the model from torchvision: https://github.com/pytorch/vision/blob/main/torchvision/models/video/swin_transformer.py#L363
     Args:
         patch_size (List[int]): Patch size.
         embed_dim (int): Patch embedding dimension.
@@ -356,7 +42,6 @@ class SwinTransformer3d(nn.Module):
         norm_layer (nn.Module, optional): Normalization layer. Default: None.
         patch_embed (nn.Module, optional): Patch Embedding layer. Default: None.
     """
-
     def __init__(
         self,
         patch_size: List[int],
@@ -371,86 +56,31 @@ class SwinTransformer3d(nn.Module):
         num_classes: Optional[int] = 400,
         norm_layer: Optional[Callable[..., nn.Module]] = None,
         block: Optional[Callable[..., nn.Module]] = None,
+        downsample_layer: Callable[..., nn.Module] = PatchMerging,
         patch_embed: Optional[Callable[..., nn.Module]] = None,
     ):
-        super().__init__()
-        self.num_classes = num_classes
-
-        if block is None:
-            block = partial(SwinTransformerBlock, attn_layer=ShiftedWindowAttention3d)
-
-        if norm_layer is None:
-            norm_layer = partial(nn.LayerNorm, eps=1e-5)
-
-        if patch_embed is None:
-            patch_embed = PatchEmbed3d
-
-        # split image into non-overlapping patches
-        self.patch_embed = patch_embed(
-            patch_size=patch_size, embed_dim=embed_dim, norm_layer=norm_layer
-        )
-        self.pos_drop = nn.Dropout(p=dropout)
-
-        layers: List[nn.Module] = []
-        total_stage_blocks = sum(depths)
-        stage_block_id = 0
-        # build SwinTransformer blocks
-        for i_stage in range(len(depths)):
-            stage: List[nn.Module] = []
-            dim = embed_dim * 2**i_stage
-            for i_layer in range(depths[i_stage]):
-                # adjust stochastic depth probability based on the depth of the stage block
-                sd_prob = (
-                    stochastic_depth_prob
-                    * float(stage_block_id)
-                    / (total_stage_blocks - 1)
-                )
-                stage.append(
-                    block(
-                        dim,
-                        num_heads[i_stage],
-                        window_size=window_size,
-                        shift_size=[
-                            0 if i_layer % 2 == 0 else w // 2 for w in window_size
-                        ],
-                        mlp_ratio=mlp_ratio,
-                        dropout=dropout,
-                        attention_dropout=attention_dropout,
-                        stochastic_depth_prob=sd_prob,
-                        norm_layer=norm_layer,
-                        attn_layer=ShiftedWindowAttention3d,
-                    )
-                )
-                stage_block_id += 1
-            layers.append(nn.Sequential(*stage))
-            # add patch merging layer
-            if i_stage < (len(depths) - 1):
-                layers.append(PatchMerging(dim, norm_layer))
-        self.features = nn.Sequential(*layers)
-
-        self.num_features = embed_dim * 2 ** (len(depths) - 1)
-        self.norm = norm_layer(self.num_features)
-        self.avgpool = nn.AdaptiveAvgPool3d(1)
+        # Create non-optional _num_classes to construct torchvision SwinTransformer3d
+        _num_classes = 400
         if num_classes is not None:
-            self.head = nn.Linear(self.num_features, num_classes)
-        else:
-            self.head = None
+            _num_classes = num_classes
 
-        for m in self.modules():
-            if isinstance(m, nn.Linear):
-                nn.init.trunc_normal_(m.weight, std=0.02)
-                if m.bias is not None:
-                    nn.init.zeros_(m.bias)
+        super().__init__(
+            patch_size=patch_size,
+            embed_dim=embed_dim,
+            depths=depths,
+            num_heads=num_heads,
+            window_size=window_size,
+            mlp_ratio=mlp_ratio,
+            dropout=dropout,
+            attention_dropout=attention_dropout,
+            stochastic_depth_prob=stochastic_depth_prob,
+            num_classes=_num_classes,
+            norm_layer=norm_layer,
+            block=block,
+            downsample_layer=downsample_layer,
+            patch_embed=patch_embed,
+        )
 
-    def forward(self, x: Tensor) -> Tensor:
-        # x: B C D H W
-        x = self.patch_embed(x)  # B _D _H _W C
-        x = self.pos_drop(x)
-        x = self.features(x)  # B _D _H _W C
-        x = self.norm(x)
-        x = x.permute(0, 4, 1, 2, 3)  # B, C, _D, _H, _W
-        x = self.avgpool(x)
-        x = torch.flatten(x, 1)
-        if self.num_classes is not None:
-            x = self.head(x)
-        return x
+        if num_classes is None:
+            # Convert the head into identity
+            self.head = nn.Identity()

--- a/torchmultimodal/modules/encoders/swin_transformer_3d_encoder.py
+++ b/torchmultimodal/modules/encoders/swin_transformer_3d_encoder.py
@@ -10,16 +10,18 @@
 
 from typing import Callable, List, Optional
 
-from torch import nn, Tensor
+from torch import nn
 from torchvision.models.video.swin_transformer import (
     SwinTransformer3d as TVSwinTransformer3d,
     PatchMerging as TVPatchMerging,
-    PatchEmbed3d as TVPatchEmbed3d
+    PatchEmbed3d as TVPatchEmbed3d,
+    ShiftedWindowAttention3d as TVShiftedWindowAttention3d,
 )
 
 # We redefine this because they are imported on other script
 PatchMerging = TVPatchMerging
 PatchEmbed3d = TVPatchEmbed3d
+ShiftedWindowAttention3d = TVShiftedWindowAttention3d
 
 
 class SwinTransformer3d(TVSwinTransformer3d):

--- a/torchmultimodal/modules/encoders/swin_transformer_3d_encoder.py
+++ b/torchmultimodal/modules/encoders/swin_transformer_3d_encoder.py
@@ -12,22 +12,21 @@ from typing import Callable, List, Optional
 
 from torch import nn
 from torchvision.models.video.swin_transformer import (
-    SwinTransformer3d as TVSwinTransformer3d,
-    PatchMerging as TVPatchMerging,
     PatchEmbed3d as TVPatchEmbed3d,
-    ShiftedWindowAttention3d as TVShiftedWindowAttention3d,
+    PatchMerging as TVPatchMerging,
+    SwinTransformer3d as TVSwinTransformer3d,
 )
 
 # We redefine this because they are imported on other script
 PatchMerging = TVPatchMerging
 PatchEmbed3d = TVPatchEmbed3d
-ShiftedWindowAttention3d = TVShiftedWindowAttention3d
 
 
 class SwinTransformer3d(TVSwinTransformer3d):
     """
     Implements 3D Swin Transformer from the `"Video Swin Transformer" <https://arxiv.org/abs/2106.13230>`_ paper.
-    We upstream the model from torchvision: https://github.com/pytorch/vision/blob/main/torchvision/models/video/swin_transformer.py#L363
+    We upstream the model from torchvision:
+    https://github.com/pytorch/vision/blob/main/torchvision/models/video/swin_transformer.py#L363
     Args:
         patch_size (List[int]): Patch size.
         embed_dim (int): Patch embedding dimension.
@@ -44,6 +43,7 @@ class SwinTransformer3d(TVSwinTransformer3d):
         norm_layer (nn.Module, optional): Normalization layer. Default: None.
         patch_embed (nn.Module, optional): Patch Embedding layer. Default: None.
     """
+
     def __init__(
         self,
         patch_size: List[int],


### PR DESCRIPTION
Summary:

- Use the upstreamed SwinTransformer3d implementation in TorchVision
- Fix the test for SwinTransformer3d (update the value because the random init changed)
- Remove component test for SwinTransformer3d since it is upstreamed from torchvision no need for this anymore
- Also fix the notebook import

Test plan:
- Run all cells in the notebook: https://github.com/facebookresearch/multimodal/blob/main/examples/omnivore/omnivore_inference_demo.ipynb
- See the CI tests run, or run manually:
    - `pytest models/test_omnivore.py`
    - `pytest modules/encoders/test_swin_transformer_3d_encoder.py`
