### PR TITLE
Add  __init__.py to diffusion folder to make a package

### DIFF
--- a/torchmultimodal/modules/diffusion/__init__.py
+++ b/torchmultimodal/modules/diffusion/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
Same as title. Missing __init__.py file causes folder to not be packaged in our pip wheel.

Test plan:
No real code change.

Fixes failed nightly build