### PR TITLE
fix nightly by adding workflow deps

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -47,6 +47,8 @@ jobs:
           python -m pip install --pre torch torchvision torchtext --extra-index-url \
             https://download.pytorch.org/whl/nightly/cpu
           python -m pip install -r requirements.txt
+      - name: Install other dependencies
+        run: python -m pip install attrs
       - name: Test installation of dependencies
         run: |
           python -c "import torch"


### PR DESCRIPTION
Summary:
Update deps to fix broken nightly build

Test plan:
manually trigger workflow to run all the tests

Fixes #{issue number}
nightly build failures
