### PR TITLE
Replace nn.GroupNorm with Fp32GroupNorm for mixed precision training

### DIFF
--- a/tests/modules/layers/test_normalizations.py
+++ b/tests/modules/layers/test_normalizations.py
@@ -5,11 +5,18 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
+from torchmultimodal.modules.layers.normalizations import Fp32GroupNorm, Fp32LayerNorm
 
 
 def test_fp32layernorm():
     x = torch.ones(1, 1, dtype=torch.float16)
     norm = Fp32LayerNorm(1)
+    output = norm(x)
+    assert output.dtype == torch.float16
+
+
+def test_fp32groupnorm():
+    x = torch.ones(2, 4, dtype=torch.float16)
+    norm = Fp32GroupNorm(2, 4)
     output = norm(x)
     assert output.dtype == torch.float16

--- a/torchmultimodal/modules/layers/normalizations.py
+++ b/torchmultimodal/modules/layers/normalizations.py
@@ -22,3 +22,26 @@ class Fp32LayerNorm(nn.LayerNorm):
             self.eps,
         )
         return output.type_as(x)
+
+
+class Fp32GroupNorm(nn.GroupNorm):
+    """
+    GroupNorm that supports mixed-precision / fp16 training by performing normalization
+    in fp32 and converting back.
+
+    Code ref:
+    https://github.com/facebookresearch/fairseq/blob/0338cdc3094ca7d29ff4d36d64791f7b4e4b5e6e/fairseq/modules/fp32_group_norm.py#L13
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+    def forward(self, x: Tensor) -> Tensor:
+        output = nn.functional.group_norm(
+            x.float(),
+            self.num_groups,
+            self.weight.float() if self.weight is not None else None,
+            self.bias.float() if self.bias is not None else None,
+            self.eps,
+        )
+        return output.type_as(x)


### PR DESCRIPTION
Summary: To support mixed-precision / fp16 training, replaced all GroupNorm layers with Fp32GroupNorm, transferred from [fairseq](https://github.com/facebookresearch/fairseq/blob/0338cdc3094ca7d29ff4d36d64791f7b4e4b5e6e/fairseq/modules/fp32_group_norm.py#L13). This ensure normalization in fp32, even if input is fp16.

Reviewed By: kartikayk

Differential Revision: D43581790

