### PR TITLE
Move Dalle2 + Diffusion Components to OSS

### DIFF
--- a/tests/models/dalle2/test_adm.py
+++ b/tests/models/dalle2/test_adm.py
@@ -1,0 +1,188 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+import pytest
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torch import nn
+from torchmultimodal.models.dalle2.adm.adm import ADM, ADMStack, ADMUNet
+from torchmultimodal.models.dalle2.adm.attention_block import ADMAttentionBlock
+from torchmultimodal.models.dalle2.adm.res_block import ADMResBlock
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(4)
+
+
+@pytest.fixture
+def params():
+    in_channels = 3
+    s = 4
+    embed_dim = 6
+    return in_channels, s, embed_dim
+
+
+@pytest.fixture
+def x(params):
+    in_ch, s, _ = params
+    out = torch.randn((1, in_ch, s, s), dtype=torch.float32)
+    return out
+
+
+@pytest.fixture
+def t(params):
+    time_dim = params[-1]
+    return torch.randn((1, time_dim), dtype=torch.float32)
+
+
+@pytest.fixture
+def c(params):
+    in_ch, _, embed_dim = params
+    return torch.randn((1, in_ch, embed_dim), dtype=torch.float32)
+
+
+class TestADM:
+    @pytest.fixture
+    def cond(self, params):
+        embed_dim = params[-1]
+        c = torch.ones(1, embed_dim)
+        return {"test": c}
+
+    @pytest.fixture
+    def timestep(self):
+        return torch.ones(1)
+
+    @pytest.fixture
+    def time_encoder(self, params):
+        embed_dim = params[-1]
+
+        class DummyTime(nn.Module):
+            def forward(self, x):
+                x = torch.tensor(x)
+                return x.repeat(embed_dim).unsqueeze(0)
+
+        return DummyTime()
+
+    @pytest.fixture
+    def unet(self):
+        class DummyUNet(nn.Module):
+            def forward(self, x, t, c):
+                return x + t + c
+
+        return DummyUNet()
+
+    @pytest.fixture
+    def model(self, unet, time_encoder):
+        cond_proj = {"test": nn.Identity()}
+        return partial(ADM, unet, time_encoder, cond_proj, cond_proj)
+
+    def test_get_conditional_projections(self, model, params, timestep, cond):
+        embed_dim = params[-1]
+        adm = model(predict_variance_value=False)
+        actual_res, actual_attn = adm._get_conditional_projections(timestep, cond)
+        expected_res = 2 * torch.ones(1, embed_dim)
+        expected_attn = torch.ones(1, 1, embed_dim)
+        assert_expected(actual_res, expected_res)
+        assert_expected(actual_attn, expected_attn)
+
+    def test_forward(self, model, params, timestep, cond):
+        embed_dim = params[-1]
+        x = torch.ones(1, embed_dim)
+        adm = model(predict_variance_value=False)
+        actual = adm(x, timestep, cond)
+        expected = 4 * torch.ones(1, embed_dim)
+        assert_expected(actual.prediction, expected.unsqueeze(1))
+
+    def test_cond_proj_incorrect_embed_dim(self, model, timestep, cond):
+        cond["test"] = cond["test"][:, :-1]
+        adm = model(predict_variance_value=False)
+        with pytest.raises(ValueError):
+            _ = adm._get_conditional_projections(timestep, cond)
+
+    def test_predict_variance_value_incorrect_channel_dim_error(
+        self, model, params, timestep, cond
+    ):
+        embed_dim = params[-1]
+        x = torch.ones(1, embed_dim)
+        adm = model(predict_variance_value=True)
+        with pytest.raises(ValueError):
+            _ = adm(x, timestep, cond)
+
+
+# All expected values come after first testing the ADMUNet has the exact output
+# as the corresponding UNet class in d2go, then simply forward passing
+# ADMUNet with params, random seed, and initialization order in this file.
+class TestADMUNet:
+    @pytest.fixture
+    def model(self, params):
+        in_dim, _, time_dim = params
+        net = ADMUNet(
+            channels_per_layer=[32, 32],
+            num_resize=1,
+            num_res_per_layer=2,
+            use_attention_for_layer=[True, True],
+            dim_res_cond=time_dim,
+            dim_attn_cond=time_dim,
+            in_channels=in_dim,
+            out_channels=in_dim,
+        )
+        net.eval()
+        return net
+
+    def test_forward(self, model, x, t, c):
+        actual = model(x, t, c)
+        expected = torch.tensor(2.3899)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+        assert_expected(actual.shape, x.shape)
+
+    def test_less_channels_attention_error(self, params):
+        in_dim, _, time_dim = params
+        with pytest.raises(ValueError):
+            _ = ADMUNet(
+                channels_per_layer=[32, 32],
+                num_resize=1,
+                num_res_per_layer=2,
+                use_attention_for_layer=[True],
+                dim_res_cond=time_dim,
+                dim_attn_cond=time_dim,
+                in_channels=in_dim,
+                out_channels=in_dim,
+            )
+
+    def test_less_channels_resize_error(self, params):
+        in_dim, _, time_dim = params
+        with pytest.raises(ValueError):
+            _ = ADMUNet(
+                channels_per_layer=[32, 32],
+                num_resize=3,
+                num_res_per_layer=2,
+                use_attention_for_layer=[True, True],
+                dim_res_cond=time_dim,
+                dim_attn_cond=time_dim,
+                in_channels=in_dim,
+                out_channels=in_dim,
+            )
+
+
+class TestADMStack:
+    @pytest.fixture
+    def model(self, params):
+        in_dim, _, time_dim = params
+        stack = ADMStack()
+        stack.append(ADMResBlock(in_dim, in_dim, time_dim, norm_groups=in_dim))
+        stack.append(ADMAttentionBlock(in_dim, time_dim, norm_groups=in_dim))
+        # To use the else statement in ADMStack
+        stack.append(nn.Identity())
+        return stack
+
+    def test_forward(self, model, x, t, c):
+        actual = model(x, t, c)
+        expected = torch.tensor(-11.8541)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+        assert_expected(actual.shape, x.shape)

--- a/tests/models/dalle2/test_adm_blocks.py
+++ b/tests/models/dalle2/test_adm_blocks.py
@@ -1,0 +1,153 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+import pytest
+
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.models.dalle2.adm.attention_block import ADMAttentionBlock
+from torchmultimodal.models.dalle2.adm.res_block import (
+    adm_res_block,
+    adm_res_downsample_block,
+    adm_res_upsample_block,
+    ADMResBlock,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(4)
+
+
+@pytest.fixture
+def params():
+    in_dim = 32  # in and out dim must be divisible by 32 because of GroupNorm
+    out_dim = 32
+    time_dim = 2
+    kernel = 6
+    return in_dim, out_dim, time_dim, kernel
+
+
+@pytest.fixture
+def x(params):
+    in_dim, _, _, kernel = params
+    out = torch.randn((1, in_dim, kernel, kernel), dtype=torch.float32)
+    return out
+
+
+@pytest.fixture
+def t(params):
+    time_dim = params[2]
+    return torch.ones((1, time_dim), dtype=torch.float32)
+
+
+# All expected values come after first testing the ADMResBlock has the exact output
+# as the corresponding residual block class in d2go, then simply forward passing
+# ADMResBlock with params, random seed, and initialization order in this file.
+class TestADMResBlock:
+    @pytest.fixture
+    def block(self, params):
+        in_dim, out_dim, time_dim, _ = params
+        return partial(ADMResBlock, in_dim, out_dim, time_dim)
+
+    def test_forward(self, block, x, t):
+        res = block()
+        actual = res(x, t)
+        expected = torch.tensor(-193.9132)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_forward_no_scale_shift(self, block, x, t):
+        res = block(scale_shift_conditional=False)
+        actual = res(x, t)
+        expected = torch.tensor(-96.7350)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_forward_rescale_skip(self, block, x, t):
+        res = block(rescale_skip_connection=True)
+        actual = res(x, t)
+        expected = torch.tensor(-137.1381)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_channel_mismatch_error(self):
+        with pytest.raises(ValueError):
+            _ = ADMResBlock(1, 2, 3)
+
+    def test_channel_indivisible_norm_group_error(self):
+        with pytest.raises(ValueError):
+            _ = ADMResBlock(2, 2, 3)
+
+    def test_both_updownsample_error(self, block):
+        with pytest.raises(ValueError):
+            _ = block(use_upsample=True, use_downsample=True)
+
+
+class TestADMAttentionBlock:
+    @pytest.fixture
+    def xattn_dim(self):
+        return 48
+
+    @pytest.fixture
+    def cond(self, xattn_dim):
+        return torch.ones((1, 4, xattn_dim), dtype=torch.float32)
+
+    @pytest.fixture
+    def block(self, params, xattn_dim):
+        in_dim = params[0]
+        return partial(ADMAttentionBlock, in_dim, xattn_dim, 1)
+
+    def test_forward(self, block, x, cond):
+        attn = block()
+        actual = attn(x, cond)
+        expected = torch.tensor(-53.3069)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_forward_rescale_skip(self, block, x, cond):
+        attn = block(rescale_skip_connection=True)
+        actual = attn(x, cond)
+        expected = torch.tensor(-37.6994)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_channel_indivisible_norm_group_error(self):
+        with pytest.raises(ValueError):
+            _ = ADMAttentionBlock(2)
+
+
+def test_adm_res_block(params, x, t):
+    in_dim, out_dim, time_dim, _ = params
+    res = adm_res_block(in_dim, out_dim, time_dim)
+    actual = res(x, t)
+    expected = torch.tensor(-193.9132)
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+
+def test_adm_res_upsample_block(params, x, t):
+    in_dim, _, time_dim, kernel = params
+    res = adm_res_upsample_block(in_dim, time_dim)
+    actual = res(x, t)
+    expected = torch.tensor(-761.6157)
+    expected_shape = torch.Size([1, in_dim, kernel * 2, kernel * 2])
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+    assert_expected(actual.shape, expected_shape)
+
+
+def test_adm_res_downsample_block(params, x, t):
+    in_dim, _, time_dim, kernel = params
+    res = adm_res_downsample_block(in_dim, time_dim)
+    actual = res(x, t)
+    expected = torch.tensor(-36.9527)
+    expected_shape = torch.Size([1, in_dim, kernel // 2, kernel // 2])
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+    assert_expected(actual.shape, expected_shape)
+
+
+def test_adm_res_skipconv_block(params, x, t):
+    in_dim, out_dim, time_dim, kernel = params
+    res = adm_res_block(in_dim, out_dim * 2, time_dim)
+    actual = res(x, t)
+    expected = torch.tensor(-43.1194)
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)

--- a/tests/models/dalle2/test_adm_crossattention.py
+++ b/tests/models/dalle2/test_adm_crossattention.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.models.dalle2.adm.attention_block import (
+    adm_attention,
+    ADMCrossAttention,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(4)
+
+
+@pytest.fixture
+def params():
+    embed_dim = 32  # in and out dim must be divisible by 32 because of GroupNorm
+    cond_dim = 48
+    n_head = 2
+    kernel = 2
+    return embed_dim, cond_dim, n_head, kernel
+
+
+@pytest.fixture
+def x(params):
+    embed_dim, _, n_head, kernel = params
+    out = torch.randn(
+        (1, n_head, kernel, kernel, embed_dim // n_head), dtype=torch.float32
+    )
+    return out
+
+
+@pytest.fixture
+def c(params):
+    cond_dim = params[1]
+    return torch.ones((1, 4, cond_dim), dtype=torch.float32)
+
+
+# All expected values come after first testing that ADMCrossAttention has
+# the exact output as the corresponding QKVAttention class in d2go, then simply forward passing
+# ADMCrossAttention with params, random seed, and initialization order in this file.
+class TestADMCrossAttention:
+    @pytest.fixture
+    def attn(self, params):
+        embed_dim, cond_dim, *_ = params
+        return ADMCrossAttention(dim_qkv=embed_dim, dim_cond=cond_dim)
+
+    def test_forward(self, attn, x, c):
+        actual = attn(x, x, x, c)
+        expected = torch.tensor(-18.1184)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_head_indivisible_error(self, attn, x):
+        x_ = torch.cat([x, x[:, :1, :, :, :]], dim=1)
+        with pytest.raises(ValueError):
+            _ = attn(x_, x_, x_)
+
+    def test_embedding_dim_error(self, attn, x):
+        x_ = x[:, :, :, :, :-1]
+        with pytest.raises(ValueError):
+            _ = attn(x_, x_, x_)
+
+
+def test_adm_attention(params, x, c):
+    embed_dim, cond_dim, n_head, _ = params
+    attn = adm_attention(
+        num_channels=embed_dim,
+        dim_cond=cond_dim,
+        num_heads=n_head,
+    )
+    x = x.permute(0, 2, 3, 4, 1).flatten(start_dim=-2, end_dim=-1)
+    actual = attn(x, conditional_embedding=c)
+    expected = torch.tensor(3.6252)
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)

--- a/tests/modules/diffusion/test_cfguidance.py
+++ b/tests/modules/diffusion/test_cfguidance.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torch import nn
+from torchmultimodal.modules.diffusion.cfguidance import CFGuidance
+from torchmultimodal.utils.diffusion_utils import DiffusionOutput
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(4)
+
+
+@pytest.fixture
+def params():
+    in_channels = 3
+    s = 4
+    embed_dim = 6
+    return in_channels, s, embed_dim
+
+
+class DummyADM(nn.Module):
+    def __init__(self, variance_flag=False):
+        super().__init__()
+        self.variance_flag = variance_flag
+
+    def forward(self, x, t, c):
+        c_sum = 0
+        count = 0
+        for i, (k, v) in enumerate(c.items()):
+            c_sum += v
+            count += 1
+
+        prediction = x + t[..., None, None] + c_sum[..., None, None] + count
+        if self.variance_flag:
+            variance_value = x
+        else:
+            variance_value = None
+        return DiffusionOutput(prediction=prediction, variance_value=variance_value)
+
+
+class TestCFGuidance:
+    @pytest.fixture
+    def cond(self, params):
+        embed_dim = params[-1]
+        c = torch.ones(1, embed_dim)
+        return {"test": c}
+
+    @pytest.fixture
+    def dim_cond(self, cond):
+        return {k: v.shape[-1] for k, v in cond.items()}
+
+    @pytest.fixture
+    def models(self):
+        return {"mean": DummyADM(False), "mean_variance": DummyADM(True)}
+
+    @pytest.fixture
+    def cfguidance_models(self, models, dim_cond):
+        return {
+            k: CFGuidance(model, dim_cond, p=0, guidance=2, learn_null_emb=False)
+            for k, model in models.items()
+        }
+
+    def test_training_forward(self, cfguidance_models, params, cond):
+        embed_dim = params[-1]
+        x = torch.ones(1, embed_dim, params[1], params[1])
+        t = torch.ones(1, 1)
+        for k, cfguidance_model in cfguidance_models.items():
+            actual = cfguidance_model(x, t, cond)
+            if k == "mean":  # if adm model returns only prediction
+                expected = 4 * torch.ones(1, embed_dim, params[1], params[1])
+                assert_expected(actual.prediction, expected)
+                assert_expected(actual.variance_value, None)
+            elif (
+                k == "mean_variance"
+            ):  # if adm model returns both prediction and variance
+                expected_prediction = 4 * torch.ones(1, embed_dim, params[1], params[1])
+                expected_variance = torch.ones(1, embed_dim, params[1], params[1])
+                assert_expected(actual.prediction, expected_prediction)
+                assert_expected(actual.variance_value, expected_variance)
+
+    def test_inference_forward(self, cfguidance_models, params, cond):
+        embed_dim = params[-1]
+        x = torch.ones(1, embed_dim, params[1], params[1])
+        t = torch.ones(1, 1)
+
+        for k, cfguidance_model in cfguidance_models.items():
+            cfguidance_model.eval()
+            actual = cfguidance_model(x, t, cond)
+            if k == "mean":  # if adm model returns only prediction
+                expected_prediction = 6 * torch.ones(1, embed_dim, params[1], params[1])
+                assert_expected(actual.prediction, expected_prediction)
+                assert_expected(actual.variance_value, None)
+            elif (
+                k == "mean_variance"
+            ):  # if adm model returns both prediction and variance
+                expected_prediction = 6 * torch.ones(1, embed_dim, params[1], params[1])
+                expected_variance = torch.ones(1, embed_dim, params[1], params[1])
+                assert_expected(actual.prediction, expected_prediction)
+                assert_expected(actual.variance_value, expected_variance)
+
+    def test_get_prob_dict(self, cfguidance_models):
+        cfguidance_model = cfguidance_models["mean"]
+        actual = cfguidance_model._get_prob_dict(0.1)
+        expected = {"test": 0.1}
+        assert_expected(actual, expected)
+
+        actual = cfguidance_model._get_prob_dict({"test": 0.1})
+        expected = {"test": 0.1}
+        assert_expected(actual, expected)
+
+        with pytest.raises(ValueError):
+            actual = cfguidance_model._get_prob_dict({"test_2": 0.1, "test": 0.1})
+
+        with pytest.raises(TypeError):
+            actual = cfguidance_model._get_prob_dict("test")

--- a/tests/modules/diffusion/test_ddim.py
+++ b/tests/modules/diffusion/test_ddim.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn as nn
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.diffusion.ddim import DDIModule
+from torchmultimodal.modules.diffusion.predictors import NoisePredictor
+from torchmultimodal.modules.diffusion.schedules import (
+    DiffusionSchedule,
+    linear_beta_schedule,
+)
+from torchmultimodal.utils.diffusion_utils import DiffusionOutput
+
+
+class DummyUNet(nn.Module):
+    def __init__(self, learn_variance=True):
+        super().__init__()
+        self.learn_variance = learn_variance
+        self.net = nn.Conv2d(3, 6, 3, 1, padding=1)
+
+    def forward(self, x, t, c):
+        x = self.net(x)
+        return DiffusionOutput(prediction=x.chunk(2, dim=1)[0])
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(4)
+
+
+class TestDDIModule:
+    @pytest.fixture
+    def module(self):
+        model = DummyUNet(True)
+        schedule = DiffusionSchedule(linear_beta_schedule(1000))
+        predictor = NoisePredictor(schedule)
+        model = DDIModule(model, schedule, predictor)
+        return model
+
+    @pytest.fixture
+    def input(self):
+        data = {}
+        data["prediction"] = torch.randn(2, 3, 4, 4)
+        data["xt"] = torch.randn(2, 3, 4, 4)
+        data["t"] = torch.randint(0, 1000, (2,), dtype=torch.long)
+        data["cur_step"] = 9 * torch.ones(data["xt"].size(0), dtype=torch.long)
+        data["next_step"] = 8 * torch.ones(data["xt"].size(0), dtype=torch.long)
+        return data
+
+    def test_remove_noise(self, module, input):
+        set_rng_seed(4)
+        xt = input["xt"]
+        with torch.no_grad():
+            actual = (
+                module.remove_noise(xt, None, input["cur_step"], input["next_step"])
+                .mean()
+                .item()
+            )
+
+        expected = -0.1227
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_generator(self, module, input):
+        set_rng_seed(4)
+        xt = input["xt"]
+        with torch.no_grad():
+            gen = module.generator(xt)
+            for i in range(10):
+                actual = next(gen)
+        expected = -0.1958
+        assert_expected(actual.mean().item(), expected, rtol=0, atol=1e-4)

--- a/tests/modules/diffusion/test_ddpm.py
+++ b/tests/modules/diffusion/test_ddpm.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.diffusion.ddpm import DDPModule
+from torchmultimodal.modules.diffusion.predictors import NoisePredictor
+from torchmultimodal.modules.diffusion.schedules import (
+    DiffusionSchedule,
+    linear_beta_schedule,
+)
+from torchmultimodal.utils.diffusion_utils import DiffusionOutput
+
+
+class DummyUNet(nn.Module):
+    def __init__(self, learn_variance=True):
+        super().__init__()
+        self.learn_variance = learn_variance
+        channels = 6 if learn_variance else 3
+        self.net = nn.Conv2d(3, channels, 3, 1, padding=1)
+
+    def forward(self, x, t, c):
+        x = F.tanh(self.net(x))
+        var_value = None
+        if self.learn_variance:
+            x, var_value = x.chunk(2, dim=1)
+            var_value = (var_value + 1) / 2
+        return DiffusionOutput(prediction=x, variance_value=var_value)
+
+
+# All expected values come after first testing the Schedule has the exact output
+# as the corresponding p methods from GaussianDiffusion in D2Go
+class TestDDPModule:
+    @pytest.fixture
+    def module(self):
+        set_rng_seed(4)
+        model = DummyUNet(True)
+        schedule = DiffusionSchedule(linear_beta_schedule(1000))
+        predictor = NoisePredictor(schedule)
+        eval_steps = torch.arange(0, 1000, 50)
+        model = DDPModule(model, schedule, predictor, eval_steps)
+        return model
+
+    @pytest.fixture
+    def input(self):
+        set_rng_seed(4)
+        sample = {}
+        sample["prediction"] = torch.randn(2, 3, 4, 4)
+        sample["xt"] = torch.randn(2, 3, 4, 4)
+        sample["t"] = torch.randint(0, 1000, (2,), dtype=torch.long)
+        return sample
+
+    def test_predict_parameters(self, module, input):
+        inp = DiffusionOutput(prediction=input["prediction"])
+        xt, t = input["xt"], input["t"]
+        actual_mean, actual_log_var = module.predict_parameters(inp, xt, t)
+        expected_mean, expected_log_var = torch.tensor(-0.1970), torch.tensor(-5.3342)
+        assert_expected(actual_mean.mean(), expected_mean, rtol=0, atol=1e-4)
+        assert_expected(actual_log_var.mean(), expected_log_var, rtol=0, atol=1e-4)
+
+    def test_remove_noise(self, module, input):
+        set_rng_seed(4)
+        xt, t = input["xt"], input["t"]
+        with torch.no_grad():
+            actual = module.remove_noise(xt, t, None).mean()
+        expected = torch.tensor(-0.1876)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_generator(self, module, input):
+        set_rng_seed(4)
+        xt = input["xt"]
+        module.eval()
+        with torch.no_grad():
+            gen = module.generator(xt)
+            for actual in gen:
+                pass
+        expected = torch.tensor(-20.1526)
+        assert_expected(actual.mean(), expected, rtol=0, atol=1e-4)
+
+    def test_forward(self, module, input):
+        xt, t = input["xt"], input["t"]
+        module.train()
+        with torch.no_grad():
+            actual = module(xt, t)
+        expected_pred, expected_var_value = torch.tensor(-0.0852), torch.tensor(0.4979)
+        expected_mean, expected_log_var = torch.tensor(-0.1955), torch.tensor(-5.3285)
+        assert_expected(actual.prediction.mean(), expected_pred, rtol=0, atol=1e-4)
+        assert_expected(
+            actual.variance_value.mean(), expected_var_value, rtol=0, atol=1e-4
+        )
+        assert_expected(actual.mean.mean(), expected_mean, rtol=0, atol=1e-4)
+        assert_expected(actual.log_variance.mean(), expected_log_var, rtol=0, atol=1e-4)

--- a/tests/modules/diffusion/test_predictors.py
+++ b/tests/modules/diffusion/test_predictors.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.diffusion.predictors import NoisePredictor, TargetPredictor
+from torchmultimodal.modules.diffusion.schedules import (
+    DiffusionSchedule,
+    linear_beta_schedule,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(4)
+
+
+@pytest.fixture
+def input():
+    data = {}
+    data["prediction"] = torch.randn(2, 3, 4, 4)
+    data["xt"] = torch.randn(2, 3, 4, 4)
+    data["t"] = torch.randint(0, 1000, (2,), dtype=torch.long)
+    return data
+
+
+# All expected values come after first testing the Schedule has the exact output
+# as the corresponding q methods from GaussianDiffusion in D2Go
+class TestNoisePredictor:
+    @pytest.fixture
+    def module(self):
+        schedule = DiffusionSchedule(linear_beta_schedule(1000))
+        predictor = NoisePredictor(schedule, None)
+        return predictor
+
+    def test_predict_x0(self, module, input):
+        actual = module.predict_x0(**input).mean()
+        expected = torch.tensor(-1.9352)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_predict_noise(self, module, input):
+        actual = module.predict_noise(**input).mean()
+        expected = torch.tensor(0.0411)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+
+class TestTargetPredictor:
+    @pytest.fixture
+    def module(self):
+        schedule = DiffusionSchedule(linear_beta_schedule(1000))
+        predictor = TargetPredictor(schedule, None)
+        return predictor
+
+    def test_predict_x0(self, module, input):
+        actual = module.predict_x0(**input).mean()
+        expected = torch.tensor(0.0411)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_predict_noise(self, module, input):
+        # TODO: add with DDIM
+        pass

--- a/tests/modules/diffusion/test_schedule.py
+++ b/tests/modules/diffusion/test_schedule.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.diffusion.schedules import (
+    cosine_beta_schedule,
+    DiffusionSchedule,
+    linear_beta_schedule,
+    quadratic_beta_schedule,
+    sigmoid_beta_schedule,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(4)
+
+
+# All expected values come after first testing the Schedule has the exact output
+# as the corresponding q methods from GaussianDiffusion in D2Go
+class TestDiffusionSchedule:
+    @pytest.fixture
+    def module(self):
+        schedule = DiffusionSchedule(linear_beta_schedule(1000))
+        return schedule
+
+    @pytest.fixture
+    def input(self):
+        input = {}
+        input["x0"] = torch.randn(2, 3, 4, 4)
+        input["xt"] = torch.randn(2, 3, 4, 4)
+        input["noise"] = torch.randn(2, 3, 4, 4)
+        input["t"] = torch.randint(0, 1000, (2,), dtype=torch.long)
+        return input
+
+    def test_sample_noise(self, module, input):
+        x = input["x0"]
+        actual = module.sample_noise(x).mean()
+        expected = torch.tensor(-0.0291)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_sample_steps(self, module, input):
+        x = input["x0"]
+        actual = module.sample_steps(x).sum().item()
+        expected = 1806
+        assert actual == expected, "Wrong number of steps"
+
+    def test_q_sample(self, module, input):
+        actual = module.q_sample(input["x0"], input["noise"], input["t"]).mean()
+        expected = torch.tensor(-0.0033)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_q_posterior(self, module, input):
+        actual_mean, actual_log_var = module.q_posterior(
+            input["x0"], input["xt"], input["t"]
+        )
+        expected_mean, expected_log_var = torch.tensor(-0.1944), torch.tensor(-4.6365)
+        assert_expected(actual_mean.mean(), expected_mean, rtol=0, atol=1e-4)
+        assert_expected(actual_log_var.mean(), expected_log_var, rtol=0, atol=1e-4)
+
+    def test_steps(self, module):
+        actual = module.steps
+        expected = 1000
+        assert actual == expected, "Wrong number of steps"
+
+    def test_call(self, module, input):
+        t, shape = input["t"], input["x0"].shape
+        alphas_cumprod = module("alphas_cumprod", t, shape)
+        expected_mean = torch.tensor(0.2016, dtype=torch.float64)
+        expected_shape = (2, 1, 1, 1)
+        assert_expected(alphas_cumprod.mean(), expected_mean, rtol=0, atol=1e-4)
+        assert alphas_cumprod.shape == expected_shape, "Wrong shape"
+
+
+def test_cosine_beta_schedule():
+    actual = cosine_beta_schedule(1000).mean()
+    expected = torch.tensor(0.0124415, dtype=torch.float64)
+    assert_expected(actual, expected, rtol=0, atol=1e-6)
+
+
+def test_linear_beta_schedule():
+    actual = linear_beta_schedule(1000).mean()
+    expected = torch.tensor(0.0100500, dtype=torch.float64)
+    assert_expected(actual, expected, rtol=0, atol=1e-6)
+
+
+def test_quadratic_beta_schedule():
+    actual = quadratic_beta_schedule(1000).mean()
+    expected = torch.tensor(0.0071743, dtype=torch.float64)
+    assert_expected(actual, expected, rtol=0, atol=1e-6)
+
+
+def test_sigmoid_beta_schedule():
+    actual = sigmoid_beta_schedule(1000).mean()
+    expected = torch.tensor(0.0100500, dtype=torch.float64)
+    assert_expected(actual, expected, rtol=0, atol=1e-6)

--- a/tests/modules/layers/test_position_embedding.py
+++ b/tests/modules/layers/test_position_embedding.py
@@ -11,6 +11,7 @@ from tests.test_utils import assert_expected
 from torch import nn
 from torchmultimodal.modules.layers.position_embedding import (
     BroadcastedPositionEmbedding,
+    SinusoidalPositionEmbeddings,
 )
 
 
@@ -96,3 +97,18 @@ class TestBroadcastedPositionEmbedding:
         with pytest.raises(IndexError) as exc_info:
             pos_emb(position_ids=torch.tensor([[0, 6]]))
         assert exc_info.value.args[0] == "Invalid position ids: tensor([6])"
+
+
+class TestSinusoidalPositionEmbeddings:
+    @pytest.fixture
+    def data(self):
+        return torch.Tensor([1, 2, 3])
+
+    @pytest.fixture
+    def emb(self):
+        return SinusoidalPositionEmbeddings(5)
+
+    def test_forward(self, data, emb):
+        actual = emb(data)
+        expected = torch.Size([3, 5])
+        assert_expected(actual.shape, expected)

--- a/tests/modules/losses/test_diffusion_loss.py
+++ b/tests/modules/losses/test_diffusion_loss.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn as nn
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.modules.diffusion.schedules import (
+    DiffusionSchedule,
+    linear_beta_schedule,
+)
+from torchmultimodal.modules.losses.diffusion import DiffusionHybridLoss, VLBLoss
+from torchmultimodal.utils.diffusion_utils import DiffusionOutput
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(4)
+
+
+@pytest.fixture
+def schedule():
+    return DiffusionSchedule(linear_beta_schedule(1000))
+
+
+@pytest.fixture
+def input():
+    outs = [torch.randn(2, 3, 4, 4) for _ in range(4)]
+    return DiffusionOutput(*outs)
+
+
+@pytest.fixture
+def target():
+    target = {}
+    target["x0"] = torch.randn(2, 3, 4, 4)
+    target["xt"] = torch.randn(2, 3, 4, 4)
+    target["noise"] = torch.randn(2, 3, 4, 4)
+    target["t"] = torch.randint(0, 1000, (2,), dtype=torch.long)
+    return target
+
+
+# All expected values come after first testing the HybridLoss has the exact output
+# as the corresponding p_losses in D2Go Guassian Diffusion
+class TestDiffusionHybridLoss:
+    @pytest.fixture
+    def loss(self, schedule):
+        simple = nn.MSELoss()
+        return DiffusionHybridLoss(schedule, simple)
+
+    def test_forward(self, loss, input, target):
+        x0, xt, _, t = target.values()
+        actual = loss(
+            input.prediction, target["noise"], input.mean, input.log_variance, x0, xt, t
+        )
+        expected = torch.tensor(1.9727)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+
+# All expected values come after first testing the HybridLoss has the exact output
+# as the corresponding p_losses in D2Go Guassian Diffusion
+class TestVLBLoss:
+    @pytest.fixture
+    def loss(self, schedule):
+        return VLBLoss(schedule)
+
+    def test_forward(self, loss, input, target):
+        x0, xt, _, t = target.values()
+        actual = loss(input.mean, input.log_variance, x0, xt, t)
+        expected = torch.tensor(3.9603)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_approx_standard_normal_cdf(self, loss, input):
+        x = input.prediction
+        actual = loss.approx_standard_normal_cdf(x).mean()
+        expected = torch.tensor(0.5051)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_discretized_gaussian_log_likelihood(self, loss, input, target):
+        x = target["x0"]
+        mean, log_var = input.mean, input.log_variance
+        actual = loss.discretized_gaussian_log_likelihood(
+            x, mean=mean, log_scale=log_var
+        ).mean()
+        expected = torch.tensor(-8.1964)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    def test_normal_kl(self, loss, input):
+        mean, log_var = input.mean, input.log_variance
+        actual = loss.normal_kl(mean, log_var, mean, log_var).mean()
+        expected = torch.tensor(0.0)
+        assert_expected(actual, expected, rtol=0, atol=1e-4)

--- a/tests/transforms/test_diffusion_transforms.py
+++ b/tests/transforms/test_diffusion_transforms.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from PIL import Image
+from tests.test_utils import assert_expected
+from torchmultimodal.transforms.diffusion_transforms import (
+    Dalle2ImageTransform,
+    RandomDiffusionSteps,
+)
+
+
+class DummySchedule:
+    def sample_steps(self, x):
+        return x
+
+    def sample_noise(self, x):
+        return x
+
+    def q_sample(self, x, noise, t):
+        return x
+
+
+def test_random_diffusion_steps():
+    transform = RandomDiffusionSteps(DummySchedule())
+    actual = len(transform(torch.ones(1)))
+    expected = 4
+    assert actual == expected, "Transform not returning correct keys"
+
+
+def test_dalle_image_transform():
+    img_size = 5
+    transform = Dalle2ImageTransform(image_size=img_size, image_min=-1, image_max=1)
+    image = Image.new("RGB", size=(20, 20), color=(128, 0, 0))
+    actual = transform(image).sum()
+    normalized128 = 128 / 255 * 2 - 1
+    normalized0 = -1
+    expected = torch.tensor(
+        normalized128 * img_size**2 + 2 * normalized0 * img_size**2
+    )
+    assert_expected(actual, expected, rtol=0, atol=1e-4)

--- a/tests/utils/test_diffusion_utils.py
+++ b/tests/utils/test_diffusion_utils.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from PIL import Image
+from torchmultimodal.utils.diffusion_utils import cascaded_resize
+
+
+def test_cascaded_resize():
+    image = Image.new("RGBA", size=(15, 20), color=(128, 0, 0))
+    actual = sum(cascaded_resize(image, 3).size)
+    expected = 8
+    assert actual == expected, "Cascaded resize returning wrong size"

--- a/torchmultimodal/models/dalle2/__init__.py
+++ b/torchmultimodal/models/dalle2/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/models/dalle2/adm/__init__.py
+++ b/torchmultimodal/models/dalle2/adm/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/models/dalle2/adm/adm.py
+++ b/torchmultimodal/models/dalle2/adm/adm.py
@@ -1,0 +1,540 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, Dict, List, Optional, Tuple
+
+import torch
+from torch import nn, Tensor
+from torchmultimodal.models.dalle2.adm.attention_block import (
+    adm_attn_block,
+    ADMAttentionBlock,
+)
+from torchmultimodal.models.dalle2.adm.res_block import (
+    adm_res_block,
+    adm_res_downsample_block,
+    adm_res_upsample_block,
+    ADMResBlock,
+)
+from torchmultimodal.modules.layers.normalizations import Fp32GroupNorm
+from torchmultimodal.modules.layers.position_embedding import (
+    SinusoidalPositionEmbeddings,
+)
+from torchmultimodal.utils.diffusion_utils import DiffusionOutput
+
+
+class ADM(nn.Module):
+    """Ablated Diffusion Model as described in "Diffusion Models Beat GANs on Image Synthesis" (https://arxiv.org/abs/2105.05233)
+
+    ADM consists of three major components:
+        1) the timestep encoder, which embeds the timestep provided as an int
+        2) the conditional projections, which project any conditional inputs such as class embeddings, CLIP image/text embeddings
+        3) the UNet, which processes the above and a noised input, x, to generate an unnoised image.
+
+    The UNet can be swapped with any module. The UNet used in the paper is constructed in the ADMUNet class.
+
+    Code ref: https://fburl.com/code/b6lk39ym
+
+    Attributes:
+        unet (nn.Module): model that will process three inputs: the input noised image, embedded timestep, and
+            projected conditional embeddings to produce an output.
+        timestep_encoder (nn.Module): module that will embed an integer timestep. Expected output shape is [b, c]
+            where c is the embedding dim.
+        res_cond_proj (Optional[nn.ModuleDict]): optional dict that maps user-defined keys to modules to project
+            conditional_inputs before passed into the UNet. Keys should align with the dict passed into conditional_inputs.
+            Output of projections are SUMMED with the embedded timestep and passed into the residual blocks of the unet,
+            if using ADMUNet. Embedding dims of outputs need to match embedding dim of timestep_encoder output.
+        attn_cond_proj (Optional[nn.ModuleDict]): optional dict that maps user-defined keys to modules to project
+            conditional_inputs before passed into the UNet. Keys should align with the dict passed into conditional_inputs.
+            Output of projections are CONCATENATED in the sequence dimension and passed into the attention blocks of the unet,
+            if using ADMUNet.
+        predict_variance_value (bool): If True, expects unet model to output doubled channels, second half of which are the
+            predicted variances for q, the posterior of the forward diffusion process. This corresponds to the v variable
+            in Eq. 15 of "Improved Denoising Diffusion Probabilistic Models". If False, simply return the unet output.
+            Default is True.
+        variance_value_transform (Optional[Callable]): optional function to transform the model output towards an intended
+            output range. The variance_value is intended to be a value from 0 to 1. If the model is trained to output values
+            from -n to n, then a recommended transform would be lambda x: (x + n) / 2n.
+
+
+    Args:
+        x (Tensor): input Tensor of shape [b, c, h, w]
+        timestep (Tensor): diffusion timesteps of shape [b, ]
+        conditional_inputs (Optional[Dict[str, Tensor]]): optional Tensor inputs to condition the unet model on. Keyed by
+            user-defined strings that should align with res_cond_proj or attn_cond_proj, otherwise the value is unused.
+            Expected shape of tensors are [b, c], where c is the embedding dim of the Tensor.
+    """
+
+    def __init__(
+        self,
+        unet: nn.Module,
+        timestep_encoder: nn.Module,
+        res_cond_proj: Optional[nn.ModuleDict] = None,
+        attn_cond_proj: Optional[nn.ModuleDict] = None,
+        predict_variance_value: bool = True,
+        variance_value_transform: Optional[Callable] = None,
+    ):
+        super().__init__()
+        self.unet = unet
+        self.timestep_encoder = timestep_encoder
+        self.res_cond_proj = res_cond_proj
+        self.attn_cond_proj = attn_cond_proj
+        self.predict_variance_value = predict_variance_value
+        self.variance_value_transform = variance_value_transform or nn.Identity()
+
+    def forward(
+        self,
+        x: Tensor,
+        timestep: Tensor,
+        conditional_inputs: Optional[Dict[str, Tensor]] = None,
+    ) -> DiffusionOutput:
+        (
+            res_conditional_embedding,
+            attn_conditional_embedding,
+        ) = self._get_conditional_projections(timestep, conditional_inputs)
+        h = self.unet(x, res_conditional_embedding, attn_conditional_embedding)
+        # If model is predicting variance, then it should be configured to output double the channels as input
+        if self.predict_variance_value:
+            if h.shape[1] != x.shape[1] * 2:
+                raise ValueError(
+                    f"unet is not configured to predict variance values. "
+                    f"Expected output channel dim to be {x.shape[1] * 2}, got {h.shape[1]}"
+                )
+            # Split in half in channel dim
+            prediction, variance_value = torch.chunk(h, 2, dim=1)
+            variance_value = self.variance_value_transform(variance_value)
+            return DiffusionOutput(
+                prediction=prediction,
+                variance_value=variance_value,
+            )
+        else:
+            return DiffusionOutput(
+                prediction=h,
+            )
+
+    def _get_conditional_projections(
+        self,
+        timestep: Tensor,
+        conditional_inputs: Optional[Dict[str, Tensor]] = None,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        res_cond = []
+        attn_cond = []
+        # Prevent for loop from running if conditional_inputs is None
+        conditional_inputs = (
+            conditional_inputs if conditional_inputs is not None else {}
+        )
+
+        t_embed = self.timestep_encoder(timestep)
+        t_embed_dim = t_embed.shape[-1]
+        res_cond.append(t_embed)
+
+        for key in conditional_inputs:
+            additional_input = conditional_inputs[key]
+
+            if self.res_cond_proj is not None and key in self.res_cond_proj:
+                cond_proj = self.res_cond_proj[key](additional_input)
+                if cond_proj.shape[-1] != t_embed_dim:
+                    raise ValueError(
+                        f"Embedding dim of res_cond_proj for {key} incompatible with timestep_encoder: "
+                        f"expected {t_embed_dim}, got {cond_proj.shape[-1]}"
+                    )
+                res_cond.append(cond_proj)
+
+            if self.attn_cond_proj is not None and key in self.attn_cond_proj:
+                cond_proj = self.attn_cond_proj[key](additional_input)
+                # Append as [b, c] -> [b, t, c]
+                if len(cond_proj.shape) < 3:
+                    cond_proj = cond_proj.unsqueeze(1)
+                attn_cond.append(cond_proj)
+
+        res_cond = torch.stack(res_cond).sum(dim=0)
+        # Concat on sequence dimension
+        attn_cond = torch.concat(attn_cond, dim=1) if attn_cond else None
+        return res_cond, attn_cond
+
+
+class ADMUNet(nn.Module):
+    """Composes all the blocks for the downsampling encoder, bottleneck, and upsampling encoder in the ADM UNet.
+    Constructs the network by adding residual blocks, attention blocks, and up/downsampling blocks for every layer
+    based on user specifications.
+
+    Follows the architecture described in "Diffusion Models Beat GANs on Image Synthesis"
+    (https://arxiv.org/abs/2105.05233).
+
+    Code ref:
+    https://github.com/openai/guided-diffusion/blob/22e0df8183507e13a7813f8d38d51b072ca1e67c/guided_diffusion/unet.py#L396
+
+    Structure for the encoder and decoder:
+    x -> ((ResBlock + MHA) * num_res -> ResDown/UpBlock) * num_layers -> h
+
+    Overall structure:
+    x -> encoder -> bottleneck -> decoder -> out
+
+    Attributes:
+        channels_per_layer (List[int]): list of channels for each layer. Total number of layers is determined by
+            length of this list. Each item must be divisible by number of groups used in GroupNorm layers. ADMResBlock
+            and ADMAttentionBlock use 32 as a default.
+        num_resize (int): number of layers that will include downsampling or upsampling
+        num_res_per_layer (int): number of residual blocks per layer
+        use_attention_for_layer (List[bool]): list indicating whether to include attention after res block for each layer.
+            Must match the length of channels_per_layer.
+        dim_res_cond (int): dimensionality of conditional projection layer in each res block
+        dim_attn_cond (Optional[int]): dimensionality of cross attention inputs used in attention blocks. If None, do not
+            use conditional inputs in attention blocks
+        in_channels (int): number of channels in input image. Defaults to 3.
+        out_channels (int): number of channels in output image. Defaults to 3.
+
+    Args:
+        x (Tensor): input Tensor of shape [b, in_channels, h, w]
+        res_conditional_embedding (Tensor): conditioning embedding vector of shape [b, dim_res_cond].
+        attn_conditional_embedding (Tensor): inputs to be used in cross attention of shape [b, n, dim_attn_cond] where n is the
+            number of tokens.
+    """
+
+    def __init__(
+        self,
+        channels_per_layer: List[int],
+        num_resize: int,
+        num_res_per_layer: int,
+        use_attention_for_layer: List[bool],
+        dim_res_cond: int,
+        dim_attn_cond: Optional[int] = None,
+        in_channels: int = 3,
+        out_channels: int = 3,
+    ):
+        super().__init__()
+
+        if len(channels_per_layer) != len(use_attention_for_layer):
+            raise ValueError(
+                f"Attention or number of channels not specified for each layer, expected {len(channels_per_layer)} layers"
+            )
+        if len(channels_per_layer) < num_resize:
+            raise ValueError(
+                f"Not enough channels specified, cannot have less than num_resize ({num_resize})"
+            )
+
+        self.channels_per_layer = channels_per_layer
+        self.num_resize = num_resize
+        self.num_res_per_layer = num_res_per_layer
+        self.use_attention_for_layer = use_attention_for_layer
+        self.dim_res_cond = dim_res_cond
+        self.dim_attn_cond = dim_attn_cond
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        self.down, down_channels = self._create_downsampling_encoder()
+        self.bottleneck = self._create_bottleneck(down_channels[-1])
+        self.up = self._create_upsampling_decoder(down_channels)
+
+    def _create_downsampling_encoder(self) -> Tuple[nn.ModuleList, List]:
+        # Keep track of output channels of every block for thru connections to decoder
+        down_channels = []
+        # Use ADMStack for conv layer so we can pass in conditional inputs and ignore them
+        init_conv: nn.ModuleList = ADMStack(
+            [
+                nn.Conv2d(
+                    self.in_channels,
+                    self.channels_per_layer[0],
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                )
+            ]
+        )
+        down_channels.append(self.channels_per_layer[0])
+
+        stacks = []
+        layer_in_channels = self.channels_per_layer[0]
+        # you can pass more channels than downsample layers, in which case
+        # the last few layers will not use downsampling blocks. so we
+        # should track the number of layers from channel list
+        for layer_num, layer_channels in enumerate(self.channels_per_layer):
+            layer_out_channels = layer_channels
+            # First create res blocks for the layer, with attention in between if specified
+            for block_num in range(self.num_res_per_layer):
+                if self.use_attention_for_layer[layer_num]:
+                    stacks.append(
+                        adm_stack_res_attn(
+                            in_channels=layer_in_channels,
+                            out_channels=layer_out_channels,
+                            dim_res_cond=self.dim_res_cond,
+                            dim_attn_cond=self.dim_attn_cond,
+                        )
+                    )
+                else:
+                    stacks.append(
+                        adm_stack_res(
+                            in_channels=layer_in_channels,
+                            out_channels=layer_out_channels,
+                            dim_cond=self.dim_res_cond,
+                        )
+                    )
+                down_channels.append(layer_out_channels)
+                layer_in_channels = layer_out_channels
+            # Now create the down/upsampling res block
+            if layer_num < self.num_resize:
+                stacks.append(
+                    adm_stack_res_down(
+                        num_channels=layer_out_channels, dim_cond=self.dim_res_cond
+                    )
+                )
+                down_channels.append(layer_out_channels)
+
+        net = nn.ModuleList([init_conv] + stacks)
+        return net, down_channels
+
+    def _create_bottleneck(self, num_channels: int) -> nn.ModuleList:
+        in_resblock = adm_res_block(
+            in_channels=num_channels,
+            out_channels=num_channels,
+            dim_cond=self.dim_res_cond,
+        )
+        mid_attention = adm_attn_block(
+            num_channels=num_channels, dim_cond=self.dim_attn_cond
+        )
+        out_resblock = adm_res_block(
+            in_channels=num_channels,
+            out_channels=num_channels,
+            dim_cond=self.dim_res_cond,
+        )
+        return ADMStack([in_resblock, mid_attention, out_resblock])
+
+    def _create_upsampling_decoder(self, down_channels: List[int]) -> nn.ModuleList:
+        # reverse so it's easier to iterate when going up the decoder
+        up_channels_per_layer = list(reversed(self.channels_per_layer))
+        up_attention_for_layer = list(reversed(self.use_attention_for_layer))
+
+        stacks = []
+        layer_in_channels = up_channels_per_layer[0]
+        # you can pass more channels than downsample layers, in which case
+        # the last few layers will not use downsampling blocks. so we
+        # should track the number of layers from channel list
+        for layer_num, layer_channels in enumerate(up_channels_per_layer):
+            layer_out_channels = layer_channels
+            # Code ref uses + 1 res blocks in upsampling decoder to add extra res block before upsampling
+            for block_num in range(self.num_res_per_layer + 1):
+                thru_channels = down_channels.pop() if down_channels else 0
+
+                if up_attention_for_layer[layer_num]:
+                    stacks.append(
+                        adm_stack_res_attn(
+                            in_channels=layer_in_channels + thru_channels,
+                            out_channels=layer_out_channels,
+                            dim_res_cond=self.dim_res_cond,
+                            dim_attn_cond=self.dim_attn_cond,
+                        )
+                    )
+                else:
+                    stacks.append(
+                        adm_stack_res(
+                            in_channels=layer_in_channels + thru_channels,
+                            out_channels=layer_out_channels,
+                            dim_cond=self.dim_res_cond,
+                        )
+                    )
+                layer_in_channels = layer_out_channels
+            # Now create the down/upsampling res block
+            if layer_num < self.num_resize:
+                stacks[-1].append(
+                    adm_res_upsample_block(
+                        num_channels=layer_out_channels,
+                        dim_cond=self.dim_res_cond,
+                    )
+                )
+
+        out_conv = ADMStack(
+            [
+                Fp32GroupNorm(32, up_channels_per_layer[-1]),
+                nn.SiLU(),
+                nn.Conv2d(
+                    up_channels_per_layer[-1],
+                    self.out_channels,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                ),
+            ]
+        )
+
+        net = nn.ModuleList(stacks + [out_conv])
+        return net
+
+    def forward(
+        self,
+        x: Tensor,
+        res_conditional_embedding: Tensor,
+        attn_conditional_embedding: Tensor,
+    ) -> Tensor:
+        hidden_states = []
+        h = x
+        for block in self.down:
+            h = block(h, res_conditional_embedding, attn_conditional_embedding)
+            hidden_states.append(h)
+        h = self.bottleneck(h, res_conditional_embedding, attn_conditional_embedding)
+        for block in self.up:
+            if hidden_states:
+                h = torch.cat([h, hidden_states.pop()], dim=1)
+            h = block(h, res_conditional_embedding, attn_conditional_embedding)
+        return h
+
+
+class ADMStack(nn.ModuleList):
+    """A container that acts as a ModuleList of ADM blocks and handles passing conditional inputs
+    correctly to the children ADMResBlocks and ADMAttentionBlocks.
+
+    Code ref: https://fburl.com/code/x9nuqaov
+    """
+
+    def forward(
+        self,
+        x: Tensor,
+        res_conditional_embedding: Tensor,
+        attn_conditional_embedding: Tensor,
+    ) -> Tensor:
+        h = x
+        for block in self:
+            if isinstance(block, ADMResBlock):
+                h = block(h, res_conditional_embedding)
+            elif isinstance(block, ADMAttentionBlock):
+                h = block(h, attn_conditional_embedding)
+            else:
+                h = block(h)
+        return h
+
+
+def adm_stack_res(in_channels: int, out_channels: int, dim_cond: int) -> nn.ModuleList:
+    return ADMStack(
+        [
+            adm_res_block(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                dim_cond=dim_cond,
+            )
+        ]
+    )
+
+
+def adm_stack_res_attn(
+    in_channels: int,
+    out_channels: int,
+    dim_res_cond: int,
+    dim_attn_cond: Optional[int] = None,
+) -> nn.ModuleList:
+    return ADMStack(
+        [
+            adm_res_block(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                dim_cond=dim_res_cond,
+            ),
+            adm_attn_block(
+                num_channels=out_channels,
+                dim_cond=dim_attn_cond,
+            ),
+        ]
+    )
+
+
+def adm_stack_res_down(num_channels: int, dim_cond: int) -> nn.ModuleList:
+    return ADMStack(
+        [
+            adm_res_downsample_block(
+                num_channels=num_channels,
+                dim_cond=dim_cond,
+            )
+        ]
+    )
+
+
+def dalle2_adm(
+    *,
+    # ADM args
+    time_embed_dim: int = 512,
+    cond_embed_dim: int = 2048,
+    clip_embed_dim: int = 768,
+    clip_embed_name: str = "clip_image",
+    predict_variance_value: bool = True,
+    # ADMUNet args
+    image_channels: int = 4,
+    depth: int = 512,
+    num_resize: int = 3,
+    num_res_per_layer: int = 3,
+) -> nn.Module:
+    """Constructs the DALLE-2 base conditional UNet
+
+    Consists of an ADM UNet diffusion model conditioned on CLIP image embeddings.
+
+    Follows parameters from paper: https://arxiv.org/abs/2204.06125
+
+
+    Args:
+        time_embed_dim (int): desired dimensionality of timestep embedding
+        cond_embed_dim (int): desired dimensionality of conditional input embeddings
+        clip_embed_dim (int): expected dimensionality of CLIP image embeddings
+        clip_embed_name (str): name of CLIP embedding conditional input
+        predict_variance_value (bool): if True, will double UNet's output channel dim to predict variance values of
+            diffusion process
+        image_channels (int): channel dim of input images
+        depth (int): channel dim of UNet convolutional modules. Expands everytime resolution is downscaled.
+            Must be divisible by number of groups used in GroupNorm layers. ADMResBlock
+            and ADMAttentionBlock use 32 as a default.
+        num_resize (int): number of times resolution will be scaled
+        num_res_per_layer (int): number of residual blocks per resolution
+    """
+    #
+    # Construct UNet
+    #
+    in_channels = image_channels
+
+    # If predicting variance, double the channel dim of UNet output and use those values as variance
+    out_channels = image_channels * 2 if predict_variance_value else image_channels
+
+    # e.g., if depth is 512 and num_resize is 3, then channels are [512, 1024, 1536, 2048]
+    channels_per_layer = [depth * (i + 1) for i in range(num_resize + 1)]
+    # Assuming image size is 64x64, use attention at resolutions 32x32, 16x16, 8x8
+    use_attention_per_layer = [False] + [True] * num_resize
+    unet = ADMUNet(
+        channels_per_layer=channels_per_layer,
+        num_resize=num_resize,
+        num_res_per_layer=num_res_per_layer,
+        use_attention_for_layer=use_attention_per_layer,
+        dim_res_cond=cond_embed_dim,
+        dim_attn_cond=cond_embed_dim,
+        in_channels=in_channels,
+        out_channels=out_channels,
+    )
+
+    #
+    # Construct ADM (UNet + timestep/conditional projections)
+    #
+    time_embed = nn.Sequential(
+        SinusoidalPositionEmbeddings(embed_dim=time_embed_dim),
+        nn.Linear(time_embed_dim, cond_embed_dim),
+        nn.SiLU(),
+        nn.Linear(cond_embed_dim, cond_embed_dim),
+    )
+
+    # Project clip embeddings to residual and attention blocks
+    res_clip_proj = nn.ModuleDict(
+        {clip_embed_name: nn.Linear(clip_embed_dim, cond_embed_dim)}
+    )
+    attn_clip_proj = nn.ModuleDict(
+        {
+            clip_embed_name: nn.Sequential(
+                nn.Linear(
+                    clip_embed_dim, cond_embed_dim * 4
+                ),  # four tokens of context as per paper ref
+                nn.Unflatten(-1, (4, cond_embed_dim)),
+            )
+        }
+    )
+    return ADM(
+        unet=unet,
+        timestep_encoder=time_embed,
+        res_cond_proj=res_clip_proj,
+        attn_cond_proj=attn_clip_proj,
+        predict_variance_value=predict_variance_value,
+        variance_value_transform=lambda x: (x + 1) / 2,
+    )

--- a/torchmultimodal/models/dalle2/adm/attention_block.py
+++ b/torchmultimodal/models/dalle2/adm/attention_block.py
@@ -1,0 +1,181 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from torch import nn, Tensor
+from torchmultimodal.modules.layers.attention import MultiHeadAttention, split_multihead
+from torchmultimodal.modules.layers.normalizations import Fp32GroupNorm
+from torchmultimodal.utils.common import shift_dim
+
+
+class ADMAttentionBlock(nn.Module):
+    """Attention block in the ADM net that consists of group norm, multihead attention, and a residual connection.
+
+    Follows the architecture described in "Diffusion Models Beat GANs on Image Synthesis"
+    (https://arxiv.org/abs/2105.05233)
+
+    Code ref:
+    https://github.com/openai/guided-diffusion/blob/22e0df8183507e13a7813f8d38d51b072ca1e67c/guided_diffusion/unet.py#L259
+
+    Defaults taken from https://fburl.com/code/tiryi2f9.
+
+    Attributes:
+        num_channels (int): channel dim expected in input, determines embedding dim of q, k, v in attention module.
+            Needs to be divisible by norm_groups.
+        dim_cond (Optional[int]): dimensionality of conditional input for cross attention. If not specified,
+            do not use conditional input.
+        rescale_skip_connection (bool): whether to rescale skip connection by 1/sqrt(2), as described in "Diffusion
+            Models Beat GANs on Image Synthesis" (https://arxiv.org/abs/2105.05233). Defaults to False.
+        norm_groups (int): number of groups used in GroupNorm layer. Defaults to 32.
+
+    Args:
+        x (Tensor): input Tensor of shape [b, c, h, w]
+        conditional_embedding (Optional[Tensor]): tokens of shape [b, n, dim_cond] where n is the number of tokens.
+            If provided, will be passed as cross-attention input to the MultiHeadAttention block. Defaults to None.
+    """
+
+    def __init__(
+        self,
+        num_channels: int,
+        dim_cond: Optional[int] = None,
+        num_heads: int = 1,
+        rescale_skip_connection: bool = False,
+        norm_groups: int = 32,
+    ):
+        super().__init__()
+
+        if num_channels % norm_groups != 0:
+            raise ValueError("Channel dims need to be divisible by norm_groups")
+
+        self.norm = Fp32GroupNorm(norm_groups, num_channels)
+        self.attn = adm_attention(num_channels, dim_cond, num_heads)
+        self.rescale_skip_connection = rescale_skip_connection
+
+    def forward(
+        self,
+        x: Tensor,
+        conditional_embedding: Optional[Tensor] = None,
+    ) -> Tensor:
+        norm_out = self.norm(x)
+        # [b, c, h, w] -> [b, h, w, c]
+        norm_out = shift_dim(norm_out, 1, -1)
+        attn_out = self.attn(norm_out, conditional_embedding=conditional_embedding)
+        # [b, h, w, c] -> [b, c, h, w]
+        attn_out = shift_dim(attn_out, -1, 1)
+        if self.rescale_skip_connection:
+            return (x + attn_out) / 1.414
+        else:
+            return x + attn_out
+
+
+class ADMCrossAttention(nn.Module):
+    """Similar to standard cross-attention, except conditioning inputs are passed through a separate projection
+    and then concatenated with the key and value vectors before scaled dot product attention.
+
+    Code ref: https://fburl.com/code/rxl1md57
+
+    Attributes:
+        dim_qkv (int): embedding dimension of query, key, and value vectors. conditional_embedding is projected into this
+            dimension * 2, to account for k and v.
+        dim_cond (int, optional): embedding dimension of conditional input. If unspecified, this class becomes standard
+            self attention.
+
+    Args:
+        q, k, v (Tensor): Query/key/value of shape [b, h, d1, ..., dn, dim_qkv // h] or [b, h, seq_len, dim_qkv //h] where
+            h is number of attention heads, d1, ..., dn are spatial dimensions and dim_qkv is
+            the embedding dim.
+        conditional_embedding (Tensor, Optional): tensor of shape [b, d1, ..., dn, dim_cond] to condition k and v on
+
+    Returns:
+        A tensor of shape [b, h, d1, ..., dn, dim_qkv // h] with the output of the attention calculation.
+    """
+
+    def __init__(self, dim_qkv: int, dim_cond: Optional[int] = None) -> None:
+        super().__init__()
+        self.dim_qkv = dim_qkv
+        self.cond_proj: Optional[nn.Module] = None
+        if dim_cond is not None:
+            # Times 2 for both k and v
+            self.cond_proj = nn.Linear(dim_cond, dim_qkv * 2)
+
+    def forward(
+        self,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        conditional_embedding: Optional[Tensor] = None,
+    ) -> Tensor:
+        _, n_head, *spatial_dims, dim_q = q.shape
+        dim_q = dim_q * n_head
+        dim_k = k.shape[-1] * n_head
+        dim_v = v.shape[-1] * n_head
+        if self.dim_qkv != dim_q or self.dim_qkv != dim_k or self.dim_qkv != dim_v:
+            raise ValueError(
+                f"The embedding dim of q, k, v does not match expected embedding dim of {self.dim_qkv}."
+            )
+        if self.dim_qkv % n_head != 0:
+            raise ValueError(
+                "The embedding dim of q, k, v must be a multiple of the number of attention heads."
+            )
+
+        # [b, h, d1, ..., dn, dim_qkv] -> [b, h, t, dim_qkv]
+        q = q.flatten(start_dim=2, end_dim=-2)
+        k = k.flatten(start_dim=2, end_dim=-2)
+        v = v.flatten(start_dim=2, end_dim=-2)
+
+        if conditional_embedding is not None and self.cond_proj is not None:
+            # [b, d1, ..., dn, dim_cond] -> [b, h, d1, ..., dn, dim_qkv * 2 // h]
+            cond = split_multihead(self.cond_proj(conditional_embedding), n_head)
+            # [b, h, d1, ..., dn, dim_qkv * 2 // h] -> [b, h, t, dim_qkv * 2 // h]
+            cond = cond.flatten(start_dim=2, end_dim=-2)
+            # [b, h, t, dim_qkv // h]
+            cond_k, cond_v = cond.split(self.dim_qkv // n_head, dim=-1)
+            # concat on sequence length dimension
+            k = torch.cat([cond_k, k], dim=2)
+            v = torch.cat([cond_v, v], dim=2)
+
+        # Use PyTorch's optimized scaled_dot_product_attention
+        attn = nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=0,
+            is_causal=False,
+        )
+        # [b, h, t, dim_qkv // h] -> [b, h, d1, ..., dn, dim_qkv // h]
+        attn = attn.unflatten(2, spatial_dims)
+
+        return attn
+
+
+def adm_attention(
+    num_channels: int,
+    dim_cond: Optional[int] = None,
+    num_heads: int = 1,
+) -> nn.Module:
+    attn = ADMCrossAttention(
+        dim_qkv=num_channels,
+        dim_cond=dim_cond,
+    )
+    return MultiHeadAttention(
+        dim_q=num_channels,
+        dim_kv=num_channels,
+        n_head=num_heads,
+        attn_module=attn,
+    )
+
+
+def adm_attn_block(
+    num_channels: int,
+    dim_cond: Optional[int] = None,
+) -> ADMAttentionBlock:
+    return ADMAttentionBlock(
+        num_channels=num_channels,
+        dim_cond=dim_cond,
+    )

--- a/torchmultimodal/models/dalle2/adm/res_block.py
+++ b/torchmultimodal/models/dalle2/adm/res_block.py
@@ -1,0 +1,193 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch import nn, Tensor
+from torchmultimodal.modules.layers.normalizations import Fp32GroupNorm
+
+
+class ADMResBlock(nn.Module):
+    """Residual block in the ADM net. Supports projecting a conditional embedding to add to the hidden state.
+    This typically contains the timestep embedding, but can also contain class embedding for classifier free guidance,
+    CLIP image embedding and text encoder output for text-to-image generation as in DALL-E 2, or anything you want to
+    condition the diffusion model on.
+
+    Follows the architecture described in "Diffusion Models Beat GANs on Image Synthesis"
+    (https://arxiv.org/abs/2105.05233) and BigGAN residual blocks (https://arxiv.org/abs/1809.11096).
+
+    Code ref:
+    https://github.com/openai/guided-diffusion/blob/22e0df8183507e13a7813f8d38d51b072ca1e67c/guided_diffusion/unet.py#L143
+
+    Defaults taken from https://fburl.com/code/tiryi2f9.
+
+    Attributes:
+        in_channels (int): num channels expected in input. Needs to be divisible by norm_groups.
+        out_channels (int): num channels desired in output. Needs to be divisible by norm_groups.
+        dim_cond (int): dimensionality of conditional projection layer
+        use_upsample (bool): include nn.Upsample layer before first conv on hidden state and on skip connection.
+            Defaults to False. Cannot be True if use_downsample is True.
+        use_downsample (bool): include nn.AvgPool2d layer before first conv on hidden state and on skip connection.
+            Defaults to False. Cannot be True if use_upsample is True.
+        activation (nn.Module): activation used before convs. Defaults to nn.SiLU().
+        skip_conv (nn.Module): module used for additional convolution on skip connection. Defaults to nn.Identity().
+        rescale_skip_connection (bool): whether to rescale skip connection by 1/sqrt(2), as described in "Diffusion
+            Models Beat GANs on Image Synthesis" (https://arxiv.org/abs/2105.05233). Defaults to False.
+        scale_shift_conditional (bool): if True, splits conditional embedding into two separate projections,
+            and adds to hidden state as Norm(h)(w + 1) + b, as described in Appendix A in
+            "Improved Denoising Diffusion Probabilistic Models" (https://arxiv.org/abs/2102.09672).
+            Defaults to True.
+        pre_outconv_dropout (float): dropout probability before the second conv. Defaults to 0.1.
+        norm_groups (int): number of groups used in GroupNorm layer. Defaults to 32.
+
+    Args:
+        x (Tensor): input Tensor of shape [B x C x H x W]
+        conditional_embedding (Tensor): conditioning embedding vector of shape [B x C].
+
+    Raises:
+        TypeError: When skip_conv is not defined and in_channels != out_channels.
+        TypeError: When use_upsample and use_downsample are both True.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        dim_cond: int,
+        use_upsample: bool = False,
+        use_downsample: bool = False,
+        activation: nn.Module = nn.SiLU(),
+        skip_conv: nn.Module = nn.Identity(),
+        rescale_skip_connection: bool = False,
+        scale_shift_conditional: bool = True,
+        pre_outconv_dropout: float = 0.1,
+        norm_groups: int = 32,
+    ):
+        super().__init__()
+
+        if isinstance(skip_conv, nn.Identity) and in_channels != out_channels:
+            raise ValueError(
+                "You must specify a skip connection conv if out_channels != in_channels"
+            )
+
+        if in_channels % norm_groups != 0 or out_channels % norm_groups != 0:
+            raise ValueError("Channel dims need to be divisible by norm_groups")
+
+        hidden_updownsample_layer: nn.Module
+        skip_updownsample_layer: nn.Module
+        if use_downsample and use_upsample:
+            raise ValueError("Cannot use both upsample and downsample in res block")
+        elif use_downsample:
+            hidden_updownsample_layer = nn.AvgPool2d(kernel_size=2, stride=2)
+            skip_updownsample_layer = nn.AvgPool2d(kernel_size=2, stride=2)
+        elif use_upsample:
+            hidden_updownsample_layer = nn.Upsample(scale_factor=2, mode="nearest")
+            skip_updownsample_layer = nn.Upsample(scale_factor=2, mode="nearest")
+        else:
+            hidden_updownsample_layer = nn.Identity()
+            skip_updownsample_layer = nn.Identity()
+
+        cond_channels = 2 * out_channels if scale_shift_conditional else out_channels
+        self.cond_proj = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(dim_cond, cond_channels),
+        )
+        self.in_block = nn.Sequential(
+            Fp32GroupNorm(norm_groups, in_channels),  # groups = 32 from code ref
+            activation,
+            hidden_updownsample_layer,
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1),
+        )
+        self.out_block = nn.Sequential(
+            Fp32GroupNorm(norm_groups, out_channels),
+            activation,
+            nn.Dropout(pre_outconv_dropout),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1),
+        )
+        self.skip_block = nn.Sequential(
+            skip_updownsample_layer,
+            skip_conv,
+        )
+
+        self.scale_shift_conditional = scale_shift_conditional
+        self.rescale_skip_connection = rescale_skip_connection
+
+    def forward(
+        self,
+        x: Tensor,
+        conditional_embedding: Tensor,
+    ) -> Tensor:
+        t = self.cond_proj(conditional_embedding)
+        # [b, c] -> [b, c, 1, 1]
+        t = t.unsqueeze(-1).unsqueeze(-1)
+        skip = self.skip_block(x)
+        h = self.in_block(x)
+        # If specified, split conditional embedding into two separate projections.
+        # Use half to multiply with hidden state and half to add.
+        # This is typically done after normalization.
+        if self.scale_shift_conditional:
+            h = self.out_block[0](h)
+            scale, shift = torch.chunk(t, 2, dim=1)
+            h = h * (1 + scale) + shift
+            h = self.out_block[1:](h)
+        else:
+            h = self.out_block(h + t)
+        if self.rescale_skip_connection:
+            h = (skip + h) / 1.414
+        else:
+            h = skip + h
+        return h
+
+
+def adm_res_block(
+    in_channels: int,
+    out_channels: int,
+    dim_cond: int,
+) -> ADMResBlock:
+    if in_channels != out_channels:
+        return adm_res_skipconv_block(in_channels, out_channels, dim_cond)
+    return ADMResBlock(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        dim_cond=dim_cond,
+    )
+
+
+def adm_res_downsample_block(
+    num_channels: int,
+    dim_cond: int,
+) -> ADMResBlock:
+    return ADMResBlock(
+        in_channels=num_channels,
+        out_channels=num_channels,
+        dim_cond=dim_cond,
+        use_downsample=True,
+    )
+
+
+def adm_res_skipconv_block(
+    in_channels: int,
+    out_channels: int,
+    dim_cond: int,
+) -> ADMResBlock:
+    skip_conv = nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=1)
+    return ADMResBlock(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        dim_cond=dim_cond,
+        skip_conv=skip_conv,
+    )
+
+
+def adm_res_upsample_block(
+    num_channels: int,
+    dim_cond: int,
+) -> ADMResBlock:
+    return ADMResBlock(
+        in_channels=num_channels,
+        out_channels=num_channels,
+        dim_cond=dim_cond,
+        use_upsample=True,
+    )

--- a/torchmultimodal/models/dalle2/dalle2_decoder.py
+++ b/torchmultimodal/models/dalle2/dalle2_decoder.py
@@ -1,0 +1,113 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torchmultimodal.models.dalle2.adm.adm import dalle2_adm
+from torchmultimodal.modules.diffusion.cfguidance import CFGuidance
+from torchmultimodal.modules.diffusion.ddpm import DDPModule
+from torchmultimodal.modules.diffusion.predictors import NoisePredictor
+from torchmultimodal.modules.diffusion.schedules import (
+    cosine_beta_schedule,
+    DiffusionSchedule,
+)
+
+
+def dalle2_decoder(
+    *,
+    # DiffusionSchedule args
+    timesteps: int = 1000,
+    # ADM args
+    time_embed_dim: int = 512,
+    cond_embed_dim: int = 2048,
+    clip_embed_dim: int = 768,
+    clip_embed_name: str = "clip_image",
+    predict_variance_value: bool = True,
+    image_channels: int = 4,
+    depth: int = 512,
+    num_resize: int = 3,
+    num_res_per_layer: int = 3,
+    # CFGuidance args
+    use_cf_guidance: bool = True,
+    clip_image_guidance_dropout: float = 0.1,
+    guidance_strength: float = 7.0,
+    learn_null_emb: bool = True,
+) -> DDPModule:
+    """Constructs primary DALLE-2 diffusion decoder without upsampling.
+
+    Consists of an ADM UNet diffusion model conditioned on CLIP image embeddings. Uses DDPM to generate
+    images.
+
+    Ref: https://arxiv.org/abs/2204.06125
+
+    Follows parameters in this config: https://fburl.com/code/jyi0nhdt
+
+    Args:
+        timesteps (int): number of timesteps in the diffusion process
+        time_embed_dim (int): desired dimensionality of timestep embedding
+        cond_embed_dim (int): desired dimensionality of conditional input embeddings
+        clip_embed_dim (int): expected dimensionality of CLIP image embeddings
+        clip_embed_name (str): name of CLIP embedding conditional input
+        predict_variance_value (bool): if True, will double UNet's output channel dim to predict variance values of
+            diffusion process
+        image_channels (int): channel dim of input images
+        depth (int): channel dim of UNet convolutional modules. Expands everytime resolution is downscaled.
+            Must be divisible by number of groups used in GroupNorm layers. ADMResBlock
+            and ADMAttentionBlock use 32 as a default.
+        num_resize (int): number of times resolution will be scaled
+        num_res_per_layer (int): number of residual blocks per resolution
+        use_cf_guidance (bool): if True, use classifier-free guidance with a conditional input (CLIP embeddings).
+            If False, do not condition the model, and ignore clip_image_guidance_dropout, guidance_strength,
+            learn_null_emb, clip_embed_dim parameters.
+        clip_image_guidance_dropout (float): probability of dropping CLIP image embedding conditional input
+            and using the unconditional embedding.
+        guidance_strength (float): probability values control the ratio of conditional
+            and unconditional generation during inference. Higher values give
+            better sample quality at the cost of lesser diversity. A value of -1
+            ignores conditional variables, while a value of 0 ignores unconditional
+            variables. Default is 2.0, from code ref: https://fburl.com/code/04wxq7ln
+        learn_null_emb (bool): If False, then unconditional embeddings are set to zero and are not trainable
+            If True, then unconditional embeddings are set to random and are trainable. Defaults to True.
+    """
+    #
+    # Construct UNet
+    #
+    diffusion_model = dalle2_adm(
+        time_embed_dim=time_embed_dim,
+        cond_embed_dim=cond_embed_dim,
+        clip_embed_dim=clip_embed_dim,
+        clip_embed_name=clip_embed_name,
+        predict_variance_value=predict_variance_value,
+        image_channels=image_channels,
+        depth=depth,
+        num_resize=num_resize,
+        num_res_per_layer=num_res_per_layer,
+    )
+
+    #
+    # Construct CFGuidance wrapper around ADM model
+    #
+    if use_cf_guidance:
+        diffusion_model = CFGuidance(
+            model=diffusion_model,
+            dim_cond={clip_embed_name: clip_embed_dim},
+            p=clip_image_guidance_dropout,
+            guidance=guidance_strength,
+            learn_null_emb=learn_null_emb,
+        )
+
+    #
+    # Construct DDPM decoder
+    #
+    eval_steps = torch.linspace(0, timesteps - 1, timesteps // 4, dtype=torch.int)
+    schedule = DiffusionSchedule(cosine_beta_schedule(timesteps))
+    predictor = NoisePredictor(schedule, lambda x: x.clamp(-1, 1))
+    model = DDPModule(
+        model=diffusion_model,
+        schedule=schedule,
+        predictor=predictor,
+        eval_steps=eval_steps,
+    )
+    return model

--- a/torchmultimodal/modules/diffusion/cfguidance.py
+++ b/torchmultimodal/modules/diffusion/cfguidance.py
@@ -1,0 +1,184 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, Dict, Optional, Union
+
+import torch
+from torch import nn, Tensor
+
+from torchmultimodal.utils.diffusion_utils import DiffusionOutput
+
+
+class CFGuidance(nn.Module):
+    """
+    Classifier free guidance gives diffusion models the ability to sample from a conditional
+    distribution, while maintaining a healthy ratio between exploitation (i.e. correlation
+    with conditional variables) and exploration (i.e. diversity of generation).
+    As described in "Diffusion Models Beat GANs on Image Synthesis"
+    (https://arxiv.org/abs/2105.05233)
+    and "GLIDE: Towards Photorealistic Image Generation and Editing with Text-Guided
+    Diffusion Models" (https://arxiv.org/abs/2112.10741)
+
+    During training, `p` controls how often does the model see/use the
+    unconditional embeddings (i.e. zero or random).
+    During inference, `guidance` guides what ratio of unconditional vs
+    conditional embeddings guide the generative output.
+
+    Attributes:
+        model (nn.Module): the neural network
+        dim_cond (Dict[str, int]): the dimensions of conditional embeddings as a dictionary
+            #TODO embedding sizes to be infered by running a forward pass (like LazyLinear)
+        p (Union[float, Dict[str, float]]): probability values control
+            conditional and unconditional generation during training.
+            Defaults to 0.1 for all dim_cond keys.
+        guidance (float): a magnitude to control the strength of the context_embedding
+            during inference. Higher values give better alignment with the context at the
+            cost of lesser diversity. Expecting a value from 0 to inf, defaults to 0.
+        learn_null_emb (bool): If False, then unconditional embeddings are set to zero and are not trainable
+            If True, then unconditional embeddings are set to random and are trainable. Defaults to True.
+    Args:
+        x (Tensor): input Tensor of shape [b, in_channels, ...]
+        timestep (Tensor): diffusion step
+        conditional_inputs (Dict[str, Tensor]): conditional embedding as a dictionary.
+            Conditional embeddings must have at least 2 dimensions.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        dim_cond: Dict[str, int],
+        p: Union[int, float, Dict[str, float]] = 0.1,
+        guidance: float = 0.0,
+        learn_null_emb: bool = True,
+    ):
+        super().__init__()
+        self.model = model
+        self.dim_cond = dim_cond
+        self.p = self._get_prob_dict(p)
+        self.guidance = guidance
+        self.learn_null_emb = learn_null_emb
+
+        init_fn: Callable  # [[str, Tensor, Tensor], Tensor]
+        if self.learn_null_emb:
+            init_fn = torch.rand
+            requires_grad = True
+        else:
+            init_fn = torch.zeros
+            requires_grad = False
+
+        self.unconditional_embedding = nn.ParameterDict(
+            {
+                k: nn.Parameter(init_fn(1, dim), requires_grad=requires_grad)
+                for k, dim in self.dim_cond.items()
+            }
+        )
+
+    def _get_prob_dict(self, prob: Union[float, Dict[str, float]]) -> Dict[str, float]:
+        """
+        Converting probability parameters to a consistent dict format.
+        If prob is a float value, then it is assumed to be the same value for all keys
+            in self.dim_cond and converted to a dict accordingly
+        If prob is a dictionary, it is verfied that the keys in the probs match
+            the keys in self.dim_cond
+
+        Args:
+            prob (Union[float, Dict[str, float]]): probability parameters
+
+        """
+        if isinstance(prob, float) or isinstance(prob, int):
+            return {k: prob for k in self.dim_cond}
+        elif isinstance(prob, dict):
+            if prob.keys() != self.dim_cond.keys():
+                prob_keys = ("'{}'," * (len(prob) - 1) + "'{}'").format(*prob.keys())
+                dim_cond_keys = ("'{}'," * (len(self.dim_cond) - 1) + "'{}'").format(
+                    *self.dim_cond.keys()
+                )
+                raise ValueError(
+                    """prob has keys: [{}], dim_cond has keys: [{}];
+                expected prob and dim_cond to have the same keys""".format(
+                        prob_keys, dim_cond_keys
+                    )
+                )
+            return prob
+        else:
+            raise TypeError(
+                "prob should be either a float or a dict. Instead, it is a {}".format(
+                    type(prob)
+                )
+            )
+
+    def _update_conditions(
+        self, inputs: Dict[str, Tensor], merge_func: Optional[Callable], batch_size: int
+    ) -> Dict[str, Tensor]:
+        """
+        Merge provided conditions with learned "unconditional" embeddings. It is assumed that inputs
+        are a subset of the learned unconditional embeddings. This function updates the conditional embedding
+        with provided input conditions as defined by the merge_func.
+
+        Args:
+            inputs (Dict[str, Tensor]): dictionary of user provided conditional embeddings
+            merge_func(Callable): function defining how to merge the conditional and unconditional embedding. This
+                function takes as input the embedding key (str), and the conditional (Tensor) and unconditional
+                (Tensor) embedding
+            batch_size (int): batch size for the output embeddings
+        """
+        if not inputs.keys() <= self.dim_cond.keys():
+            raise ValueError(
+                "All conditional_inputs must be specified in the dim_cond dict while initiating class {}".format(
+                    self.__class__.__name__
+                )
+            )
+        embedding = dict()
+        for k, uncond in self.unconditional_embedding.items():
+            if k in inputs:
+                cond = inputs[k]
+                embedding[k] = merge_func(k, cond, uncond) if merge_func else cond
+            else:
+                embedding[k] = uncond.expand(batch_size, *uncond.shape[1:])
+        return embedding
+
+    def forward(
+        self,
+        x: Tensor,
+        timestep: Tensor,
+        conditional_inputs: Optional[Dict[str, Tensor]] = None,
+    ) -> DiffusionOutput:
+        conditional_inputs = conditional_inputs or {}
+        b = x.shape[0]
+        if self.training:
+            # Classifier free guidance during training
+            # Dropout randomly drops out conditional inputs based on self.p for learned unconditional ones
+            dropout_func = lambda key, cond, uncond: torch.where(
+                torch.rand(b, 1, device=x.device) < self.p[key], uncond, cond
+            )
+            embedding = self._update_conditions(conditional_inputs, dropout_func, b)
+            return self.model(x, timestep, embedding)
+        elif self.guidance == 0 or not conditional_inputs:
+            # If guidance is 0 or there are no conditional inputs to guide, then run inference
+            # with no guidance. We still update conditions incase there are conditional inputs
+            # and guidance is set to 0.
+            embedding = self._update_conditions(conditional_inputs, None, b)
+            return self.model(x, timestep, embedding)
+        else:
+            # Classifier free guidance during inference
+            # Cat concatenates the conditional and unconditional input to compute both model outputs
+            cat_func = lambda key, cond, uncond: torch.cat(
+                [cond, uncond.expand_as(cond)], dim=0
+            )
+            embedding = self._update_conditions(conditional_inputs, cat_func, 2 * b)
+
+            # Duplicate x and t to perform both conditional and unconditional generation
+            x_ = torch.cat([x, x], dim=0)
+            t_ = torch.cat([timestep, timestep], dim=0)
+            output = self.model(x_, t_, embedding)
+            cond, uncond = torch.chunk(output.prediction, 2, dim=0)
+            # Combine conditional and unconditional generation
+            output.prediction = (1 + self.guidance) * cond - self.guidance * uncond
+
+            # variance_value is duplicated, so deduplicating
+            if output.variance_value is not None:
+                output.variance_value, _ = torch.chunk(output.variance_value, 2, dim=0)
+            return output

--- a/torchmultimodal/modules/diffusion/ddim.py
+++ b/torchmultimodal/modules/diffusion/ddim.py
@@ -1,0 +1,167 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Generator, Iterable, Optional, Union
+
+import torch
+from torch import nn, Tensor
+from torchmultimodal.modules.diffusion.predictors import Predictor
+
+from torchmultimodal.modules.diffusion.schedules import DiffusionSchedule
+from torchmultimodal.utils.diffusion_utils import DiffusionOutput
+
+
+class DDIModule(nn.Module):
+    """
+    DDIModule implements "Denoising Diffusion Implicit Models" presented by Song et. al
+    (https://arxiv.org/abs/2010.02502).
+
+    DDIMs are a class of iterative implicit probabilistic models that has the same
+    training procedure as DDPMs, but can produce high quality samples much faster.
+    Song et. al propose a new generative process where given a noisy x_t, we first
+    make a prediction for x_0, and we then use it to obtain a sample for x_{t−1}.
+    DDIMs are known to be effective in generating high quality samples faster than
+    DDPMs.
+
+    Example:
+        ddim_model = DDPModule(model, schedule, predictor)
+        prediction_t = ddim_model(x_t, t)
+
+        ddim_model.eval()
+        x_0 = ddim_model(x_T, T)
+
+    Code ref:
+    https://github.com/openai/improved-diffusion/blob/main/improved_diffusion/gaussian_diffusion.py
+
+    Attributes:
+    model (nn.Module):
+    schedule (DiffusionSchedule): defines noise diffusion throughout time
+    predictor (Predictor): used to help predict x0
+    eval_steps (Tensor): a subset of steps to sample at inference time
+    eta (float): scaling factor used in Equation 12 of Song et. al
+                    (https://arxiv.org/abs/2010.02502)
+    Args:
+        xt (Tensor): corrupted data at time t (when t = schedule.steps, xt is fully noise)
+                     of shape  [b, c, ...]
+        timestep (Tensor): diffusion step
+        conditional_inputs (Dict): dictionary of context embeddings
+
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        schedule: DiffusionSchedule,
+        predictor: Predictor,
+        eval_steps: Optional[Tensor] = None,
+        progress_bar: bool = True,
+        eta: float = 1.0,
+    ):
+        super().__init__()
+
+        self.model = model
+        self.schedule = schedule
+        self.predictor = predictor
+        self.progress_bar = progress_bar
+        self.eta = eta
+
+        if eval_steps is None:
+            eval_steps = torch.arange(self.schedule.steps)
+        else:
+            eval_steps, _ = eval_steps.sort()
+
+        self.eval_steps: Tensor
+        self.register_buffer("eval_steps", eval_steps.to(torch.long))
+
+    def remove_noise(
+        self,
+        xt: Tensor,
+        c: Optional[Dict[str, Tensor]],
+        cur_step: Tensor,
+        next_step: Tensor,
+    ) -> Tensor:
+        """Given corrupted data (x at step t), compute x, denoised by one diffusion step,
+        x_{t-1}.
+
+
+        Args:
+            xt (Tensor): uncorrupted data at step 0
+            t (Tensor): diffusion step
+            c (Optional[Dict[str, Tensor]]):
+            cur_step Tensor:
+            next_step Tensor:
+            eta float:
+        """
+        # Model outputs
+        alpha_bar = self.schedule("alphas_cumprod", cur_step, xt.shape)
+        alpha_bar_next = self.schedule("alphas_cumprod", next_step, xt.shape)
+        alpha_bar_next_sqred = self.schedule("sqrt_alphas_cumprod", next_step, xt.shape)
+
+        out = self.model(xt, cur_step, c)
+        pred = out.prediction
+
+        x0 = self.predictor.predict_x0(pred, xt, cur_step)
+        noise = self.schedule.sample_noise(xt)
+
+        pred_noise = self.predictor.predict_noise(pred, xt, cur_step)
+
+        sigma = (
+            self.eta
+            * (
+                (1 - alpha_bar / alpha_bar_next)
+                * (1 - alpha_bar_next)
+                / (1 - alpha_bar)
+            ).sqrt()
+        )
+
+        # Equation 12
+        # In this equation, we use the predicted x_0, stochastic noise, and the
+        # predicted noise to compute x_{t-1}.
+        xt = (
+            x0 * alpha_bar_next_sqred
+            + sigma * noise
+            # pyre-fixme
+            + (((1 - alpha_bar_next) - torch.square(sigma)).sqrt()) * pred_noise
+        ).to(dtype=xt.dtype)
+
+        return xt
+
+    def generator(
+        self,
+        xt: Tensor,
+        c: Optional[Dict[str, Tensor]] = None,
+    ) -> Generator[Tensor, None, None]:
+        """Generate xt for each t in self.eval_steps"""
+        steps = self.eval_steps.flip(0)
+        for step, next_step in zip(steps[:-1], steps[1:]):
+            # Convert steps to batched tensors
+            t = step * torch.ones(xt.size(0), device=xt.device, dtype=torch.long)
+            t1 = next_step * torch.ones(xt.size(0), device=xt.device, dtype=torch.long)
+            # Remove noise between step t and t+1
+            xt = self.remove_noise(xt, c, t, t1)
+            yield xt
+
+    def forward(
+        self,
+        xt: Tensor,
+        timestep: Optional[Tensor] = None,
+        conditional_inputs: Optional[Dict[str, Tensor]] = None,
+    ) -> Union[DiffusionOutput, Tensor]:
+        if self.training:
+            if timestep is None:
+                raise ValueError("Must provide a timestep value during training")
+            return self.model(xt, timestep, conditional_inputs)
+        else:
+            gen: Iterable = self.generator(xt, conditional_inputs)
+            if self.progress_bar:
+                # Lazy import so that we don't depend on tqdm.
+                from tqdm.auto import tqdm
+
+                gen = tqdm(gen, total=len(self.eval_steps) - 1)
+            for x in gen:
+                pass
+            # pyre-ignore
+            return x

--- a/torchmultimodal/modules/diffusion/ddpm.py
+++ b/torchmultimodal/modules/diffusion/ddpm.py
@@ -1,0 +1,171 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+from typing import Dict, Generator, Iterable, Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from torch import nn, Tensor
+from torchmultimodal.modules.diffusion.predictors import Predictor
+
+from torchmultimodal.modules.diffusion.schedules import DiffusionSchedule
+from torchmultimodal.utils.diffusion_utils import DiffusionOutput
+
+
+class DDPModule(nn.Module):
+    """DDPModule acts as a wrapper module around an inner neural network. During training it uses the
+    inner neural network to predict a single denoising step. When set to eval, calling forward will
+    sample the entire diffusion schedule. This module follows the denoising diffusion process as
+    described in "Denoising Diffusion Probabilistic Models"
+    (https://arxiv.org/abs/2006.11239) and "Improved Denoising Diffusion Probabilistic Models"
+    (https://arxiv.org/abs/2102.09672).
+
+    Example:
+        ddpm_model = DDPModule(model, schedule, predictor)
+        prediction_t = ddpm_model(x_t, t)
+
+        ddpm_model.eval()
+        x_0 = ddpm_model(x_T, T)
+
+    Code ref:
+    https://github.com/openai/improved-diffusion/blob/main/improved_diffusion/gaussian_diffusion.py
+
+    Attributes:
+        model (nn.Module): prediction neural network
+        schedule (DiffusionSchedule): defines diffusion of noise through time
+        predictor (Predictor): predictor class to handle predictions depending on the model input
+        eval_steps (Tensor): subset of steps to sample at inference
+
+    Args:
+        xt (Tensor): corrupted data at time t (when t = schedule.steps, xt is equivalent to noise)
+        timestep (Tensor): diffusion step
+        conditional_inputs (Dict): dictionary of context embeddings
+
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        schedule: DiffusionSchedule,
+        predictor: Predictor,
+        eval_steps: Optional[Tensor] = None,
+        progress_bar: bool = True,
+    ):
+        super().__init__()
+
+        self.model = model
+        self.train_schedule = schedule
+        self.train_predictor = predictor
+        self.progress_bar = progress_bar
+
+        if eval_steps is None:
+            eval_steps = torch.arange(self.train_schedule.steps)
+            eval_steps_map = eval_steps
+            self.eval_schedule = schedule
+            self.eval_predictor = predictor
+        else:
+            # Special schedule for strided sampling from equation 19
+            # in "Improved Denoising Diffusion Probabilistic Models"
+            eval_steps, _ = eval_steps.sort()
+            # eval_map maps from timestep in full schedule, to timestep in truncated eval scheule
+            # e.g. if train has 1000 steps, and eval has 3, then t = 500 would map to eval timestep = 1
+            eval_steps_map = torch.zeros(self.train_schedule.steps, dtype=torch.long)
+            eval_steps_map[eval_steps] = torch.arange(len(eval_steps))
+
+            # Compute cumulative product of only the alphas in the eval steps
+            # Recompute betas based on these cumulative products and create a new schedule with these betas
+            alphas_cumprod = schedule.alphas_cumprod[eval_steps]
+            alphas_cumprod_prev = F.pad(alphas_cumprod[:-1], (1, 0), value=1.0)
+            beta_schedule = 1 - alphas_cumprod / alphas_cumprod_prev
+            self.eval_schedule = copy.deepcopy(schedule)
+            self.eval_schedule.betas = beta_schedule
+            self.eval_predictor = copy.deepcopy(predictor)
+            self.eval_predictor.schedule.betas = beta_schedule
+
+        self.eval_steps: Tensor
+        self.eval_steps_map: Tensor
+        self.register_buffer("eval_steps", eval_steps.to(torch.long))
+        self.register_buffer("eval_steps_map", eval_steps_map)
+
+    def predict_parameters(
+        self, input: DiffusionOutput, xt: Tensor, t: Tensor
+    ) -> Tuple[Tensor, Tensor]:
+        """Given model predictions, corrupted data (x at step t) and noise (x at final step T),
+        compute the predicted normal mean and log_variance for the given diffusion step t.
+
+        Args:
+            input (DiffusionOutput): model output values
+            xt (Tensor): corrupted data at time t
+            t (Tensor): int diffusion steps
+        """
+        pred, value = input.prediction, input.variance_value
+        schedule = self.train_schedule if self.training else self.eval_schedule
+        predictor = self.train_predictor if self.training else self.eval_predictor
+        timestep = t if self.training else self.eval_steps_map[t]
+
+        x0 = predictor.predict_x0(pred, xt, timestep)
+        return schedule.q_posterior(x0, xt, timestep, value)
+
+    def remove_noise(
+        self, xt: Tensor, t: Tensor, c: Optional[Dict[str, Tensor]]
+    ) -> Tensor:
+        """Given corrupted data (x at step t) and noise (x at final step T), compute x denoised
+        by one diffusion step. This is the function p(xt) from
+        https://arxiv.org/abs/2006.11239.
+
+        Args:
+            xt (Tensor): corrupted data at time t
+            t (Tensor): int diffusion steps
+            c (Dict): dictionary of context embeddings
+        """
+        # Model outputs
+        out = self.model(xt, t, c)
+        mean, log_variance = self.predict_parameters(out, xt, t)
+
+        # Predict x_{t-1}
+        dtype = xt.dtype
+        noise = self.train_schedule.sample_noise(xt)
+        # Mask noise when t = 0; shape (b, 1, ..., 1) with same dims as xt
+        nonzero_mask = (t != 0).to(dtype).view(-1, *([1] * (xt.dim() - 1)))
+        # pyre-ignore
+        return mean + nonzero_mask * (0.5 * log_variance).exp() * noise
+
+    def generator(
+        self, xt: Tensor, c: Optional[Dict[str, Tensor]] = None
+    ) -> Generator[Tensor, None, None]:
+        """Generate xt for each t in sample_steps"""
+        for step in self.eval_steps.flip(0):
+            t = step * torch.ones(xt.size(0), device=xt.device, dtype=torch.long)
+            xt = self.remove_noise(xt, t, c)
+            yield xt
+
+    def forward(
+        self,
+        xt: Tensor,
+        timestep: Optional[Tensor] = None,
+        conditional_inputs: Optional[Dict[str, Tensor]] = None,
+    ) -> Union[DiffusionOutput, Tensor]:
+        if self.training:
+            if timestep is None:
+                raise ValueError("Must provide a t value during training")
+            out = self.model(xt, timestep, conditional_inputs)
+            if not isinstance(out, DiffusionOutput):
+                raise TypeError("Model is expected to output a DiffusionOutput class")
+            if out.variance_value is not None:
+                out.mean, out.log_variance = self.predict_parameters(out, xt, timestep)
+            return out
+        else:
+            gen: Iterable = self.generator(xt, conditional_inputs)
+            if self.progress_bar:
+                # Lazy import so that we don't depend on tqdm.
+                from tqdm.auto import tqdm
+
+                gen = tqdm(gen, total=len(self.eval_steps))
+            for x in gen:
+                pass
+            # pyre-ignore
+            return x

--- a/torchmultimodal/modules/diffusion/predictors.py
+++ b/torchmultimodal/modules/diffusion/predictors.py
@@ -1,0 +1,113 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from typing import Callable, Optional
+
+from torch import Tensor
+from torchmultimodal.modules.diffusion.schedules import DiffusionSchedule
+
+
+class Predictor(ABC):
+    """Helper class to help predict various parts of the diffusion process. Different
+    implementations of each method are needed depending on what the model itself was
+    trained to predict.
+    """
+
+    schedule: DiffusionSchedule
+    clamp_func: Optional[Callable]
+
+    @abstractmethod
+    def predict_x0(self, prediction: Tensor, xt: Tensor, t: Tensor) -> Tensor:
+        """Predict x0
+
+        Args:
+            prediction (Tensor): model prediction
+            xt (Tensor): noised data to step t
+            t (Tensor): int diffusion step for xt
+        """
+        pass
+
+    @abstractmethod
+    def predict_noise(self, prediction: Tensor, xt: Tensor, t: Tensor) -> Tensor:
+        """Predict noise
+
+        Args:
+            prediction (Tensor): model prediction
+            xt (Tensor): noised data to step t
+            t (Tensor): int diffusion step for xt
+        """
+        pass
+
+
+class NoisePredictor(Predictor):
+    """Given a model that's trained to predict diffusion noise and corresponding schedule,
+        this class computes the predicted noise and x0 at step t.
+
+    Attributes:
+        schedule (DiffusionSchedule): defines diffusion of noise through time
+        clamp_func (Callable): function to clamp prediction values
+    """
+
+    def __init__(
+        self, schedule: DiffusionSchedule, clamp_func: Optional[Callable] = None
+    ):
+        self.clamp_func = clamp_func
+        schedule.add_property("sqrt_recip_alphas_cumprod", _sqrt_recip_alphas_cumprod)
+        schedule.add_property(
+            "sqrt_recipm1_alphas_cumprod", _sqrt_recipm1_alphas_cumprod
+        )
+        self.schedule = schedule
+
+    def predict_x0(self, prediction: Tensor, xt: Tensor, t: Tensor) -> Tensor:
+        shape, dtype = xt.shape, xt.dtype
+        x_coef = self.schedule("sqrt_recip_alphas_cumprod", t, shape)
+        e_coef = self.schedule("sqrt_recipm1_alphas_cumprod", t, shape)
+        x0 = x_coef * xt - e_coef * prediction
+        if self.clamp_func is not None:
+            x0 = self.clamp_func(x0)
+        return x0.to(dtype)
+
+    def predict_noise(self, prediction: Tensor, xt: Tensor, t: Tensor) -> Tensor:
+        return prediction
+
+
+class TargetPredictor(Predictor):
+    """Given a model that's trained to predict x0 and corresponding schedule,
+        this class computes the predicted noise and x0 at step t.
+
+    Attributes:
+        schedule (DiffusionSchedule): defines diffusion of noise through time
+        clamp_func (Callable): function to clamp prediction values
+    """
+
+    def __init__(
+        self, schedule: DiffusionSchedule, clamp_func: Optional[Callable] = None
+    ):
+        self.clamp_func = clamp_func
+        self.schedule = schedule
+
+    def predict_x0(self, prediction: Tensor, xt: Tensor, t: Tensor) -> Tensor:
+        if self.clamp_func is not None:
+            prediction = self.clamp_func(prediction)
+        return prediction
+
+    def predict_noise(self, prediction: Tensor, xt: Tensor, t: Tensor) -> Tensor:
+        # TODO: For DDIM add predict_noise
+        pass
+
+
+# TODO: Add VPredictor from https://arxiv.org/abs/2202.00512
+
+
+def _sqrt_recip_alphas_cumprod(schedule: DiffusionSchedule) -> Tensor:
+    # pyre-ignore
+    return (1.0 / schedule.alphas_cumprod).sqrt()
+
+
+def _sqrt_recipm1_alphas_cumprod(schedule: DiffusionSchedule) -> Tensor:
+    # pyre-ignore
+    return (1.0 / schedule.alphas_cumprod - 1).sqrt()

--- a/torchmultimodal/modules/diffusion/schedules.py
+++ b/torchmultimodal/modules/diffusion/schedules.py
@@ -1,0 +1,294 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+class DiffusionSchedule:
+    """Diffusion is a thermondynamic process of two substances intermingling, likewise diffusion probabilistic models represent
+    the transformation of one distribution into another as a gradual stochastic process. Specifically, in Denoising Diffusion, we
+    model the transformation from the Gaussian distribution to some data distribution over a number of time steps. DiffusionSchedule
+    is a parameterized helper class to model the changing distribution from Gaussian (noise) to data (x). This is an implementation
+    of a diffusion schedule with discrete time steps.
+
+    DiffusionSchedule manages all timestep properties that are a function of the variance schedule (betas). For example, to
+    calculate the compliment of betas (called alphas in the paper), you define alphas
+
+    def alphas(schedule):
+        return (1.0 - schedule.betas)
+
+    and then call schedule.add_property("alphas", alphas). This will compute the values of alphas and add the attribute to schedule.
+    You can safely use any other existing property to define your new property. If betas is updated (e.g. for a shorter inference
+    time schedule) then all of these attributes will be automatically recomputed.
+
+    The details of diffusion can be found in "Deep Unsupervised Learning using Nonequilibrium Thermodynamics
+    (https://arxiv.org/abs/1503.03585) and "Denoising Diffusion Probabilistic Models" (https://arxiv.org/abs/2006.11239)
+
+    Code ref:
+    https://github.com/hojonathanho/diffusion/blob/master/diffusion_tf/diffusion_utils.py
+
+    Attributes:
+        betas (Tensor): Beta variance value for each time step
+        variance_range_value (float): variance value for reverse diffusion process defined from 0.0 to 1.0. For each step the
+                                      variance lower and upper bound is computed, and this value is used to set the interpolation
+                                      between them.
+    """
+
+    def __init__(self, betas: Tensor, variance_range_value: float = 0.0):
+        super().__init__()
+        if not 0.0 <= variance_range_value <= 1.0:
+            ValueError("Variance_range_value must be between 0 and 1")
+        self._betas = betas
+        self.variance_range_value = variance_range_value
+        self.expressions: Dict[str, Callable] = {}
+
+        self.add_property("alphas", _alphas)
+        self.add_property("alphas_cumprod", _alphas_cumprod)
+        self.add_property("alphas_cumprod_prev", _alphas_cumprod_prev)
+        self.add_property("sqrt_alphas_cumprod", _sqrt_alphas_cumprod)
+        self.add_property(
+            "sqrt_compliment_alphas_cumprod", _sqrt_compliment_alphas_cumprod
+        )
+
+        # Lower and upper bound for forward process variances based on reverse process
+        self.add_property("lower_posterior_log_variance", _lower_posterior_log_variance)
+        self.add_property("upper_posterior_log_variance", _upper_posterior_log_variance)
+
+        # Coefficients for posterior q function (EQ 11 from Improving DDPMs)
+        self.add_property("posterior_mean_x0_coef", _posterior_mean_x0_coef)
+        self.add_property("posterior_mean_xt_coef", _posterior_mean_xt_coef)
+
+    def add_property(self, name: str, expression: Callable) -> None:
+        """Define diffusion schedule properties as functions of schedule
+        An expression should be of the form
+
+        def <func_name>(schedule):
+           return <expr>
+
+        Lambdas aren't allowed as they cannot be pickled. The expression is
+        stored so it can be computed as often as necessary. The property name
+        is used to add an instance attribute the first time the user uses it.
+        e.g. schedule.<name> returns <expression>(self)
+        """
+        assert name not in self.expressions, "Property already exists"
+        assert (
+            expression.__name__ != "<lambda>"
+        ), "Properties must be named functions, lambdas are not picklable"
+        # Expression added to dictionary, expression computed and lazily added as attribute <name> in __getattr__
+        self.expressions[name] = expression
+
+    def _clear_cache(self) -> None:
+        """Clear cached properties, they will be lazily recomputed next time they're called"""
+        for p in self.expressions.keys():
+            # properties are cached as instance variables
+            if p in vars(self):
+                vars(self).pop(p)
+
+    def sample_noise(self, x_like: Tensor) -> Tensor:
+        """Sample from Gaussian distribution"""
+        return torch.randn_like(x_like)
+
+    def sample_steps(self, x_like: Tensor) -> Tensor:
+        """Sample diffusion steps"""
+        b = x_like.size(0)
+        return torch.randint(0, self.steps, (b,), device=x_like.device, dtype=torch.int)
+
+    def q_sample(self, x0: Tensor, noise: Tensor, t: Tensor) -> Tensor:
+        """Given data (x at step 0) and noise, compute xt for the given
+        diffusion t. Function q(xt | x0) from
+        https://arxiv.org/abs/2006.11239.
+
+        Args:
+            x0 (Tensor): uncorrupted data at step 0
+            noise (Tensor): sample noise, same size as x0
+            t (Tensor): int diffusion steps
+        """
+        shape, dtype = x0.shape, x0.dtype
+        x_coef = self("sqrt_alphas_cumprod", t, shape)
+        e_coef = self("sqrt_compliment_alphas_cumprod", t, shape)
+        xt = x_coef * x0 + e_coef * noise
+        return xt.to(dtype)
+
+    def q_posterior(
+        self,
+        x0: Tensor,
+        xt: Tensor,
+        t: Tensor,
+        variance_range_value: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        """Given data (x at step 0) and corrupted data (x at step t), compute normal
+        mean and log_variance for the given diffusion step t. Computes mu(xt, x0) and
+        Sigma(xt, t, v) where v is the interpolation value. Equation 13 and 15 from
+        https://arxiv.org/abs/2102.09672.
+
+        Args:
+            x0 (Tensor): uncorrupted data at step 0
+            xt (Tensor): noised data to step t
+            t (Tensor): int diffusion step for xt
+            variance_range_value (Tensor): variance range if provided by the model
+        """
+        if variance_range_value is None:
+            variance_range_value = torch.ones_like(x0) * self.variance_range_value
+        shape, dtype = xt.shape, xt.dtype
+        min_log = self("lower_posterior_log_variance", t, shape)
+        max_log = self("upper_posterior_log_variance", t, shape)
+        log_variance = (
+            variance_range_value * max_log + (1 - variance_range_value) * min_log
+        )
+        mean = (
+            self("posterior_mean_x0_coef", t, shape) * x0
+            + self("posterior_mean_xt_coef", t, shape) * xt
+        )
+        return mean.to(dtype), log_variance.to(dtype)
+
+    @property
+    def betas(self) -> Tensor:
+        return self._betas
+
+    @betas.setter
+    def betas(self, betas: Tensor) -> None:
+        self._betas = betas
+        self._clear_cache()
+
+    @property
+    def steps(self) -> int:
+        return len(self.betas)
+
+    def __call__(
+        self, var_name: str, t: Tensor, shape: Union[Tensor, torch.Size]
+    ) -> Tensor:
+        """Access a DiffusionSchedule property with a given shape at a given timestep"""
+        tensor = getattr(self, var_name)
+        # Ensure attribute is on same device as timestep tensor
+        if tensor.device != t.device:
+            tensor = tensor.to(t.device)
+            setattr(self, var_name, tensor)
+        b = t.numel()
+        out = tensor.gather(-1, t.long())
+        return out.reshape(b, *((1,) * (len(shape) - 1)))
+
+    def __getattr__(self, name: str) -> Any:
+        """Override object __getattr__ to lazily evaluate expressions.
+        __getattr__ is called when __getattribute__ fails, i.e. when attribute <name> is not defined
+        The first time a user accesses a property (schedule.<name>), __getattr__ will be called and
+        compute the expression and save it as an instance attribute
+        """
+        if name in object.__getattribute__(self, "expressions"):
+            value = object.__getattribute__(self, "expressions")[name](self)
+            setattr(self, name, value)
+            return value
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'"
+        )
+
+
+# **************************************** Scheduler Functions ****************************************
+def _alphas(schedule: DiffusionSchedule) -> Tensor:
+    return 1.0 - schedule.betas
+
+
+def _alphas_cumprod(schedule: DiffusionSchedule) -> Tensor:
+    return schedule.alphas.cumprod(axis=0)
+
+
+def _alphas_cumprod_prev(schedule: DiffusionSchedule) -> Tensor:
+    return F.pad(schedule.alphas_cumprod[:-1], (1, 0), value=1.0)
+
+
+def _sqrt_alphas_cumprod(schedule: DiffusionSchedule) -> Tensor:
+    return schedule.alphas_cumprod.sqrt()
+
+
+def _sqrt_compliment_alphas_cumprod(schedule: DiffusionSchedule) -> Tensor:
+    # pyre-ignore
+    return (1.0 - schedule.alphas_cumprod).sqrt()
+
+
+def _lower_posterior_log_variance(schedule: DiffusionSchedule) -> Tensor:
+    # First element is 0 which has an infinite log (EQ 15 from Improving DDPMs)
+    compliment_alphas_bar = 1.0 - schedule.alphas_cumprod
+    compliment_alphas_bar_prev = 1.0 - schedule.alphas_cumprod_prev
+    lpv = schedule.betas * compliment_alphas_bar_prev / compliment_alphas_bar
+    # pyre-ignore
+    lpv = torch.cat([lpv[1:2], lpv[1:]])
+    return lpv.log()
+
+
+def _upper_posterior_log_variance(schedule: DiffusionSchedule) -> Tensor:
+    return schedule.betas.log()
+
+
+def _posterior_mean_x0_coef(schedule: DiffusionSchedule) -> Tensor:
+    alphas_cumprod_prev_sqrt = schedule.alphas_cumprod_prev.sqrt()
+    compliment_alphas_cumprod = 1.0 - schedule.alphas_cumprod
+    return schedule.betas * alphas_cumprod_prev_sqrt / compliment_alphas_cumprod
+
+
+def _posterior_mean_xt_coef(schedule: DiffusionSchedule) -> Tensor:
+    compliment_alphas_cumprod_prev = 1.0 - schedule.alphas_cumprod_prev
+    alphas_sqrt = schedule.alphas.sqrt()
+    compliment_alphas_cumprod = 1.0 - schedule.alphas_cumprod
+    return compliment_alphas_cumprod_prev * alphas_sqrt / compliment_alphas_cumprod
+
+
+# **************************************** Beta schedules ****************************************
+def cosine_beta_schedule(timesteps: int, s: float = 0.008) -> Tensor:
+    """
+    Diffusion variances from step 0 to T, following a cosine function
+    as proposed in "Improved Denoising Diffusion Probabilistic Models"
+    (https://arxiv.org/abs/2102.09672)
+    """
+    steps = timesteps + 1
+    x = torch.linspace(0, timesteps, steps, dtype=torch.float64)
+    alphas_cumprod = torch.cos(((x / timesteps) + s) / (1 + s) * torch.pi * 0.5).pow(2)
+    alphas_cumprod = alphas_cumprod / alphas_cumprod[0]
+    betas = 1 - (alphas_cumprod[1:] / alphas_cumprod[:-1])
+    return torch.clip(betas, 0, 0.999)
+
+
+def linear_beta_schedule(
+    timesteps: int, start: Optional[float] = None, end: Optional[float] = None
+) -> Tensor:
+    """
+    Diffusion variances from step 0 to T, following a linear function
+    """
+    scale = 1000 / timesteps
+    beta_start = scale * 0.0001 if start is None else start
+    beta_end = scale * 0.02 if end is None else end
+    return torch.linspace(beta_start, beta_end, timesteps, dtype=torch.float64)
+
+
+def quadratic_beta_schedule(
+    timesteps: int, start: Optional[float] = None, end: Optional[float] = None
+) -> Tensor:
+    """
+    Diffusion variances from step 0 to T, following a quadratic function
+    """
+    scale = 1000 / timesteps
+    beta_start = scale * 0.0001 if start is None else start
+    beta_end = scale * 0.02 if end is None else end
+    return torch.linspace(
+        math.sqrt(beta_start), math.sqrt(beta_end), timesteps, dtype=torch.float64
+    ).pow(2)
+
+
+def sigmoid_beta_schedule(
+    timesteps: int, start: Optional[float] = None, end: Optional[float] = None
+) -> Tensor:
+    """
+    Diffusion variances from step 0 to T along a sigmoid curve
+    """
+    scale = 1000 / timesteps
+    beta_start = scale * 0.0001 if start is None else start
+    beta_end = scale * 0.02 if end is None else end
+    # the range [-6, 6] constitutes a majority of the sigmoid curve
+    betas = torch.linspace(-6, 6, timesteps, dtype=torch.float64)
+    return torch.sigmoid(betas) * (beta_end - beta_start) + beta_start

--- a/torchmultimodal/modules/losses/diffusion.py
+++ b/torchmultimodal/modules/losses/diffusion.py
@@ -1,0 +1,168 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import torch
+from torch import nn, Tensor
+from torchmultimodal.modules.diffusion.schedules import DiffusionSchedule
+
+
+class DiffusionHybridLoss(nn.Module):
+    """
+    Combines both simple loss (typically MSE) and VLB loss weighted by lambda, as described in Eq. 16 of
+    "Improved Denoising Diffusion Probabilistic Models" (https://arxiv.org/abs/2102.09672).
+    VLB loss is only used to train the model learned variance.
+
+    Attributes:
+        schedule (DiffusionSchedule): defines diffusion of noise through time
+        simple_loss (nn.Module): loss function computed on prediction of diffusion model and desired target
+            (typically noise). Default is nn.MSELoss.
+        lmbda (float): lambda weight for vlb loss. Default is 0.001.
+
+    Args:
+        input (Tensor): prediction of diffusion model of shape [b, c, ...]
+        target (Tensor): desired target of shape [b, c, ...]
+        mean (Tensor): predicted mean of posterior/xt of shape [b, c, ...]
+        log_variance (Tensor): predicted log variance of posterior/xt of shape [b, c, ...]
+        x0 (Tensor): data sample of shape [b, c,...]
+        xt (Tensor): noised data sample from diffusion process of shape [b, c, ...]
+        t (Tensor): diffusion timesteps of shape [b, ]
+
+    """
+
+    def __init__(
+        self,
+        schedule: DiffusionSchedule,
+        simple_loss: nn.Module = nn.MSELoss(),
+        lmbda: float = 0.001,
+    ):
+        super().__init__()
+        self.simple_loss = simple_loss
+        self.vlb_loss = VLBLoss(schedule)
+        self.lmbda = lmbda
+
+    def forward(
+        self,
+        input: Tensor,
+        target: Tensor,
+        mean: Tensor,
+        log_variance: Tensor,
+        x0: Tensor,
+        xt: Tensor,
+        t: Tensor,
+    ) -> Tensor:
+        # Detach mean as stop gradient for vlb loss
+        # Weight the vlb loss smaller, for stability, when training in a hybrid setting using
+        # another criterion to train the predictor as in the paper (recommended 0.001)
+        return self.simple_loss(input, target) + self.lmbda * self.vlb_loss(
+            mean.detach(), log_variance, x0, xt, t
+        )
+
+
+class VLBLoss(nn.Module):
+    """VLBLoss minimizes the KL divergence between the distribution of the forward diffusion process (noising) and the
+    learned reverse process (denoising). Its name is derived from the Variational Lower Bound which is being optimized.
+    This loss function can be used on it's own or used in conjunction with a simpler loss method as proposed by
+    Nicol & Dhariwal 2021.
+
+    The details of the loss function are described in "Denoising Diffusion Probabilistic Models"
+    (https://arxiv.org/abs/2006.11239) and "Improved Denoising Diffusion Probabilistic Models"
+    (https://arxiv.org/abs/2102.09672)
+
+    Code ref:
+    https://github.com/openai/improved-diffusion/blob/main/improved_diffusion/losses.py
+
+    Attributes:
+        schedule (DiffusionSchedule): defines diffusion of noise through time
+
+    Args:
+        pred_mean (Tensor): predicted mean for time t
+        pred_log_variance (Tensor): predicted log variance for time t
+        x0 (Tensor): target data point
+        xt (Tensor): corrupted datapoint
+        t (Tensor): diffusion step
+
+    """
+
+    def __init__(self, schedule: DiffusionSchedule):
+        super().__init__()
+        self.schedule = schedule
+
+    def approx_standard_normal_cdf(self, x: Tensor) -> Tensor:
+        return 0.5 * (
+            1.0 + torch.tanh(((2.0 / math.pi) ** 0.5) * (x + 0.044715 * (x.pow(3))))
+        )
+
+    def discretized_gaussian_log_likelihood(
+        self,
+        x: Tensor,
+        mean: Tensor,
+        log_scale: Tensor,
+        thres: float = 0.999,
+        eps: float = 1e-12,
+    ) -> Tensor:
+        if not x.shape == mean.shape == log_scale.shape:
+            ValueError("x, mean, and log_scale must all be the same shape")
+        # TODO: lucidrain found eps = 1e-3 worked better for fp16
+        centered_x = x - mean
+        inv_stdv = torch.exp(-log_scale)
+        plus_in = inv_stdv * (centered_x + 1.0 / 255.0)
+        cdf_plus = self.approx_standard_normal_cdf(plus_in)
+        min_in = inv_stdv * (centered_x - 1.0 / 255.0)
+        cdf_min = self.approx_standard_normal_cdf(min_in)
+        log_cdf_plus = cdf_plus.clamp(min=eps).log()
+        log_one_minus_cdf_min = (1.0 - cdf_min).clamp(min=eps).log()
+        cdf_delta = cdf_plus - cdf_min
+
+        log_probs = torch.where(
+            x < -thres,
+            log_cdf_plus,
+            torch.where(
+                x > thres, log_one_minus_cdf_min, cdf_delta.clamp(min=eps).log()
+            ),
+        )
+
+        return log_probs
+
+    def meanflat(self, x: Tensor) -> Tensor:
+        return x.mean(dim=tuple(range(1, len(x.shape))))
+
+    def normal_kl(
+        self, x_mean: Tensor, x_log_var: Tensor, p_mean: Tensor, p_log_var: Tensor
+    ) -> Tensor:
+        return 0.5 * (
+            -1.0
+            + p_log_var
+            - x_log_var
+            + (x_log_var - p_log_var).exp()
+            + ((x_mean - p_mean).pow(2)) * (-p_log_var).exp()
+        )
+
+    def forward(
+        self,
+        pred_mean: Tensor,
+        pred_log_var: Tensor,
+        x0: Tensor,
+        xt: Tensor,
+        t: Tensor,
+    ) -> Tensor:
+        # Compute Targets
+        mean, log_variance = self.schedule.q_posterior(x0, xt, t)
+
+        nat = 1.0 / math.log(2.0)
+        kl = self.normal_kl(mean, log_variance, pred_mean, pred_log_var)
+        kl = self.meanflat(kl) * nat
+
+        decoder_nll = -self.discretized_gaussian_log_likelihood(
+            x0, mean=pred_mean, log_scale=0.5 * pred_log_var
+        )
+        decoder_nll = self.meanflat(decoder_nll) * nat
+
+        # At the first timestep return the decoder NLL, otherwise return KL(q(x_{t-1}|x_t,x_0) || p(x_{t-1}|x_t))
+        losses = torch.where(t == 0, decoder_nll, kl)
+
+        return losses.mean()

--- a/torchmultimodal/transforms/diffusion_transforms.py
+++ b/torchmultimodal/transforms/diffusion_transforms.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+from typing import List, Tuple, Union
+
+import torch
+import torchvision.transforms as tv
+from PIL.Image import Image
+
+from torch import nn, Tensor
+from torchmultimodal.modules.diffusion.schedules import DiffusionSchedule
+from torchmultimodal.utils.diffusion_utils import cascaded_resize
+
+
+def normalize(x: Tensor, image_min: int, image_max: int) -> Tensor:
+    # Normalize image values between min and max
+    return (image_max - image_min) * x + image_min
+
+
+class Dalle2ImageTransform(nn.Module):
+    """Dalle image transform normalizes the data between a min and max value. Defaults
+    are -1 and 1 like the Dalle2 Paper.
+
+    Args:
+        image_size (int): desired output image size.
+        image_min (float): min of images, used for normalization.
+        image_max (float): max of images, used for normalization.
+
+    Inputs:
+        image (Union[List[Image], Image]): Image or batch of images upon which
+            to apply the transform.
+    """
+
+    def __init__(
+        self,
+        image_size: int = 64,
+        image_min: float = -1.0,
+        image_max: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.image_transform = tv.Compose(
+            [
+                partial(cascaded_resize, resolution=image_size),
+                tv.CenterCrop(image_size),
+                tv.ToTensor(),
+                partial(normalize, image_min=image_min, image_max=image_max),
+            ]
+        )
+
+    def forward(self, image: Union[List[Image], Image]) -> Tensor:
+        if isinstance(image, Image):
+            image = [image]
+        # pyre-ignore
+        image_result = torch.stack([self.image_transform(x) for x in image])
+        return image_result
+
+
+class RandomDiffusionSteps(nn.Module):
+    """Data Transform to randomly sample noised data from the diffusion schedule.
+    During diffusion training, random diffusion steps are sampled per model update.
+    This transform samples steps and returns the steps (t), seed noise, and transformed
+    data at time t (xt).
+
+    Attributes:
+        schedule (DiffusionSchedule): defines diffusion of noise through time
+        batched (bool): if True, transform expects a batched input
+
+    Args:
+        x (Tensor): data representing x0, artifact being learned. The 0 represents zero diffusion steps.
+    """
+
+    def __init__(self, schedule: DiffusionSchedule, batched: bool = True):
+        super().__init__()
+        self.schedule = schedule
+        self.batched = batched
+
+    def __call__(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        if not self.batched:
+            t = self.schedule.sample_steps(x.unsqueeze(0))
+            t = t.squeeze(0)
+        else:
+            t = self.schedule.sample_steps(x)
+        noise = self.schedule.sample_noise(x)
+        xt = self.schedule.q_sample(x, noise, t)
+        return x, xt, noise, t

--- a/torchmultimodal/utils/diffusion_utils.py
+++ b/torchmultimodal/utils/diffusion_utils.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from typing import Optional
+
+import PIL
+import torch
+from PIL.Image import Image
+from torch import Tensor
+
+
+@dataclass
+class DiffusionOutput:
+    prediction: Tensor
+    variance_value: Optional[Tensor] = None
+    mean: Optional[Tensor] = None
+    log_variance: Optional[Tensor] = None
+
+
+def cascaded_resize(pil_image: Image, resolution: int) -> Image:
+    """Cascaded resizing
+    Based on D2Go: https://fburl.com/nxlme9rj, resize by powers of 2 to nearest power of 2
+    for improved BICUBIC performance.
+
+    Args:
+        image (Image): PIL image
+        resolution (int): image minimum size target
+    """
+    while min(*pil_image.size) >= 2 * resolution:
+        pil_image = pil_image.resize(
+            tuple(x // 2 for x in pil_image.size), resample=PIL.Image.BOX
+        )
+    scale = resolution / min(*pil_image.size)
+    pil_image = pil_image.resize(
+        tuple(round(x * scale) for x in pil_image.size),
+        resample=PIL.Image.BICUBIC,
+    )
+
+    return pil_image
+
+
+def denormalize_to_0_1(images: Tensor) -> Tensor:
+    """Denormalize tensors from range [-1, 1] to [0, 1]"""
+    denormed_images = torch.clamp((images + 1) / 2, 0, 1)
+
+    return denormed_images


### PR DESCRIPTION
Summary: This is the first in a stack of diffs to transfer all the diffusion components to OSS. This diff will be responsible for copying each components into the appropriate directory in OSS and test that nothing breaks during moving. Please comment on the structure/location of the new files. The following diffs will handle updating fbcode imports and removing the duplicated files from fb/generation.

Differential Revision: D45832058

