### PR TITLE
Add multihead self attn to use sdpa from core

### DIFF
--- a/tests/modules/layers/test_multi_head_attention.py
+++ b/tests/modules/layers/test_multi_head_attention.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from tests.test_utils import assert_expected
+from torch import nn
+from torchmultimodal.modules.layers.multi_head_attention import MultiHeadSelfAttention
+
+
+class TestMultiHeadSelfAttention:
+    @pytest.fixture
+    def embed_dim(self):
+        return 4
+
+    @pytest.fixture
+    def multi_head_self_attn(self, embed_dim):
+        mhsa = MultiHeadSelfAttention(embed_dim, num_heads=2)
+        mhsa.input_proj.weight = nn.Parameter(torch.ones(3 * embed_dim, embed_dim))
+        mhsa.input_proj.bias = nn.Parameter(torch.ones(3 * embed_dim))
+        mhsa.output_proj.weight = nn.Parameter(torch.ones(embed_dim, embed_dim))
+        mhsa.output_proj.bias = nn.Parameter(torch.ones(embed_dim))
+        mhsa.eval()
+        return mhsa
+
+    def test_multi_head_self_attention(
+        self,
+        embed_dim,
+        multi_head_self_attn,
+    ):
+        q = torch.Tensor([[[1, 2, 3, 1], [4, 3, 2, 1], [1, 1, 1, 1]]])
+        actual = multi_head_self_attn(q)
+        expected = torch.tensor(
+            [
+                [
+                    [45.0, 45.0, 45.0, 45.0],
+                    [45.0, 45.0, 45.0, 45.0],
+                    [45.0, 45.0, 45.0, 45.0],
+                ]
+            ]
+        )
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_scripting(
+        self,
+        embed_dim,
+        multi_head_self_attn,
+    ):
+        q = torch.Tensor([[[1, 2, 3, 1], [4, 3, 2, 1], [1, 1, 1, 1]]])
+        scripted_model = torch.jit.script(multi_head_self_attn)
+        assert_expected(scripted_model(q), multi_head_self_attn(q), rtol=0, atol=1e-4)

--- a/torchmultimodal/modules/layers/multi_head_attention.py
+++ b/torchmultimodal/modules/layers/multi_head_attention.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch.nn.functional as F
+from torch import nn, Tensor
+
+
+class MultiHeadSelfAttention(nn.Module):
+    """
+    Multihead self attention.
+    Similar to the self attention variant of MHA in attention.py but uses the scaled_dot_product_attention from PyTorch
+    (which uses flash or memory efficient version for certain conditions).
+    TODO: merge this into attention.py once other models are ready to use it.
+
+    Args:
+        embed_dim (int): embedding dimension of the input
+        num_heads (int): number of attn heads
+        dropout (float): dropout rate
+    """
+
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float = 0.0):
+        super().__init__()
+        self.input_proj = nn.Linear(embed_dim, 3 * embed_dim)
+        self.output_proj = nn.Linear(embed_dim, embed_dim)
+        self.num_heads = num_heads
+        self.dropout = dropout
+
+    def forward(
+        self,
+        query: Tensor,
+        attn_mask: Optional[Tensor] = None,
+        is_causal: bool = False,
+    ) -> Tensor:
+        """
+        Args:
+            query (Tensor): input query of shape bsz x seq_len x embed_dim
+            attn_mask (optional Tensor): attention mask of shape bsz x seq_len x seq_len. Two types of masks are supported.
+            A boolean mask where a value of True indicates that the element should take part in attention.
+            A float mask of the same type as query that is added to the attention score.
+            is_causal (bool): If true, does causal attention masking. attn_mask should be set to None if this is set to True
+
+        Returns:
+            attention output Tensor of shape bsz x seq_len x embed_dim
+        """
+
+        bsz = query.size(0)
+        embed_dim = query.size(-1)
+        projected_query = self.input_proj(query)
+        query, key, value = projected_query.chunk(3, dim=-1)
+
+        head_dim = embed_dim // self.num_heads
+        # bsz x seq len x embed_dim => bsz x num_heads x seq len x head_dim
+        query = query.view(bsz, -1, self.num_heads, head_dim).transpose(1, 2)
+        key = key.view(bsz, -1, self.num_heads, head_dim).transpose(1, 2)
+        value = value.view(bsz, -1, self.num_heads, head_dim).transpose(1, 2)
+
+        attn = F.scaled_dot_product_attention(
+            query, key, value, attn_mask, self.dropout, is_causal
+        )
+        attn = attn.transpose(1, 2).reshape(bsz, -1, embed_dim)
+
+        attn_out = self.output_proj(attn)
+        return attn_out


### PR DESCRIPTION
Summary: Adding a multihead self attention that calls the spda from core so we can leverage the flash / memory efficient kernel (and also get a scriptable version)

Differential Revision: D43821987

