### PR TITLE
Remove strict=True from zip in transformer test

### DIFF
--- a/tests/modules/layers/test_transformer.py
+++ b/tests/modules/layers/test_transformer.py
@@ -534,7 +534,7 @@ class TestTransformerDecoder:
     ):
         model = get_decoder(d_model=2, norm_first=norm_first, use_cross_attention=False)
         actual_output = model(inputs, return_hidden_states=return_hidden_states)
-        for actual, expected in zip(actual_output, expected_output, strict=True):
+        for actual, expected in zip(actual_output, expected_output):
             assert_expected(actual, expected, rtol=0, atol=1e-4)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Summary:
Tests somehow broke https://github.com/facebookresearch/multimodal/actions/runs/5941786130/job/16113389085?pr=452

Test plan:
CI passes now

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
