### PR TITLE
Add reconstruction loss

### DIFF
--- a/tests/modules/losses/test_reconstruction_loss.py
+++ b/tests/modules/losses/test_reconstruction_loss.py
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from tests.test_utils import assert_expected
+from torchmultimodal.modules.losses.reconstruction_loss import ReconstructionLoss
+
+
+class TestReconstructionLoss:
+    @pytest.fixture
+    def pred(self):
+        return torch.Tensor(
+            [
+                [
+                    [-0.6, 1.7, -0.5],
+                    [-0.6, 1.9, -0.4],
+                    [-0.5, 1.5, -0.2],
+                    [-0.6, 1.8, -0.3],
+                ]
+            ]
+        )
+
+    @pytest.fixture
+    def target(self):
+        return torch.ones(1, 4, 3)
+
+    @pytest.mark.parametrize(
+        "normalize_target, expected_output", [(True, 1.2044), (False, 1.6489)]
+    )
+    def test_forward(self, normalize_target, expected_output, pred, target):
+        loss_fn = ReconstructionLoss(normalize_target=normalize_target)
+        mask = torch.Tensor([[1.0, 1.0, 0.0, 1.0], [0.0, 1.0, 1.0, 1.0]])
+        loss = loss_fn(pred, target, mask)
+        assert_expected(loss.item(), expected_output, atol=0, rtol=1e-4)
+
+    def test_no_masking_error(self, pred, target):
+        loss_fn = ReconstructionLoss()
+        mask = torch.zeros(1, 4, 3)
+        with pytest.raises(ValueError):
+            loss_fn(pred, target, mask)

--- a/torchmultimodal/modules/losses/reconstruction_loss.py
+++ b/torchmultimodal/modules/losses/reconstruction_loss.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch import nn, Tensor
+
+
+class ReconstructionLoss(nn.Module):
+    """
+    Reconstruction loss that computed MSE between predicted and target values as described in MAE paper
+    https://arxiv.org/abs/2111.06377. Loss is averaged only over masked patches.
+
+    Args:
+        normalize_target (bool) : Whether target should be normalized. Defaults to True
+
+    """
+
+    def __init__(self, normalize_target: bool = True):
+        super().__init__()
+        self.normalize_target = normalize_target
+
+    def forward(self, pred: Tensor, target: Tensor, mask: Tensor) -> Tensor:
+        """
+        Args:
+            pred (Tensor): predicted tensor with shape bsz x num_patches x (patch_size ** 2 * channels)
+            target (Tensor): patchified input with the same shape as pred
+            mask (Tensor):  Tensor of shape bsz x num_patches indicating which patches are masked.
+            1 indicates masked patch amd 0 indicated unmasked patch.
+        Returns: computed loss
+
+        """
+        if mask.sum() == 0:
+            raise ValueError("At least one patch must be masked")
+
+        if self.normalize_target:
+            mean = target.mean(dim=-1, keepdim=True)
+            var = target.var(dim=-1, keepdim=True)
+            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and
+            #  `float`.
+            target = (target - mean) / (var + 1.0e-6) ** 0.5
+
+        # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
+        loss = ((pred - target) ** 2).mean(dim=-1)
+        loss = (loss * mask).sum() / mask.sum()
+        return loss


### PR DESCRIPTION
Summary:
as title

Test plan:
pytest tests/modules/losses/test_reconstruction_loss.py
CI failures are unrelated

