### PR TITLE
Re-enable torchmultimodal's exponential distribution related test cases

### DIFF
--- a/tests/modules/losses/test_mdetr_losses.py
+++ b/tests/modules/losses/test_mdetr_losses.py
@@ -102,9 +102,6 @@ class TestMDETRLosses:
     def test_soft_token_prediction_loss(
         self, pred_logits, n_boxes_per_sample, positive_map, indices, num_boxes
     ):
-        pytest.skip(
-            "temp skip until PT side PR lands: https://github.com/pytorch/pytorch/pull/69967"
-        )
         actual = torch.Tensor(
             soft_token_prediction_loss(
                 pred_logits, n_boxes_per_sample, positive_map, indices, num_boxes
@@ -114,9 +111,6 @@ class TestMDETRLosses:
         assert_expected(actual, expected, rtol=0, atol=1e-3)
 
     def test_box_losses(self, pred_boxes, target_boxes, indices, num_boxes):
-        pytest.skip(
-            "temp skip until PT side PR lands: https://github.com/pytorch/pytorch/pull/69967"
-        )
         actual = box_losses(pred_boxes, target_boxes, indices, num_boxes)
         expected_l1_loss = torch.tensor(0.8463)
         expected_giou_loss = torch.tensor(1.2569)

--- a/tests/utils/test_generate.py
+++ b/tests/utils/test_generate.py
@@ -91,9 +91,6 @@ class TestGenerationUtil:
             generator = GenerationUtil(model=model)
 
     def test_sample(self, generation_model):
-        pytest.skip(
-            "temp skip until PT side PR lands: https://github.com/pytorch/pytorch/pull/69967"
-        )
         input_shape = self._model_params["input_shape"]
         latent_shape = self._model_params["latent_shape"]
         latent_seq_len = torch.prod(torch.tensor(latent_shape)).item()


### PR DESCRIPTION
Summary:

Re-enable exponential distribution related test cases skipped by https://github.com/facebookresearch/multimodal/pull/364

