### PR TITLE
add parallel_attention_blocks

### DIFF
--- a/tests/modules/layers/test_normalizations.py
+++ b/tests/modules/layers/test_normalizations.py
@@ -5,7 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from torchmultimodal.modules.layers.normalizations import Fp32GroupNorm, Fp32LayerNorm
+import torch.nn.functional as F
+import torch.nn as nn
+
+from torchmultimodal.modules.layers.normalizations import (
+    Fp32GroupNorm,
+    Fp32LayerNorm,
+    RMSNorm,
+)
+
+from tests.test_utils import gpu_test
 
 
 def test_fp32layernorm():
@@ -20,3 +29,45 @@ def test_fp32groupnorm():
     norm = Fp32GroupNorm(2, 4)
     output = norm(x)
     assert output.dtype == torch.float16
+
+
+def test_RMSNorm_fp32return():
+    """verify type is returned as fp32"""
+    dims = 512
+    x = torch.empty(dims, dtype=torch.float16)
+    norm = RMSNorm(
+        dims,
+    )
+    output = norm(x)
+    assert output.dtype == torch.float32
+
+
+@gpu_test(1)
+def test_RMSNorm_core_algo():
+    """compare RMSNorm with RMSNorm using F.norm version"""
+
+    dims = 1024
+    x = torch.empty(dims, dtype=torch.float16, device="cuda")
+    x2 = x.clone().detach()
+
+    class RMSNormFunctional(nn.Module):
+        def __init__(self, dim, eps=1e-6):
+            super().__init__()
+            self.scale = dim**0.5
+            self.weights = nn.Parameter(torch.ones(dim))
+            self.eps = eps
+
+        def forward(self, x):
+            return F.normalize(x, dim=-1, eps=self.eps) * self.scale * self.weights
+
+    baseNorm = RMSNorm(
+        dims,
+    ).to("cuda")
+    backupNorm = RMSNormFunctional(
+        dims,
+    ).to("cuda")
+
+    output_base = baseNorm(x)
+    output_backup = backupNorm(x2)
+
+    assert torch.allclose(output_base, output_backup)

--- a/torchmultimodal/modules/layers/normalizations.py
+++ b/torchmultimodal/modules/layers/normalizations.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Any
-
+import torch
 from torch import nn, Tensor
 
 
@@ -45,3 +45,17 @@ class Fp32GroupNorm(nn.GroupNorm):
             self.eps,
         )
         return output.type_as(x)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight

--- a/torchmultimodal/modules/layers/parallel_blocks.py
+++ b/torchmultimodal/modules/layers/parallel_blocks.py
@@ -1,0 +1,259 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from packaging import version
+from typing import Optional
+import math
+
+from normalizations import RMSNorm
+from position_embedding import RotaryEmbedding
+
+
+def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """expands kv_heads to match q num_heads
+    via
+    torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+
+    bs, slen, n_kv_heads, head_dim = x.shape
+
+    if n_rep == 1:
+        return x
+    return (
+        x[:, :, :, None, :]
+        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
+        .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
+    )
+
+
+class ParallelAttentionBlock(nn.Module):
+    """
+    Transformer layer multi-head attention and MLP, in a parallelized fashion rather than sequential,
+    with optional attention masking.
+    Inspired by PaLM:  https://arxiv.org/abs/2204.02311
+
+    * We use SwiGLU for the activation function
+    * SwiGLU will approximate same total num params as traditional MLP with GELU
+    * Cross Attention is not enabled here (but available)
+    * MQA and GQA are enabled - modify heads via 'num_heads_group_query_attn'
+    * Bias is enabled by default.  Experiment with removing via use...bias = False, for your application.
+    * Parallel blocks have automated weight initialization via _init_weights.
+    * Please pass in num_layers of your model in num_layers for the weight initialization.
+
+
+    """
+
+    def __init__(
+        self,
+        emb_dimension,
+        num_heads,
+        head_dimension=None,
+        mlp_expansion_ratio: float = 2.6875,  # 8/3 is param matching
+        qk_normalization: bool = True,
+        projection_dropout: float = 0.0,
+        attention_dropout: float = 0.0,
+        use_group_query_attention: bool = True,
+        num_heads_group_query_attention: int = 1,
+        use_in_projection_bias: bool = True,
+        use_out_projection_bias: bool = True,
+        use_weight_init: bool = True,
+        num_layers: int = 1,
+        use_rms_norm: bool = True,
+        use_rotary_embeddings: bool = False,
+        max_expected_seq_len: int = 2048,  # needed only if using rotary
+    ):
+        super().__init__()
+
+        version_check = not version.parse(torch.__version__) < version.parse("2.0.0")
+        assert (
+            version_check
+        ), f"Parallel Attention Blocks requires PT 2.0+, you are running {torch.__version__}.\nPlease upgrade your PyTorch version."
+
+        self.num_heads = num_heads
+        self.emb_dim = emb_dimension
+        self.head_dim = head_dimension if head_dimension else emb_dimension // num_heads
+        assert (
+            self.emb_dim % self.num_heads == 0
+        ), f"dimensions {self.emb_dim.shape} must be evenly divisible by num_heads {num_heads=}"
+
+        # group query attn
+        if use_group_query_attention:
+            assert (
+                self.num_heads % num_heads_group_query_attention == 0
+            ), f"num_mha_heads {self.num_heads} not evenly divisible by num_heads_group_query_attention {num_heads_group_query_attention}"
+
+        self.use_variable_kv = use_group_query_attention
+        self.group_num_kv = num_heads_group_query_attention
+        self.num_kv = self.group_num_kv if self.use_variable_kv else self.num_heads
+        self.kv_head_dims = self.head_dim * self.num_kv
+        self.kv_expansion_factor = int(self.num_heads / self.group_num_kv)
+        assert (
+            self.kv_expansion_factor > 0
+        ), f"kv expansion factor must be positive integer, got {self.kv_expansion_factor=}"
+
+        self.mlp_hidden_dim = int(mlp_expansion_ratio * self.emb_dim)
+
+        self.qk_norm: bool = qk_normalization
+
+        self.attention_dropout = nn.Dropout(attention_dropout)
+        self.mlp_dropout = nn.Dropout(projection_dropout)
+
+        # weight init
+        self.num_layers = num_layers
+        self.use_weight_init = use_weight_init
+        if self.use_weight_init:
+            assert (
+                self.num_layers > 1
+            ), f"Need to pass in global num layers for weight init"
+
+        self.weight_init_standard_dev = 0.02 / math.sqrt(2 * self.num_layers)
+
+        self.use_in_projection_bias = use_in_projection_bias
+        self.use_out_projection_bias = use_out_projection_bias
+
+        # previous init params, moved to internal defaults for streamlining
+        normalization_layer = RMSNorm if use_rms_norm else nn.LayerNorm
+        self.mlp_activation = nn.SiLU()
+
+        self.num_q = 1
+
+        self.in_proj_dims = [
+            self.head_dim * num_heads * self.num_q,
+            self.kv_head_dims,
+            self.kv_head_dims,
+            self.mlp_hidden_dim,
+            self.mlp_hidden_dim,
+        ]  # q, k, v, mlp, gate
+
+        # layer objects
+        self.in_norm = normalization_layer(emb_dimension)
+        self.in_proj = nn.Linear(
+            emb_dimension, sum(self.in_proj_dims), bias=use_in_projection_bias
+        )
+
+        self.q_norm = normalization_layer(self.head_dim)
+        self.k_norm = normalization_layer(self.head_dim)
+
+        # fused out projection
+        fused_out_input_dim = emb_dimension + self.mlp_hidden_dim
+        self.out_fused_proj = nn.Linear(
+            fused_out_input_dim, emb_dimension, bias=use_out_projection_bias
+        )
+
+        # rotary embeddings
+        if use_rotary_embeddings:
+            self.rotary_emb = RotaryEmbedding(emb_dimension, max_expected_seq_len)
+        else:
+            self.rotary_emb = None
+
+        # init weights
+        if use_weight_init:
+            self.apply(self._init_weights)
+
+    def _init_weights(self, module: nn.Module):
+        """init weights using trunc + llama style depth scaling"""
+        if isinstance(module, nn.Linear):
+            torch.nn.init.trunc_normal_(
+                module.weight,
+                mean=0.0,
+                # std_dev = 0.02 / math.sqrt(2 * self.num_layers)
+                std=self.weight_init_standard_dev,
+            )
+
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cross_x: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+        cross_mask: Optional[torch.Tensor] = None,
+        rel_pos_bias: Optional[torch.Tensor] = None,
+        has_causal_mask: bool = False,
+    ):
+        """TODO:   No KV cache support yet"""
+
+        assert not (
+            rel_pos_bias is not None and self.rotary_emb is not None
+        ), "Rotary and additive biases are exclusive"
+        assert not (
+            (rel_pos_bias is not None or attn_mask is not None) and has_causal_mask
+        ), "Causal mask optimization only valid without attn_mask or rel_pos_bias"
+
+        batch_size, seq_len, channels = x.shape
+
+        y = self.in_norm(x)
+        y = self.in_proj(y)
+
+        q, k, v, inner_mlp, gate = torch.split(y, self.in_proj_dims, dim=-1)
+
+        # b n nq h d
+        q = q.view(batch_size, seq_len, self.num_q, self.num_heads, self.head_dim)
+
+        q = q[:, :, 0].transpose(2, 1)
+
+        if self.rotary_emb:
+            start_pos = 0  # TODO: No kv-cache yet, when that happens this is seqlen saved in kv-cache
+            q, k = self.rotary_emb(q, k, start_pos)
+
+        # group query expansion
+        def kv_expansion(head):
+            head = head.view(
+                batch_size, seq_len, self.num_kv, self.head_dim
+            )  # b n hnum dimh
+            # bs, slen, n_kv_heads, head_dim = x.shape
+            if self.use_variable_kv and self.num_kv > 1:
+                head = repeat_kv(head, n_rep=self.kv_expansion_factor)
+            return head.transpose(2, 1)  # b hnum n dimh
+
+        k = kv_expansion(k)
+        v = kv_expansion(v)
+
+        if self.qk_norm:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+
+        # Merge rel pos bias and mask into single float mask
+        if rel_pos_bias is None:
+            # Given SDPA API, we expect users to either provide a boolean mask if
+            # they expect masked_fill to be done inside SDPA, or provide the float
+            # mask already with the correct -inf
+            attn_mask = mask  # b? ...? nq nk
+        else:
+            attn_mask = rel_pos_bias  # b? ...? nq nk
+
+            # We expect the shapes of mask and rel_pos_bias to be at least broadcastable
+            if mask is not None:
+                # Can't do in-place op in case broadcast makes attn_mask bigger
+                attn_mask = attn_mask.masked_fill(mask == 0, -float("inf"))
+
+        final_attn = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=attn_mask,
+            dropout_p=self.attention_dropout.p,
+            is_causal=has_causal_mask,
+        )
+
+        final_attn = (
+            final_attn.transpose(2, 1)
+            .contiguous()
+            .view(batch_size, seq_len, self.head_dim * self.num_heads)
+        )
+
+        # swiglu
+        activated_mlp = self.mlp_activation(inner_mlp) * gate
+
+        if self.mlp_dropout.p:
+            activated_mlp = self.mlp_dropout(activated_mlp)
+
+        y = torch.cat((final_attn, activated_mlp), dim=2)
+
+        y = self.out_fused_proj(y)
+
+        # Add residual
+        x = x + y
+        return x

--- a/torchmultimodal/modules/layers/position_embedding.py
+++ b/torchmultimodal/modules/layers/position_embedding.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 from torch import nn, Tensor
@@ -169,3 +169,98 @@ class SinusoidalPositionEmbeddings(nn.Module):
         if self.embed_dim % 2 == 1:
             embeddings = nn.functional.pad(embeddings, (0, 1))
         return embeddings
+
+
+class RotaryEmbedding(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        max_position_embeddings: int = 2048,
+        ratio: int = 10000,
+        device=None,
+    ):
+        """
+        Args
+        ----
+        dim : int
+            Per-head embedding dimension
+        max_position_embeddings : int
+            Maximum expected sequence length for the model, if exceeded the cached freqs will be recomputed
+        ratio: int
+            The ratio for the geometric progression to compute the rotation angles
+        """
+        super(RotaryEmbedding, self).__init__()
+        self.register_buffer(
+            "freqs",
+            1.0
+            / (
+                ratio
+                ** (torch.arange(0, dim, 2, device=device)[: (dim // 2)].float() / dim)
+            ),
+        )
+        self.compute_freqs_cis(max_position_embeddings)
+
+    def compute_freqs_cis(self, max_position_embeddings=2048):
+        t = torch.arange(
+            max_position_embeddings, device=self.freqs.device, dtype=self.freqs.dtype
+        )
+        freqs = torch.outer(t, self.freqs).float()
+        self.max_seq_len_cached = max_position_embeddings
+        self.register_buffer(
+            "cached_freqs",
+            torch.stack(
+                [
+                    torch.cos(freqs),
+                    -torch.sin(freqs),
+                    torch.sin(freqs),
+                    torch.cos(freqs),
+                ],
+                dim=2,
+            ).view(*freqs.shape, 2, 2),
+        )
+
+    def reshape_for_broadcast(self, x: torch.Tensor, cur_freqs):
+        ndim = x.ndim
+        assert 1 < ndim
+        assert cur_freqs.shape[:2] == (x.shape[2], x.shape[-2])
+        shape = [d if i == 2 or i >= ndim - 2 else 1 for i, d in enumerate(x.shape)]
+        return cur_freqs.view(*shape, 2)
+
+    def forward(
+        self, q: torch.Tensor, k: torch.Tensor, start_pos: Union[int, torch.LongTensor]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Args
+        ----
+        q : torch.Tensor
+            Embedded query tensor, expected size is B x H x S x Eh
+        k : torch.Tensor
+            Embedded query tensor, expected size is B x H x S x Eh
+        start_pos : Union[int, torch.LongTensor]
+            The starting position of the tokens encoded in q and k. This is important in
+            kv-caching and left-padding situations, for which the rotation to be applied might
+            not always be the pre-cached position 0...S. For kv-caching without dynamic batching
+            start_pos is shared for all the batch.
+        """
+        seq_len = q.shape[2]
+        q_ = q.float().reshape(*q.shape[:-1], -1, 2)  # B H L D/2 2
+        k_ = k.float().reshape(*k.shape[:-1], -1, 2)  # B H L D/2 2
+
+        if isinstance(start_pos, int):
+            if start_pos + seq_len > self.max_seq_len_cached:
+                self.compute_freqs_cis(start_pos + seq_len)
+            cur_freqs = self.cached_freqs[start_pos : start_pos + seq_len]
+            freqs = self.reshape_for_broadcast(q_, cur_freqs)
+        else:
+            max_start_pos = torch.max(start_pos).item()
+            if max_start_pos + seq_len > self.max_seq_len_cached:
+                self.compute_freqs_cis(max_start_pos + seq_len)
+            freqs_idxs = torch.arange(0, seq_len, dtype=torch.long).repeat(
+                start_pos.shape[0]
+            ).view(-1, seq_len) + start_pos.view(-1, 1)
+            freqs = self.cached_freqs[freqs_idxs].unsqueeze(1)
+
+        freqs = freqs.float()  # 1 1 L D/2 2 2
+        q_out = freqs.mul(q_.unsqueeze(-2)).sum(5).flatten(3)
+        k_out = freqs.mul(k_.unsqueeze(-2)).sum(5).flatten(3)
+        return q_out.type_as(q).contiguous(), k_out.type_as(k).contiguous()


### PR DESCRIPTION
Summary:
This PR adds Parallel Attention blocks to Torch MultiModal. 
There are 3 main additions:
a - Rotary Embeddings 
b - RMS Norm
c - Parallel_Blocks 

Test plan:
Code has been tested separately in ViT and LLM applications and with rotary unit tests.  
However, a general unit test needs to be added along with rotary unit tests being migrated. 
