### PR TITLE
Enable PT2 for dalle2 with old FSDP api

### DIFF
--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -50,8 +50,7 @@ def shift_dim(
 
     assert 0 <= src_dim < n_dims and 0 <= dest_dim < n_dims
 
-    dims = list(range(n_dims))
-    del dims[src_dim]
+    dims = [i for i in range(n_dims) if i != src_dim]
 
     permutation = []
     ctr = 0


### PR DESCRIPTION
Summary:
Enable PT2 for dalle2 models.

1. Add device to a tensor in position_embedding.py. Otherwise, PT2 compilation will fail. Earlier post by Philip: https://fb.workplace.com/groups/1405155842844877/permalink/6873941872632886/.
2. Remove the usage of del in torchmultimodal/utils/common.py. Otherwise, there will be lots of graph breaks.
3. Fix the FSDP fully_shard API compatibility issue. Switch to old FSDP API instead of fully_shard. Also fix the module self problem in torchmultimodal/fb/genai/models/adm.py. https://fb.workplace.com/groups/1075192433118967/permalink/1257752721529603/
4. Add a compile option under trainer. Default to False. Update it to True once we have longer term results.

Speedup:
1. 14% on local benchmark on one GPU: D46597744.
2. 11% on 32x8 end to end runs. (3.7k -> 4.1k).

{F1030275532}

Reviewed By: avilay

Differential Revision: D46789408

