### PR TITLE
Added OpenAI Pre-trained weights to CLIP Models

### DIFF
--- a/tests/models/clip/test_checkpoint.py
+++ b/tests/models/clip/test_checkpoint.py
@@ -1,0 +1,270 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.models.clip import model as pretrained
+
+
+class TestCLIPCheckpoint:
+    @pytest.fixture(scope="class")
+    def data(self):
+        set_rng_seed(0)
+        image224 = torch.randn(1, 3, 224, 224)
+        image288 = torch.randn(1, 3, 288, 288)
+        image384 = torch.randn(1, 3, 384, 384)
+        image448 = torch.randn(1, 3, 448, 448)
+        text = torch.randint(0, 49408, (1, 77))
+        return text, image224, image288, image384, image448
+
+    def test_clip_vit_b16(self, data):
+        text, image224, *_ = data
+        model = pretrained.clip_vit_b16(True)
+        model.eval()
+        with torch.no_grad():
+            actual_a_embedding, actual_b_embedding = model(image224, text)
+
+        assert_expected(
+            actual=actual_a_embedding.mean(),
+            expected=torch.tensor(0.0030),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=actual_b_embedding.mean(),
+            expected=torch.tensor(0.0023),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_a_embedding.size()),
+            expected=torch.tensor((1, 512)),
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_b_embedding.size()),
+            expected=torch.tensor((1, 512)),
+        )
+
+    def test_clip_vit_b32(self, data):
+        text, image224, *_ = data
+        model = pretrained.clip_vit_b32(True)
+        model.eval()
+        with torch.no_grad():
+            actual_a_embedding, actual_b_embedding = model(image224, text)
+
+        assert_expected(
+            actual=actual_a_embedding.mean(),
+            expected=torch.tensor(-0.0014),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=actual_b_embedding.mean(),
+            expected=torch.tensor(-0.0041),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_a_embedding.size()),
+            expected=torch.tensor((1, 512)),
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_b_embedding.size()),
+            expected=torch.tensor((1, 512)),
+        )
+
+    def test_clip_vit_l14(self, data):
+        text, image224, *_ = data
+        model = pretrained.clip_vit_l14(True)
+        model.eval()
+        with torch.no_grad():
+            actual_a_embedding, actual_b_embedding = model(image224, text)
+
+        assert_expected(
+            actual=actual_a_embedding.mean(),
+            expected=torch.tensor(0.0006),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=actual_b_embedding.mean(),
+            expected=torch.tensor(-0.0022),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_a_embedding.size()),
+            expected=torch.tensor((1, 768)),
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_b_embedding.size()),
+            expected=torch.tensor((1, 768)),
+        )
+
+    def test_clip_rn50(self, data):
+        text, image224, *_ = data
+        model = pretrained.clip_rn50(True)
+        model.eval()
+        with torch.no_grad():
+            actual_a_embedding, actual_b_embedding = model(image224, text)
+
+        assert_expected(
+            actual=actual_a_embedding.mean(),
+            expected=torch.tensor(-0.0012),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=actual_b_embedding.mean(),
+            expected=torch.tensor(-0.0001),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_a_embedding.size()),
+            expected=torch.tensor((1, 1024)),
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_b_embedding.size()),
+            expected=torch.tensor((1, 1024)),
+        )
+
+    def test_clip_rn101(self, data):
+        text, image224, *_ = data
+        model = pretrained.clip_rn101(True)
+        model.eval()
+        with torch.no_grad():
+            actual_a_embedding, actual_b_embedding = model(image224, text)
+
+        assert_expected(
+            actual=actual_a_embedding.mean(),
+            expected=torch.tensor(-0.0012),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=actual_b_embedding.mean(),
+            expected=torch.tensor(-0.0017),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_a_embedding.size()),
+            expected=torch.tensor((1, 512)),
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_b_embedding.size()),
+            expected=torch.tensor((1, 512)),
+        )
+
+    def test_clip_rn50x4(self, data):
+        text, _, image288, *_ = data
+        model = pretrained.clip_rn50x4(True)
+        model.eval()
+        with torch.no_grad():
+            actual_a_embedding, actual_b_embedding = model(image288, text)
+
+        assert_expected(
+            actual=actual_a_embedding.mean(),
+            expected=torch.tensor(0.0006),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=actual_b_embedding.mean(),
+            expected=torch.tensor(0.0002),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_a_embedding.size()),
+            expected=torch.tensor((1, 640)),
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_b_embedding.size()),
+            expected=torch.tensor((1, 640)),
+        )
+
+    def test_clip_rn50x16(self, data):
+        text, *_, image384, _ = data
+        model = pretrained.clip_rn50x16(True)
+        model.eval()
+        with torch.no_grad():
+            actual_a_embedding, actual_b_embedding = model(image384, text)
+
+        assert_expected(
+            actual=actual_a_embedding.mean(),
+            expected=torch.tensor(0.0017),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=actual_b_embedding.mean(),
+            expected=torch.tensor(0.0012),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_a_embedding.size()),
+            expected=torch.tensor((1, 768)),
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_b_embedding.size()),
+            expected=torch.tensor((1, 768)),
+        )
+
+    def test_clip_rn50x64(self, data):
+        text, *_, image448 = data
+        model = pretrained.clip_rn50x64(True)
+        model.eval()
+        with torch.no_grad():
+            actual_a_embedding, actual_b_embedding = model(image448, text)
+
+        assert_expected(
+            actual=actual_a_embedding.mean(),
+            expected=torch.tensor(0.0004),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=actual_b_embedding.mean(),
+            expected=torch.tensor(-0.0004),
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_a_embedding.size()),
+            expected=torch.tensor((1, 1024)),
+        )
+
+        assert_expected(
+            actual=torch.tensor(actual_b_embedding.size()),
+            expected=torch.tensor((1, 1024)),
+        )

--- a/torchmultimodal/models/clip/model.py
+++ b/torchmultimodal/models/clip/model.py
@@ -13,12 +13,25 @@ from torch import nn
 
 from torchmultimodal.models.clip.image_encoder import CLIPViTEncoder, ResNetForCLIP
 from torchmultimodal.models.clip.text_encoder import CLIPTextEncoder
+from torchmultimodal.utils.common import load_module_from_url
 from torchvision.models.resnet import Bottleneck, ResNet
 
 
 class CLIPOutput(NamedTuple):
     embeddings_a: torch.Tensor
     embeddings_b: torch.Tensor
+
+
+CLIP_MODEL_MAPPING = {
+    "vit_b16": "https://download.pytorch.org/models/multimodal/clip/clip_vit_b16.pt",
+    "vit_b32": "https://download.pytorch.org/models/multimodal/clip/clip_vit_b32.pt",
+    "vit_l14": "https://download.pytorch.org/models/multimodal/clip/clip_vit_l14.pt",
+    "rn50": "https://download.pytorch.org/models/multimodal/clip/clip_rn50.pt",
+    "rn101": "https://download.pytorch.org/models/multimodal/clip/clip_rn101.pt",
+    "rn50x4": "https://download.pytorch.org/models/multimodal/clip/clip_rn50x4.pt",
+    "rn50x16": "https://download.pytorch.org/models/multimodal/clip/clip_rn50x16.pt",
+    "rn50x64": "https://download.pytorch.org/models/multimodal/clip/clip_rn50x64.pt",
+}
 
 
 class CLIP(nn.Module):
@@ -63,23 +76,29 @@ class CLIP(nn.Module):
         return CLIPOutput(embeddings_a=embeddings_a, embeddings_b=embeddings_b)
 
 
-def clip_vit_b16() -> CLIP:
+def clip_vit_b16(pretrained: bool = False) -> CLIP:
     vision_encoder = CLIPViTEncoder(
         image_size=224, patch_size=16, layers=12, heads=12, width=768, embedding_dim=512
     )
     text_encoder = CLIPTextEncoder(embedding_dim=512)
-    return CLIP(vision_encoder, text_encoder)
+    clip = CLIP(vision_encoder, text_encoder)
+    if pretrained:
+        load_module_from_url(clip, CLIP_MODEL_MAPPING["vit_b16"])
+    return clip
 
 
-def clip_vit_b32() -> CLIP:
+def clip_vit_b32(pretrained: bool = False) -> CLIP:
     vision_encoder = CLIPViTEncoder(
         image_size=224, patch_size=32, layers=12, heads=12, width=768, embedding_dim=512
     )
     text_encoder = CLIPTextEncoder(embedding_dim=512)
-    return CLIP(vision_encoder, text_encoder)
+    clip = CLIP(vision_encoder, text_encoder)
+    if pretrained:
+        load_module_from_url(clip, CLIP_MODEL_MAPPING["vit_b32"])
+    return clip
 
 
-def clip_vit_l14() -> CLIP:
+def clip_vit_l14(pretrained: bool = False) -> CLIP:
     vision_encoder = CLIPViTEncoder(
         image_size=224,
         patch_size=14,
@@ -88,67 +107,93 @@ def clip_vit_l14() -> CLIP:
         width=1024,
         embedding_dim=768,
     )
-    text_encoder = CLIPTextEncoder(embedding_dim=768, width=768, heads=12)
-    return CLIP(vision_encoder, text_encoder)
+    text_encoder = CLIPTextEncoder(
+        embedding_dim=768, width=768, dim_feedforward=3072, heads=12
+    )
+    clip = CLIP(vision_encoder, text_encoder)
+    if pretrained:
+        load_module_from_url(clip, CLIP_MODEL_MAPPING["vit_l14"])
+    return clip
 
 
-def clip_rn50() -> CLIP:
+def clip_rn50(pretrained: bool = False) -> CLIP:
     vision_encoder = ResNetForCLIP(
         layers=(3, 4, 6, 3),
         output_dim=1024,
-        heads=1024,
-        width=2048,
+        heads=32,
+        width=64,
     )
     text_encoder = CLIPTextEncoder(embedding_dim=1024)
-    return CLIP(vision_encoder, text_encoder)
+    clip = CLIP(vision_encoder, text_encoder)
+    if pretrained:
+        load_module_from_url(clip, CLIP_MODEL_MAPPING["rn50"])
+    return clip
 
 
-def clip_rn101() -> CLIP:
+def clip_rn101(pretrained: bool = False) -> CLIP:
     vision_encoder = ResNetForCLIP(
         layers=(3, 4, 23, 3),
-        output_dim=1024,
-        heads=1024,
-        width=2048,
+        output_dim=512,
+        heads=32,
+        width=64,
     )
-    text_encoder = CLIPTextEncoder(embedding_dim=1024)
-    return CLIP(vision_encoder, text_encoder)
+    text_encoder = CLIPTextEncoder(embedding_dim=512)
+    clip = CLIP(vision_encoder, text_encoder)
+    if pretrained:
+        load_module_from_url(clip, CLIP_MODEL_MAPPING["rn101"])
+    return clip
 
 
 # Note: these models require larger image sizes
-def clip_rn50x4() -> CLIP:
+def clip_rn50x4(pretrained: bool = False) -> CLIP:
     vision_encoder = ResNetForCLIP(
         layers=(4, 6, 10, 6),
         output_dim=640,
-        heads=1280,
+        heads=40,
         input_resolution=288,
-        width=2560,
+        width=80,
     )
-    text_encoder = CLIPTextEncoder(embedding_dim=1024, width=640, heads=12)
-    return CLIP(vision_encoder, text_encoder)
+    text_encoder = CLIPTextEncoder(
+        embedding_dim=640, width=640, dim_feedforward=2560, heads=10
+    )
+    clip = CLIP(vision_encoder, text_encoder)
+    if pretrained:
+        load_module_from_url(clip, CLIP_MODEL_MAPPING["rn50x4"])
+    return clip
 
 
-def clip_rn50x16() -> CLIP:
+def clip_rn50x16(pretrained: bool = False) -> CLIP:
     vision_encoder = ResNetForCLIP(
         layers=(6, 8, 18, 8),
         output_dim=768,
-        heads=1536,
+        heads=48,
         input_resolution=384,
-        width=3072,
+        width=96,
     )
-    text_encoder = CLIPTextEncoder(embedding_dim=768, width=768, heads=12)
-    return CLIP(vision_encoder, text_encoder)
+    text_encoder = CLIPTextEncoder(
+        embedding_dim=768, width=768, dim_feedforward=3072, heads=12
+    )
+    clip = CLIP(vision_encoder, text_encoder)
+    if pretrained:
+        load_module_from_url(clip, CLIP_MODEL_MAPPING["rn50x16"])
+    return clip
 
 
-def clip_rn50x64() -> CLIP:
+def clip_rn50x64(pretrained: bool = False) -> CLIP:
     vision_encoder = ResNetForCLIP(
         layers=(3, 15, 36, 10),
         output_dim=1024,
-        heads=2048,
+        heads=64,
         input_resolution=448,
-        width=4096,
+        width=128,
     )
-    text_encoder = CLIPTextEncoder(embedding_dim=1024, width=1024, heads=16)
-    return CLIP(vision_encoder, text_encoder)
+    text_encoder = CLIPTextEncoder(
+        embedding_dim=1024, width=1024, dim_feedforward=4096, heads=16
+    )
+    clip = CLIP(vision_encoder, text_encoder)
+    if pretrained:
+        load_module_from_url(clip, CLIP_MODEL_MAPPING["rn50x64"])
+    return clip
 
 
 # Note: these models use torchvision's ResNet

--- a/torchmultimodal/models/clip/text_encoder.py
+++ b/torchmultimodal/models/clip/text_encoder.py
@@ -24,6 +24,7 @@ class CLIPTextEncoder(nn.Module):
         context_length (int): Maximum sequence length for Transforer.
         vocab_size (int): Vocab size.
         width (int): Embedding dimension for Transformer encoder.
+        dim_feedforward (int): Dimension of the feedfoward networks.
         heads (int): Number of heads in Transformer encoder.
         layers (int): Number of layers in Transformer encoder.
         use_clip_init (bool): Whether to use CLIP-specific initialization.
@@ -40,6 +41,7 @@ class CLIPTextEncoder(nn.Module):
         context_length: int = 77,
         vocab_size: int = 49408,
         width: int = 512,
+        dim_feedforward: int = 2048,
         heads: int = 8,
         layers: int = 12,
         use_clip_init: bool = True,
@@ -53,6 +55,7 @@ class CLIPTextEncoder(nn.Module):
         )
         encoder_layer = TransformerEncoderLayer(
             d_model=width,
+            dim_feedforward=dim_feedforward,
             nhead=heads,
             dropout=0.0,
             activation=SiLU(),


### PR DESCRIPTION
Summary:
Added pre-trained flag to all CLIP models. This will pull pre-trained weights for any model there are open weights for, otherwise it'll provide a warning and ignore the flag. The flag pulls the OpenAI weights from S3 which are saved as state_dict and loads those weights. All of the weights have been tested to output the same outputs as their corresponding models in the OpenAI CLIP repo.

CLIP models that were configured differently from the OpenAI repo were updated to match; this was the ViT-l/14 model and all the ResNet models. Additionally, a parameter was added to the CLIP text encoder to be able to be configured to match the OpenAI configs.

Test plan:
I added new unit tests that call each CLIP model with a random image and tokens and check the first 5 features of the text and image embeddings against an expected output. Running `pytest tests/models/clip/test_clip.py -vv` will run the tests. I removed the cached models on the server before running the test to verify the pre-trained weights were correctly pulled from S3 during the test.
Example notebook to verify weights match: https://colab.research.google.com/drive/1ANLQ4tBP2ejuLWZNprLl_Z8iWqdBG_CX?usp=sharing

Fixes https://github.com/facebookresearch/multimodal/issues/384