### PR TITLE
[FLAVA] Fix for DDP with active checkpointing

### DIFF
--- a/examples/flava/native/train.py
+++ b/examples/flava/native/train.py
@@ -146,15 +146,19 @@ class Trainer:
 
         if self.config.training.activation_checkpointing:
             check_fn = lambda submodule: isinstance(submodule, TransformerEncoderLayer)
+            checkpoint_impl = CheckpointImpl.REENTRANT
 
-            non_reentrant_wrapper = partial(
+            if strategy == "ddp":
+                checkpoint_impl = CheckpointImpl.NO_REENTRANT
+
+            checkpoint_wrapper_fn = partial(
                 checkpoint_wrapper,
                 offload_to_cpu=False,
-                checkpoint_impl=CheckpointImpl.REENTRANT,
+                checkpoint_impl=checkpoint_impl,
             )
             apply_activation_checkpointing(
                 model,
-                checkpoint_wrapper_fn=non_reentrant_wrapper,
+                checkpoint_wrapper_fn=checkpoint_wrapper_fn,
                 check_fn=check_fn,
             )
 

--- a/examples/flava/native/train.py
+++ b/examples/flava/native/train.py
@@ -148,6 +148,7 @@ class Trainer:
             check_fn = lambda submodule: isinstance(submodule, TransformerEncoderLayer)
             checkpoint_impl = CheckpointImpl.REENTRANT
 
+            # DDP gradient hooks have compatibility issues with REENTRANT autograd
             if strategy == "ddp":
                 checkpoint_impl = CheckpointImpl.NO_REENTRANT
 


### PR DESCRIPTION
Summary:
Fix for using DDP with active checkpointing. Have to change to NO_REENTRANT.

Test plan:
`NUM_GPUS=8; torchrun --nproc_per_node=$NUM_GPUS -m flava.native.train config=flava/native/configs/pretrain_debug.yaml `

Confirmed to work with DDP + AC and FSDP + AC.

Fixes #404 
