### PR TITLE
Add enum for backprop type in all-gather utility

### DIFF
--- a/tests/modules/losses/test_contrastive_loss_with_temperature.py
+++ b/tests/modules/losses/test_contrastive_loss_with_temperature.py
@@ -26,6 +26,7 @@ from torchmultimodal.modules.losses.contrastive_loss_with_temperature import (
     ContrastiveLossWithTemperature,
 )
 from torchmultimodal.utils.common import get_current_device
+from torchmultimodal.utils.distributed import BackpropType
 
 
 class TestContrastiveLossWithTemperature:
@@ -162,7 +163,9 @@ class TestContrastiveLossWithTemperature:
         local_image_embeddings = image_encoder(local_images)
         local_text_embeddings = text_encoder(local_texts)
         loss = loss_fn(
-            local_image_embeddings, local_text_embeddings, backprop_in_gather=True
+            local_image_embeddings,
+            local_text_embeddings,
+            backprop_type=BackpropType.GLOBAL,
         )
 
         # Compute gradients

--- a/torchmultimodal/modules/losses/flava.py
+++ b/torchmultimodal/modules/losses/flava.py
@@ -16,6 +16,7 @@ from torchmultimodal.modules.losses.contrastive_loss_with_temperature import (
     contrastive_loss_with_temperature,
 )
 from torchmultimodal.utils.common import ModelOutput
+from torchmultimodal.utils.distributed import BackpropType
 
 
 def assert_labels_are_present(
@@ -278,7 +279,7 @@ class FLAVAGlobalContrastiveLoss(nn.Module):
             logit_scale=self.logit_scale,
             mask=mask,
             # Always true for FLAVA global contrastive loss
-            backprop_in_gather=True,
+            backprop_type=BackpropType.GLOBAL,
         )
 
         return FLAVAGlobalContrastiveLossOutput(


### PR DESCRIPTION
Summary: Our all-gather utilities support three different behaviors wrt gradients: local backprop, global backprop, or no backprop. Currently we handle this with two different boolean flags, but that can be kinda confusing. We can instead define a single Enum to handle all three cases.

Differential Revision: D49165160


