### PR TITLE
[FLAVA]change np.int to np.int64 in transforms to account for np upgrade

### DIFF
--- a/torchmultimodal/transforms/flava_transform.py
+++ b/torchmultimodal/transforms/flava_transform.py
@@ -93,7 +93,7 @@ class ImageMaskingGenerator:
         return delta
 
     def __call__(self) -> np.ndarray:
-        mask = np.zeros(shape=self.get_shape(), dtype=np.int)  # type: ignore
+        mask = np.zeros(shape=self.get_shape(), dtype=np.int64)  # type: ignore
         mask_count = 0
         while mask_count < self.num_masking_patches:
             max_mask_patches = self.num_masking_patches - mask_count


### PR DESCRIPTION
numpy got upgraded probably due to torchvision new nightly which broke nightlies

Test plan
after upgrading numpy to 1.24 => pytest tests/transforms/test_flava_transform.py 
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #388
* __->__ #387

Differential Revision: [D41755440](https://our.internmc.facebook.com/intern/diff/D41755440)