### PR TITLE
[FLAVA] Upgrading datasets version to fix feature TypeError issue

### DIFF
--- a/examples/flava/requirements.txt
+++ b/examples/flava/requirements.txt
@@ -1,6 +1,6 @@
 Pillow==9.3.0
 pytorch-lightning==1.8.6
-datasets==2.6.1
+datasets==2.9.0
 requests==2.27.1
 DALL-E==0.1
 omegaconf==2.1.2


### PR DESCRIPTION
Summary:
Upgrading datasets version from 2.6.1 to 2.9.0 for FLAVA example.

Test plan:
`python -m flava.train config=flava/configs/pretraining/debug.yaml training.lightning.accelerator=cpu training.lightning.gpus=0 training.lightning.strategy=null`
