### PR TITLE
Remove python 3.7 support

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -19,9 +19,6 @@ jobs:
       matrix:
         include:
          - os: ubuntu-latest
-           python-version: 3.7
-           python-tag: "py37"
-         - os: ubuntu-latest
            python-version: 3.8
            python-tag: "py38"
          - os: ubuntu-latest

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As a first open source example, researchers will be able to train and extend FLA
 
 ## Installation
 
-TorchMultimodal requires Python >= 3.7. The library can be installed with or without CUDA support.
+TorchMultimodal requires Python >= 3.8. The library can be installed with or without CUDA support.
 The following assumes conda is installed.
 
 ### Prerequisites
@@ -33,7 +33,7 @@ The following assumes conda is installed.
 
 ### Install from binaries
 
-Nightly binary on Linux for Python 3.7, 3.8 and 3.9 can be installed via pip wheels.
+Nightly binary on Linux for Python 3.8 and 3.9 can be installed via pip wheels.
 For now we only support Linux platform through [PyPI](https://pypi.org/).
 
 ```


### PR DESCRIPTION
Summary:
Pytorch nightlies have dropped support for 3.7 https://github.com/pytorch/pytorch/issues/80513
doing the same for our nightlies

Test plan:
CI

