### PR TITLE
Add transformer decoder layer

### DIFF
--- a/tests/modules/layers/test_transformer.py
+++ b/tests/modules/layers/test_transformer.py
@@ -10,6 +10,8 @@ import torch
 from tests.test_utils import assert_expected, init_weights_with_constant, set_rng_seed
 from torch import Tensor
 from torchmultimodal.modules.layers.transformer import (
+    TransformerDecoder,
+    TransformerDecoderLayer,
     TransformerEncoder,
     TransformerEncoderLayer,
     TransformerOutput,
@@ -195,3 +197,426 @@ class TestTransformerEncoder:
         model = get_encoder(norm_first)
         scripted_model = torch.jit.script(model)
         assert_expected(scripted_model(inputs), model(inputs), rtol=0, atol=1e-4)
+
+
+class TestTransformerDecoderLayer:
+    @pytest.fixture
+    def get_decoder_layer(self):
+        def create_layer(d_model, norm_first, use_cross_attention, custom_init=False):
+            model = TransformerDecoderLayer(
+                d_model=d_model,
+                n_head=1,
+                dim_feedforward=2,
+                norm_first=norm_first,
+                use_cross_attention=use_cross_attention,
+            )
+            init_weights_with_constant(model)
+            if custom_init:
+                with torch.no_grad():
+                    for name, param in model.named_parameters():
+                        if "norm" in name:
+                            param.copy_(
+                                torch.arange(param.shape[0]).to(dtype=torch.float)
+                            )
+
+            model.eval()
+            return model
+
+        return create_layer
+
+    @pytest.fixture
+    def inputs(self):
+        return Tensor([[[1, 2], [4, 2], [1, 1]]])
+
+    @pytest.fixture
+    def hidden_states(self):
+        return Tensor([[[1, 2, 3, 4], [4, 2, 0, 2]]])
+
+    @pytest.fixture
+    def encoder_hidden_states(self):
+        return Tensor([[[5, 6, 7, 8], [8, 9, 11, 12], [2, 1, 0, 2], [0, 0, 4, 4]]])
+
+    @pytest.fixture
+    def past_key(self):
+        return Tensor([[[[0, 1, 2, 3], [4, 5, 6, 7]]]])
+
+    @pytest.fixture
+    def past_value(self):
+        return Tensor([[[[7, 6, 5, 4], [3, 2, 1, 0]]]])
+
+    @pytest.fixture
+    @pytest.mark.parametrize(
+        "norm_first, expected_output",
+        [
+            (
+                True,
+                (Tensor([[[15.0, 16.0], [18.0, 16.0], [15.0, 15.0]]]), (None, None)),
+            ),
+            (False, (Tensor([[[0.0, 2.0], [2.0, 0.0], [1.0, 1.0]]]), (None, None))),
+        ],
+    )
+    # Without cross-attention, results should match encoder layer
+    def test_forward_without_cross_attn(
+        self, norm_first, expected_output, inputs, get_decoder_layer
+    ):
+        model = get_decoder_layer(
+            d_model=2, norm_first=norm_first, use_cross_attention=False
+        )
+        actual = model(inputs)
+        assert_expected(actual, expected_output, rtol=0, atol=1e-3)
+
+    @pytest.mark.parametrize(
+        "norm_first, mask, expected_output",
+        [
+            (
+                True,
+                torch.BoolTensor([[False, True], [True, False]]),
+                (
+                    Tensor(
+                        [
+                            [
+                                [207.6306, 208.6306, 209.6306, 210.6306],
+                                [225.2318, 223.2318, 221.2318, 223.2318],
+                            ]
+                        ]
+                    ),
+                    None,
+                ),
+            ),
+            (
+                True,
+                None,
+                (
+                    Tensor(
+                        [
+                            [
+                                [236.8329, 237.8329, 238.8329, 239.8329],
+                                [225.2318, 223.2318, 221.2318, 223.2318],
+                            ]
+                        ]
+                    ),
+                    None,
+                ),
+            ),
+            (
+                False,
+                torch.BoolTensor([[False, True], [True, False]]),
+                (
+                    Tensor(
+                        [
+                            [
+                                [0.0000, 0.2642, 1.7713, 8.0006],
+                                [0.0000, 0.6952, 0.5130, 8.1252],
+                            ]
+                        ]
+                    ),
+                    None,
+                ),
+            ),
+            (
+                False,
+                None,
+                (
+                    Tensor(
+                        [
+                            [
+                                [0.0000, 0.2642, 1.7713, 8.0006],
+                                [0.0000, 0.6952, 0.5130, 8.1252],
+                            ]
+                        ]
+                    ),
+                    None,
+                ),
+            ),
+        ],
+    )
+    def test_forward_with_cross_attn(
+        self,
+        norm_first,
+        mask,
+        expected_output,
+        hidden_states,
+        encoder_hidden_states,
+        get_decoder_layer,
+    ):
+        model = get_decoder_layer(
+            d_model=4, norm_first=norm_first, use_cross_attention=True, custom_init=True
+        )
+        actual = model(hidden_states, encoder_hidden_states, attention_mask=mask)
+        assert_expected(actual, expected_output, rtol=0, atol=1e-4)
+
+    @pytest.mark.parametrize(
+        "norm_first, expected_current_key_value",
+        [
+            (
+                True,
+                # pre-norm: 1s matrix squared + 1s bias
+                Tensor([[[[5, 5, 5, 5], [5, 5, 5, 5]]]]),
+            ),
+            (
+                False,
+                # Should equal hidden_states * ones matrix weight + ones bias
+                # (due to init_weights_with_constant)
+                Tensor([[[[11, 11, 11, 11], [9, 9, 9, 9]]]]),
+            ),
+        ],
+    )
+    def test_kv_caching(
+        self,
+        norm_first,
+        expected_current_key_value,
+        hidden_states,
+        encoder_hidden_states,
+        past_key,
+        past_value,
+        get_decoder_layer,
+    ):
+        model = get_decoder_layer(
+            d_model=4, norm_first=norm_first, use_cross_attention=True
+        )
+        actual = model(
+            hidden_states,
+            encoder_hidden_states,
+            past_key_value=(past_key, past_value),
+            use_cache=True,
+        )
+        assert len(actual) == 2
+        assert_expected(
+            actual[1][0],
+            torch.cat([past_key, expected_current_key_value], dim=2),
+        )
+        assert_expected(
+            actual[1][1],
+            torch.cat([past_value, expected_current_key_value], dim=2),
+        )
+
+    @pytest.mark.parametrize(
+        "norm_first",
+        [
+            True,
+            False,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "use_cross_attention",
+        [
+            True,
+            False,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "use_cache",
+        [
+            True,
+            False,
+        ],
+    )
+    def test_scripting(
+        self,
+        norm_first,
+        use_cross_attention,
+        use_cache,
+        hidden_states,
+        encoder_hidden_states,
+        get_decoder_layer,
+    ):
+        model = get_decoder_layer(
+            d_model=4, norm_first=norm_first, use_cross_attention=use_cross_attention
+        )
+        scripted_model = torch.jit.script(model)
+        assert_expected(
+            scripted_model(hidden_states, encoder_hidden_states, use_cache=use_cache),
+            model(hidden_states, encoder_hidden_states, use_cache=use_cache),
+            rtol=0,
+            atol=1e-4,
+        )
+
+
+class TestTransformerDecoder:
+    @pytest.fixture
+    def get_decoder(self):
+        def create_decoder(
+            d_model,
+            norm_first,
+            use_cross_attention,
+            final_layer_norm_eps=None,
+            custom_init=False,
+        ):
+            model = TransformerDecoder(
+                n_layer=2,
+                d_model=d_model,
+                n_head=1,
+                dim_feedforward=2,
+                norm_first=norm_first,
+                final_layer_norm_eps=final_layer_norm_eps,
+                use_cross_attention=use_cross_attention,
+            )
+            init_weights_with_constant(model)
+            if custom_init:
+                with torch.no_grad():
+                    # Manually override layernorm params to give unique results
+                    for i, layer in enumerate(model.layer):
+                        for name, param in layer.named_parameters():
+                            if "norm" in name:
+                                param.copy_(
+                                    i
+                                    * torch.arange(param.shape[0]).to(dtype=torch.float)
+                                )
+
+            model.eval()
+            return model
+
+        return create_decoder
+
+    @pytest.fixture
+    def inputs(self):
+        return Tensor([[[2, 3], [1, 2]]])
+
+    @pytest.fixture
+    def hidden_states(self):
+        return Tensor([[[1, 2, 3, 4], [4, 2, 0, 2]]])
+
+    @pytest.fixture
+    def encoder_hidden_states(self):
+        return Tensor([[[5, 6, 7, 8], [8, 9, 11, 12], [2, 1, 0, 2], [0, 0, 4, 4]]])
+
+    @pytest.mark.parametrize(
+        "norm_first, return_hidden_states, expected_output",
+        [
+            (
+                True,
+                False,
+                TransformerOutput(
+                    last_hidden_state=Tensor([[[30.0, 31.0], [29.0, 30.0]]]),
+                    hidden_states=[],
+                    current_key_values=[],
+                ),
+            ),
+            (
+                False,
+                False,
+                TransformerOutput(
+                    last_hidden_state=Tensor([[[0.0, 2.0], [0.0, 2.0]]]),
+                    hidden_states=[],
+                    current_key_values=[],
+                ),
+            ),
+            (
+                True,
+                True,
+                TransformerOutput(
+                    last_hidden_state=Tensor([[[30.0, 31.0], [29.0, 30.0]]]),
+                    hidden_states=[
+                        Tensor([[[2.0, 3.0], [1.0, 2.0]]]),
+                        Tensor([[[16.0, 17.0], [15.0, 16.0]]]),
+                        Tensor([[[30.0, 31.0], [29.0, 30.0]]]),
+                    ],
+                    current_key_values=[],
+                ),
+            ),
+            (
+                False,
+                True,
+                TransformerOutput(
+                    last_hidden_state=Tensor([[[0.0, 2.0], [0.0, 2.0]]]),
+                    hidden_states=[
+                        Tensor([[[2.0, 3.0], [1.0, 2.0]]]),
+                        Tensor([[[0.0, 2.0], [0.0, 2.0]]]),
+                        Tensor([[[0.0, 2.0], [0.0, 2.0]]]),
+                    ],
+                    current_key_values=[],
+                ),
+            ),
+        ],
+    )
+    def test_forward_without_cross_attention(
+        self, inputs, norm_first, return_hidden_states, expected_output, get_decoder
+    ):
+        model = get_decoder(d_model=2, norm_first=norm_first, use_cross_attention=False)
+        actual_output = model(inputs, return_hidden_states=return_hidden_states)
+        for actual, expected in zip(actual_output, expected_output, strict=True):
+            assert_expected(actual, expected, rtol=0, atol=1e-4)
+
+    @pytest.mark.parametrize(
+        "norm_first, expected_output",
+        [
+            (
+                True,
+                Tensor(
+                    [
+                        [
+                            [409.8329, 410.8329, 411.8329, 412.8329],
+                            [398.2318, 396.2318, 394.2318, 396.2318],
+                        ]
+                    ]
+                ),
+            ),
+            (
+                False,
+                Tensor(
+                    [
+                        [
+                            [0.0000, 0.2535, 2.1998, 7.7787],
+                            [0.0000, 0.2535, 2.1998, 7.7787],
+                        ]
+                    ]
+                ),
+            ),
+        ],
+    )
+    def test_forward_with_cross_attention(
+        self,
+        hidden_states,
+        encoder_hidden_states,
+        norm_first,
+        expected_output,
+        get_decoder,
+    ):
+        model = get_decoder(
+            d_model=4, norm_first=norm_first, use_cross_attention=True, custom_init=True
+        )
+        actual = model(
+            hidden_states, encoder_hidden_states, return_hidden_states=False
+        )[0]
+        assert_expected(actual, expected_output, rtol=0, atol=1e-3)
+
+    @pytest.mark.parametrize(
+        "norm_first",
+        [
+            True,
+            False,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "use_cross_attention",
+        [
+            True,
+            False,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "use_cache",
+        [
+            True,
+            False,
+        ],
+    )
+    def test_scripting(
+        self,
+        norm_first,
+        use_cross_attention,
+        use_cache,
+        hidden_states,
+        encoder_hidden_states,
+        get_decoder,
+    ):
+        model = get_decoder(
+            d_model=4, norm_first=norm_first, use_cross_attention=use_cross_attention
+        )
+        scripted_model = torch.jit.script(model)
+        assert_expected(
+            scripted_model(hidden_states, encoder_hidden_states, use_cache=use_cache),
+            model(hidden_states, encoder_hidden_states, use_cache=use_cache),
+            rtol=0,
+            atol=1e-4,
+        )

--- a/torchmultimodal/modules/layers/transformer.py
+++ b/torchmultimodal/modules/layers/transformer.py
@@ -11,7 +11,11 @@ import torch
 
 from torch import nn, Tensor
 from torchmultimodal.modules.layers.mlp import MLP
-from torchmultimodal.modules.layers.multi_head_attention import MultiHeadSelfAttention
+from torchmultimodal.modules.layers.multi_head_attention import (
+    MHAWithCacheOutput,
+    MultiHeadAttentionWithCache,
+    MultiHeadSelfAttention,
+)
 from torchmultimodal.modules.layers.normalizations import Fp32LayerNorm
 from torchvision.ops.stochastic_depth import StochasticDepth
 
@@ -250,4 +254,411 @@ class TransformerEncoder(nn.Module):
         return TransformerOutput(
             last_hidden_state=hidden_states,
             hidden_states=all_hidden_states if return_hidden_states else None,
+        )
+
+
+class TransformerDecoderLayer(nn.Module):
+    """
+    Transformer decoder layer consisting of multihead self-attention, optional
+    cross-attention, and feedforward network.
+
+    Args:
+        d_model (int): size of hidden dimension of input
+        n_head (int): number of attention heads
+        dim_feedforward (int): size of hidden dimension of feedforward network
+        dropout (float): dropout probability for all dropouts. Defaults to 0.
+        activation (Callable): activation function in feedforward network.
+            Defaults to ``nn.ReLU``.
+        layer_norm_eps (float): the eps value in layer norms. Default is 1e-12.
+        norm_first (bool): if True, layer norm is done prior to each of self-attention,
+            (optional) cross-attention, and feedforward. Otherwise, layer norm is done
+            after. Defaults to False.
+        use_cross_attention (bool): if True, cross-attention is applied before
+            feedforward network. If False, no cross-attention is applied.
+            Defaults to True.
+        dim_kv (Optional[int]): dimension for key and value tensors in cross-attention.
+            If None, K and V are assumed to have dimension d_model. Defaults to None.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        n_head: int,
+        dim_feedforward: int,
+        dropout: float = 0.0,
+        activation: Callable[..., nn.Module] = nn.ReLU,
+        layer_norm_eps: float = 1e-12,
+        norm_first: bool = False,
+        use_cross_attention: bool = True,
+        dim_kv: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+        if dim_kv is not None:
+            dim_kv = dim_kv
+        else:
+            dim_kv = d_model
+
+        # Self-attention block
+        self.attention = MultiHeadAttentionWithCache(
+            dim_q=d_model,
+            dim_kv=d_model,
+            num_heads=n_head,
+            dropout=dropout,
+        )
+        self.attention_dropout = nn.Dropout(dropout)
+
+        # Optional cross-attention block
+        self.cross_attention: Optional[MultiHeadAttentionWithCache] = None
+        self.use_cross_attention = use_cross_attention
+        if self.use_cross_attention:
+            self.cross_attention = MultiHeadAttentionWithCache(
+                dim_q=d_model,
+                dim_kv=dim_kv,
+                num_heads=n_head,
+                dropout=dropout,
+            )
+            self.cross_attention_layernorm = Fp32LayerNorm(d_model, eps=layer_norm_eps)
+            self.cross_attention_dropout = nn.Dropout(dropout)
+
+        # Feedforward
+        self.feedforward = MLP(
+            d_model,
+            d_model,
+            dim_feedforward,
+            dropout=dropout,
+            activation=activation,
+        )
+        self.feedforward_dropout = nn.Dropout(dropout)
+
+        # Layernorms
+        self.attention_layernorm = Fp32LayerNorm(d_model, eps=layer_norm_eps)
+        self.feedforward_layernorm = Fp32LayerNorm(d_model, eps=layer_norm_eps)
+        self.norm_first = norm_first
+
+    def _self_attention_block(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Optional[Tensor] = None,
+        past_key_value: Optional[Tuple[Tensor, Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[Tensor, Optional[Tuple[Tensor, Tensor]]]:
+        attn_output = self.attention(
+            query=hidden_states,
+            key=hidden_states,
+            value=hidden_states,
+            attn_mask=attention_mask,
+            past_key_value=past_key_value,
+            use_cache=use_cache,
+        )
+        present_key_value: Optional[Tuple[Tensor, Tensor]] = None
+        if use_cache:
+            assert isinstance(attn_output, MHAWithCacheOutput)
+            attn_output_value = attn_output.attn_output
+            present_key_value = attn_output.past_key_value
+        else:
+            assert isinstance(attn_output, Tensor)
+            attn_output_value = attn_output
+        output = self.attention_dropout(attn_output_value)
+        return output, present_key_value
+
+    def _cross_attention_block(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        cross_attention_mask: Optional[Tensor] = None,
+    ) -> Tensor:
+        assert (
+            self.cross_attention is not None
+        ), """
+            Cannot use cross-attention unless self.cross_attention and
+            self.cross_attention_dropout are defined.
+        """
+        output = self.cross_attention(
+            query=hidden_states,
+            key=encoder_hidden_states,
+            value=encoder_hidden_states,
+            attn_mask=cross_attention_mask,
+            # TODO: figure out caching for cross-attention
+            use_cache=False,
+        )
+        assert torch.jit.isinstance(
+            output, Tensor
+        ), "cross-attention output must be Tensor."
+        attention_output = self.cross_attention_dropout(output)
+        return attention_output
+
+    def _feedforward_block(self, hidden_states: Tensor) -> Tensor:
+        h = self.feedforward(hidden_states)
+        h = self.feedforward_dropout(h)
+        return h
+
+    def _forward_prenorm(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        cross_attention_mask: Optional[Tensor] = None,
+        past_key_value: Optional[Tuple[Tensor, Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[Tensor, Optional[Tuple[Tensor, Tensor]]]:
+
+        # Self-attention
+        self_attn_input = self.attention_layernorm(hidden_states)
+        attn_output, present_key_value = self._self_attention_block(
+            self_attn_input,
+            attention_mask=attention_mask,
+            past_key_value=past_key_value,
+            use_cache=use_cache,
+        )
+        self_attn_output = attn_output + hidden_states
+
+        # Optional cross-attention
+        if self.use_cross_attention:
+            assert (
+                encoder_hidden_states is not None
+            ), "encoder_hidden_states must be provided for cross attention"
+            assert hasattr(
+                self, "cross_attention_layernorm"
+            ), "Cross-attention layernorm not initialized"
+            cross_attn_input = self.cross_attention_layernorm(self_attn_output)
+            cross_attn_output = self._cross_attention_block(
+                cross_attn_input,
+                encoder_hidden_states,
+                cross_attention_mask=cross_attention_mask,
+            )
+            attn_output = cross_attn_output + self_attn_output
+        else:
+            attn_output = self_attn_output
+
+        # Feedforward
+        ff_input = self.feedforward_layernorm(attn_output)
+        output = attn_output + self._feedforward_block(ff_input)
+
+        return output, present_key_value
+
+    def _forward_postnorm(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        cross_attention_mask: Optional[Tensor] = None,
+        past_key_value: Optional[Tuple[Tensor, Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[Tensor, Optional[Tuple[Tensor, Tensor]]]:
+
+        # Self-attention
+        attn_output, present_key_value = self._self_attention_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            past_key_value=past_key_value,
+            use_cache=use_cache,
+        )
+        attn_residual = attn_output + hidden_states
+        self_attn_output = self.attention_layernorm(attn_residual)
+
+        # Optional cross-attention
+        if self.use_cross_attention:
+            if encoder_hidden_states is None:
+                raise ValueError(
+                    "encoder_hidden_states must be provided for cross attention"
+                )
+            assert hasattr(
+                self, "cross_attention_layernorm"
+            ), "Cross-attention layernorm not initialized"
+            cross_attn_output = self._cross_attention_block(
+                self_attn_output, encoder_hidden_states, cross_attention_mask
+            )
+            cross_attn_residual = cross_attn_output + self_attn_output
+            attn_output = self.cross_attention_layernorm(cross_attn_residual)
+        else:
+            attn_output = self_attn_output
+
+        # Feedforward
+        ff_residual = attn_output + self._feedforward_block(attn_output)
+        output = self.feedforward_layernorm(ff_residual)
+
+        return output, present_key_value
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        cross_attention_mask: Optional[Tensor] = None,
+        past_key_value: Optional[Tuple[Tensor, Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[Tensor, Optional[Tuple[Tensor, Tensor]]]:
+        """
+        Inputs:
+            hidden_states (Tensor): input query of shape bsz x seq_len x embed_dim
+            encoder_hidden_states (Optional[Tensor]): input key/values of shape
+                bsz x seq_len x embed_dim, only used for cross-attention.
+                Default is None.
+            attention_mask (Optional[Tensor]): attention mask for self-attention,
+                supported mask type is described in MultiHeadAttentionWithCache class.
+                Default is None.
+            cross_attention_mask (Optional[Tensor]): attention mask for cross-attention,
+                similar to attention_mask. Default is None.
+            past_key_value (Optional[Tuple[Tensor, Tensor]]): cached key/value tuple
+                for self-attention. Default is None.
+            use_cache (bool): whether to use cache for key and value tensors.
+                Can be used for faster autoregressive decoding during inference.
+                    Default is False.
+
+        Returns:
+            A tuple including
+                output (Tensor): layer output of shape bsz x seq_len x embed_dim
+                present_key_value (Optional[Tuple[Tensor, Tensor]]): key/value tuple for
+                    self-attention if use_cache set to True else None
+        """
+        if self.norm_first is True:
+            return self._forward_prenorm(
+                hidden_states,
+                encoder_hidden_states,
+                attention_mask,
+                cross_attention_mask,
+                past_key_value,
+                use_cache,
+            )
+        else:
+            return self._forward_postnorm(
+                hidden_states,
+                encoder_hidden_states,
+                attention_mask,
+                cross_attention_mask,
+                past_key_value,
+                use_cache,
+            )
+
+
+class TransformerDecoder(nn.Module):
+    """
+    Transformer decoder: n transformer decoder layers and an optional final LN
+
+    Args:
+        n_layer (int): number of transformer decoder layers
+        d_model (int): size of hidden dimension of input
+        n_head (int): number of attention heads
+        dim_feedforward (int): size of hidden dimension of feedforward network
+        dropout (float): dropout probability for all dropouts. Defaults to 0.
+        activation (Callable): activation function in feedforward network.
+            Defaults to ``nn.ReLU``.
+        layer_norm_eps (float): the eps value in layer norms. Default is 1e-12.
+        norm_first (bool): if True, layer norm is done prior to each of self-attention,
+            (optional) cross-attention, and feedforward. Otherwise, layer norm is done
+            after. Defaults to False.
+        use_cross_attention (bool): if True, cross-attention is applied before
+            feedforward network. If False, no cross-attention is applied.
+            Defaults to True.
+        dim_kv (Optional[int]): dimension for key and value tensors in cross-attention.
+            If None, K and V are assumed to have dimension d_model. Defaults to None.
+        final_layer_norm_eps (Optional[float]): epsilon used in final layer norm.
+            Defaults to None (no final layer norm).
+    """
+
+    def __init__(
+        self,
+        n_layer: int,
+        d_model: int,
+        n_head: int,
+        dim_feedforward: int,
+        dropout: float = 0.0,
+        activation: Callable[..., nn.Module] = nn.ReLU,
+        layer_norm_eps: float = 1e-12,
+        norm_first: bool = False,
+        use_cross_attention: bool = True,
+        dim_kv: Optional[int] = None,
+        final_layer_norm_eps: Optional[float] = None,
+    ):
+        super().__init__()
+        self.layer = nn.ModuleList(
+            [
+                TransformerDecoderLayer(
+                    d_model,
+                    n_head,
+                    dim_feedforward,
+                    dropout,
+                    activation,
+                    layer_norm_eps,
+                    norm_first,
+                    use_cross_attention,
+                    dim_kv,
+                )
+                for i in range(n_layer)
+            ]
+        )
+        self.final_layer_norm = None
+        if final_layer_norm_eps:
+            self.final_layer_norm = Fp32LayerNorm(d_model, eps=final_layer_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        cross_attention_mask: Optional[Tensor] = None,
+        past_key_values: Optional[List[Tuple[Tensor, Tensor]]] = None,
+        use_cache: bool = False,
+        return_hidden_states: bool = False,
+    ) -> TransformerOutput:
+        """
+        Inputs:
+            hidden_states (Tensor): input query of shape bsz x seq_len x embed_dim
+            encoder_hidden_states (Optional[Tensor]): input key/values of shape
+                bsz x seq_len x embed_dim, only used for cross-attention.
+                Default is None.
+            attention_mask (Optional[Tensor]): attention mask for self-attention,
+                supported mask type is described in MultiHeadAttentionWithCache class.
+                Default is None.
+            cross_attention_mask (Optional[Tensor]): attention mask for cross-attention,
+                similar to attention_mask. Default is None.
+            past_key_values (Optional[List[Tuple[Tensor, Tensor]]]): cached key/value
+                tuples for self-attention in each layer. Default is None.
+            use_cache (bool): whether to use cache for key and value tensors.
+                Default is False.
+            return_hidden_states (bool): if True, return output from each layer of
+                transformer including the input to first layer. Default is False.
+
+        Returns:
+            output of TransformerOutput type with fields
+                last_hidden_state (Tensor): layer output of shape bsz x seq_len x embed_dim
+                hidden_states (List[Tensor]): all hidden states from decoder layers
+                present_key_value (Optional[Tuple[Tensor, Tensor]]): key/value tuple
+                    for self-attention.
+        """
+
+        all_hidden_states = []
+
+        current_key_values = torch.jit.annotate(List[Tuple[Tensor, Tensor]], [])
+
+        for i, layer_module in enumerate(self.layer):
+            if return_hidden_states:
+                all_hidden_states.append(hidden_states)
+
+            past_key_value = past_key_values[i] if past_key_values is not None else None
+
+            layer_outputs, current_key_value = layer_module(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=attention_mask,
+                past_key_value=past_key_value,
+                use_cache=use_cache,
+            )
+
+            if use_cache:
+                assert isinstance(current_key_value, tuple)
+                current_key_values.append(current_key_value)
+
+            hidden_states = layer_outputs
+
+        if return_hidden_states:
+            all_hidden_states.append(hidden_states)
+
+        if self.final_layer_norm is not None:
+            hidden_states = self.final_layer_norm(hidden_states)
+
+        return TransformerOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=all_hidden_states,
+            current_key_values=current_key_values,
         )


### PR DESCRIPTION
Summary:
Cloning the logic from existing impl

Test plan:
pytest tests/modules/layers/test_transformer.py 
Ignore CI failures, they are unrelated. tests pass internally.

