### PR TITLE
[MUGEN] Update GenerateUtil test to remove multinomial dependency

### DIFF
--- a/tests/utils/test_generate.py
+++ b/tests/utils/test_generate.py
@@ -99,45 +99,8 @@ class TestGenerationUtil:
             x, max_seq_len=latent_seq_len, use_cache=True, causal=True
         )
         assert isinstance(out, SampleOutput)
-        expected = out.tokens
-        actual = torch.tensor(
-            [
-                432,
-                691,
-                524,
-                796,
-                392,
-                298,
-                249,
-                697,
-                79,
-                927,
-                198,
-                224,
-                289,
-                63,
-                331,
-                686,
-                792,
-                1019,
-                109,
-                296,
-                342,
-                855,
-                211,
-                171,
-                376,
-                613,
-                696,
-                605,
-                1018,
-                812,
-                255,
-                670,
-            ]
-        ).unsqueeze(
-            0
-        )  # (b, out_seq_len)
+        actual = out.tokens.shape
+        expected = torch.Size([1, 32])
         assert_expected(actual, expected)
 
     def test_filter_logits(self, generation_model):


### PR DESCRIPTION
Summary:
Due to a change in pytorch's random distribution calculation (see https://github.com/pytorch/pytorch/pull/69967), `torch.multinomial` is producing different values for unit tests. `GenerationUtil` uses multinomial for autoregressive decoding and token prediction. The `test_sample` unit test now tests for output shape instead of exact tokens to mitigate sensitivities to random distributions.

Test plan:
```
python -m pytest -v tests/utils/test_generate.py

tests/utils/test_generate.py::TestLogitsMask::test_normal PASSED                                                                                                                         [  6%]
tests/utils/test_generate.py::TestLogitsMask::test_zero_dims PASSED                                                                                                                      [ 13%]
tests/utils/test_generate.py::TestLogitsMask::test_in_seq_only PASSED                                                                                                                    [ 20%]
tests/utils/test_generate.py::TestLogitsMask::test_out_seq_only PASSED                                                                                                                   [ 26%]
tests/utils/test_generate.py::TestGenerationUtil::test_model_eval_warning PASSED                                                                                                         [ 33%]
tests/utils/test_generate.py::TestGenerationUtil::test_sample PASSED                                                                                                                     [ 40%]
tests/utils/test_generate.py::TestGenerationUtil::test_filter_logits PASSED                                                                                                              [ 46%]
tests/utils/test_generate.py::TestLogitsFilterTopK::test_min_tokens_to_keep PASSED                                                                                                       [ 53%]
tests/utils/test_generate.py::TestLogitsFilterTopK::test_top_k_invalid PASSED                                                                                                            [ 60%]
tests/utils/test_generate.py::TestLogitsFilterTopK::test_default PASSED                                                                                                                  [ 66%]
tests/utils/test_generate.py::TestLogitsFilterTopK::test_top_k PASSED                                                                                                                    [ 73%]
tests/utils/test_generate.py::TestLogitsFilterTopP::test_min_tokens_to_keep PASSED                                                                                                       [ 80%]
tests/utils/test_generate.py::TestLogitsFilterTopP::test_top_p_invalid PASSED                                                                                                            [ 86%]
tests/utils/test_generate.py::TestLogitsFilterTopP::test_default PASSED                                                                                                                  [ 93%]
tests/utils/test_generate.py::TestLogitsFilterTopP::test_top_p PASSED                                                                                                                    [100%]

```
