### PR TITLE
Dont use scaler for bf16

### DIFF
--- a/examples/flava/native/train.py
+++ b/examples/flava/native/train.py
@@ -117,7 +117,11 @@ class Trainer:
             else torch.float16
         )
 
-        self.scaler = ShardedGradScaler() if config.training.enable_amp else None
+        self.scaler = (
+            ShardedGradScaler()
+            if config.training.enable_amp and self.half_dtype == torch.float16
+            else None
+        )
 
     def log(
         self,


### PR DESCRIPTION
Summary: ShardedGradScaler not needed for bf16 training.

Differential Revision: D47218367

