### PR TITLE
Pin mypy version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ black==22.3.0
 flake8-bugbear==22.4.25
 flake8==4.0.1
 iopath
-mypy
+mypy==1.0.1
 pep8-naming==0.12.1
 pre-commit
 pytest


### PR DESCRIPTION
Summary:
mypy upgrade started throwing weird error https://github.com/facebookresearch/multimodal/actions/runs/4358793404/jobs/7619815550
hence, pinning the version

Test plan:
type checking passed on the CI run on this diff

