### PR TITLE
Support returning hidden state in CLIPTextEncoder

### DIFF
--- a/torchmultimodal/models/clip/text_encoder.py
+++ b/torchmultimodal/models/clip/text_encoder.py
@@ -16,8 +16,8 @@ from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
 
 
 class CLIPTextEncoderOutput(NamedTuple):
-    projected_embeddings: torch.Tensor
-    hidden_state: torch.Tensor
+    projected_embeddings: Tensor
+    hidden_state: Tensor
 
 
 class CLIPTextEncoder(nn.Module):


### PR DESCRIPTION
Summary:
Added a `return_hidden_state` arg in CLIPTextEncoder. If set to True, forward will return a tuple of final embedding and the last hidden state.

Test plan:
pytest tests/models/clip/test_text_encoder.py

cc @abhinavarora Moved code to here for easier review and testing.