### PR TITLE
Add test util to split tensor across devices for distributed tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,3 +222,20 @@ def tensor_hash(x: torch.tensor, scaling=0.05, buckets=1000) -> torch.tensor:
     hashed_tensor = quant_tensor.int_repr().sum(-1) % buckets
 
     return hashed_tensor
+
+
+def split_tensor_for_distributed_test(
+    x: Tensor,
+    local_batch_size: int,
+    device_id: int,
+    dim: int = 0,
+    move_to_device: bool = True,
+) -> Tensor:
+    """
+    Utility for distributed testing. Splits a tensor into chunks along a given dim,
+    takes the kth chunk, and optionally moves to the specified device.
+    """
+    x = torch.split(x, local_batch_size, dim)[device_id]
+    if move_to_device:
+        x = x.to(device=device_id)
+    return x


### PR DESCRIPTION
Summary: For our distributed tests (e.g. test_contrastive_loss_with_temperature), we often construct a global tensor then split it across devices in individual workers to mock a DDP setup. Add a test util to cut down on all the copy-pastes of `torch.split(...)[gpu_id].cuda(gpu_id)`

Reviewed By: pikapecan

Differential Revision: D49157769


