### PR TITLE
add loggings for internal adoption tracking

### DIFF
--- a/torchmultimodal/modules/layers/mlp.py
+++ b/torchmultimodal/modules/layers/mlp.py
@@ -42,7 +42,7 @@ class MLP(nn.Module):
         normalization: Optional[Callable[..., nn.Module]] = None,
     ) -> None:
         super().__init__()
-
+        torch._C._log_api_usage_once(f"torchmultimodal.{self.__class__.__name__}")
         layers = nn.ModuleList()
 
         if hidden_dims is None:

--- a/torchmultimodal/modules/losses/contrastive_loss_with_temperature.py
+++ b/torchmultimodal/modules/losses/contrastive_loss_with_temperature.py
@@ -165,6 +165,7 @@ class ContrastiveLossWithTemperature(nn.Module):
         logit_scale_max: Optional[float] = math.log(100),
     ):
         super().__init__()
+        torch._C._log_api_usage_once(f"torchmultimodal.{self.__class__.__name__}")
 
         if not logit_scale_min and not logit_scale_max:
             raise ValueError(


### PR DESCRIPTION
Summary:
add adoption loggings for models with most internal usage. To avoid duplicated count, we only enable loggings for model entrypoints.
This diff includes: vision transformer, MLP, av_concat_fusion, contrastive loss and transformer fusion. CLIP logging has been enabled previously.

Reviewed By: ankitade

Differential Revision: D45532797

