### PR TITLE
Remove collation when doing clip transform on single input

### DIFF
--- a/tests/transforms/test_clip_transform.py
+++ b/tests/transforms/test_clip_transform.py
@@ -85,10 +85,10 @@ class TestCLIPTransform:
         transformed_image, transformed_text = clip_transform(image=image1, text=text1)
 
         actual_image_size = transformed_image.size()
-        expected_image_size = torch.Size([1, 3, 224, 224])
+        expected_image_size = torch.Size([3, 224, 224])
         assert_expected(actual_image_size, expected_image_size)
 
-        actual_text = transformed_text[0]
+        actual_text = transformed_text
         text1_token_len = len(text1_tokens)
         expected_text = torch.tensor(
             text1_tokens + [0] * (context_length - text1_token_len),

--- a/torchmultimodal/transforms/clip_transform.py
+++ b/torchmultimodal/transforms/clip_transform.py
@@ -15,6 +15,7 @@ from torchtext.transforms import CLIPTokenizer
 from torchvision import transforms as image_transforms
 from torchvision.transforms import InterpolationMode
 
+
 CLIP_DEFAULT_MEAN = (0.48145466, 0.4578275, 0.40821073)
 CLIP_DEFAULT_STD = (0.26862954, 0.26130258, 0.27577711)
 CLIP_DEFAULT_VOCAB_BPE_PATH = "http://download.pytorch.org/models/text/clip_merges.bpe"
@@ -74,11 +75,7 @@ class CLIPTextTransform(nn.Module):
         )
 
     def forward(self, text: Union[List[str], str]) -> Tensor:
-        if isinstance(text, str):
-            text_input = [text]
-        else:
-            text_input = text
-        text_result = self.text_transform(text_input)
+        text_result = self.text_transform(text)
         assert torch.jit.isinstance(text_result, Tensor)
         return text_result
 
@@ -132,7 +129,7 @@ class CLIPImageTransform(nn.Module):
 
     def forward(self, image: Union[List[Image], Image]) -> Tensor:
         if isinstance(image, Image):
-            image = [image]
+            return self.image_transform(image)
         image_result = torch.stack([self.image_transform(x) for x in image])
         return image_result
 


### PR DESCRIPTION
Summary:
When transform is set on the dataset, default collation takes care of stacking. So transform should not do the stacking for single sample cases else the default collation adds extra dimension on the batch. 

See repro comparing the torchvision transform with clip image transform https://colab.research.google.com/drive/1AR7tDznQS7-rWHpxfZWofQp-sUBdOG36#scrollTo=nV7kSvn9K4Sn

Test plan:
Fixed the tests themselves to expect the correct shapes
pytest tests


