### PR TITLE
[FLAVA]Upgrade lightning and pillow dependencies

### DIFF
--- a/examples/flava/configs/finetuning/qnli.yaml
+++ b/examples/flava/configs/finetuning/qnli.yaml
@@ -5,7 +5,6 @@ training:
   lightning:
     max_steps: 33112
     gpus: 1
-    progress_bar_refresh_rate: 50
     val_check_interval: 1000
     num_sanity_val_steps: 0
     strategy: ddp

--- a/examples/flava/configs/finetuning/rendered_sst2.yaml
+++ b/examples/flava/configs/finetuning/rendered_sst2.yaml
@@ -5,7 +5,6 @@ training:
   lightning:
     max_steps: 20935
     gpus: -1
-    progress_bar_refresh_rate: 50
     val_check_interval: 100
     num_sanity_val_steps: 0
     strategy: ddp

--- a/examples/flava/configs/pretraining/debug.yaml
+++ b/examples/flava/configs/pretraining/debug.yaml
@@ -4,7 +4,6 @@ training:
   lightning:
     max_steps: 450000
     gpus: -1
-    progress_bar_refresh_rate: 50
     val_check_interval: 10000
     num_sanity_val_steps: 0
     strategy: ddp

--- a/examples/flava/requirements.txt
+++ b/examples/flava/requirements.txt
@@ -1,5 +1,5 @@
-Pillow==9.0.1
-pytorch-lightning==1.6.0
+Pillow==9.2.0
+pytorch-lightning==1.8.6
 datasets==2.6.1
 requests==2.27.1
 DALL-E==0.1


### PR DESCRIPTION
Summary:
- flava broke as pytorch nightly became incompatible with lightning 1.6 due to https://github.com/pytorch/pytorch/commit/0a69c50a46d50ae265e2d1d826d0b4b69d4351fd. upgrade to 1.8.6 and remove progress_bar_refresh_rate which was removed in lightning later versions

-  upgrade pillow to fix https://github.com/facebookresearch/multimodal/security/dependabot/3

Test plan:
python -m flava.train config=flava/configs/pretraining/debug.yaml training.lightning.accelerator=cpu training.lightning.gpus=0 training.lightning.strategy=null 

Epoch 0: : 116it [08:45,  4.53s/it, loss=13.4, v_num=14, train/losses/mim_loss=9.150, train/losses/mlm_loss=9.310, train/losses/mmm_text_loss=8.370, train/losses/mmm_image_loss=9.070, train/losses/itm_loss=0.668, train/losses/global_contrastive_loss=2.090]


