### PR TITLE
Rename image embeddings -> patch embeddings

### DIFF
--- a/tests/modules/layers/test_patch_embedding.py
+++ b/tests/modules/layers/test_patch_embedding.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 from tests.test_utils import assert_expected, set_rng_seed
 from torch import nn
-from torchmultimodal.modules.layers.image_embedding import ImageEmbeddings
+from torchmultimodal.modules.layers.patch_embedding import PatchEmbeddings
 
 
 @pytest.fixture(autouse=True)
@@ -27,7 +27,7 @@ def mask():
     return torch.tensor([[1, 1, 0, 1], [0, 1, 1, 0]])
 
 
-class TestImageEmbeddings:
+class TestPatchEmbeddings:
     def _init_conv_proj(self, model):
         model.conv_projection.weight = nn.Parameter(
             torch.tensor([[[[0.0]], [[1.0]], [[2.0]]], [[[3.0]], [[4.0]], [[5.0]]]])
@@ -35,7 +35,7 @@ class TestImageEmbeddings:
 
     @pytest.fixture
     def embedding(self):
-        model = ImageEmbeddings(
+        model = PatchEmbeddings(
             image_size=2,
             patch_size=1,
             hidden_size=2,
@@ -48,7 +48,7 @@ class TestImageEmbeddings:
 
     @pytest.fixture
     def embedding_patches_dropped(self):
-        model = ImageEmbeddings(
+        model = PatchEmbeddings(
             image_size=2,
             patch_size=1,
             hidden_size=2,
@@ -89,7 +89,7 @@ class TestImageEmbeddings:
         assert_expected(actual, expected, atol=1e-4, rtol=0)
 
     def test_forward_rectangle_input(self):
-        model = ImageEmbeddings(
+        model = PatchEmbeddings(
             image_size=(4, 6),
             patch_size=2,
             hidden_size=2,
@@ -117,7 +117,7 @@ class TestImageEmbeddings:
         assert_expected(actual, expected, atol=1e-4, rtol=0)
 
     def test_forward_no_cls(self, inputs, mask):
-        embedding = ImageEmbeddings(
+        embedding = PatchEmbeddings(
             image_size=2,
             patch_size=1,
             hidden_size=2,

--- a/torchmultimodal/models/masked_auto_encoder/model.py
+++ b/torchmultimodal/models/masked_auto_encoder/model.py
@@ -13,7 +13,7 @@ from torchmultimodal.models.masked_auto_encoder.position_embeddings import (
     get_2d_sin_cos_embeddings,
 )
 from torchmultimodal.models.masked_auto_encoder.swin_decoder import SwinTransformer
-from torchmultimodal.modules.layers.image_embedding import ImageEmbeddings
+from torchmultimodal.modules.layers.patch_embedding import PatchEmbeddings
 from torchmultimodal.modules.layers.transformer import (
     TransformerEncoder,
     TransformerOutput,
@@ -59,7 +59,7 @@ class MaskedAutoEncoder(nn.Module):
     ):
         super().__init__()
         self.patch_size = patch_size
-        self.patch_embed = ImageEmbeddings(
+        self.patch_embed = PatchEmbeddings(
             image_size=input_size,
             patch_size=patch_size,
             num_channels=num_channels,

--- a/torchmultimodal/modules/encoders/vision_transformer.py
+++ b/torchmultimodal/modules/encoders/vision_transformer.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Optional, Tuple, Union
 import torch
 
 from torch import nn, Tensor
-from torchmultimodal.modules.layers.image_embedding import ImageEmbeddings
+from torchmultimodal.modules.layers.patch_embedding import PatchEmbeddings
 from torchmultimodal.modules.layers.transformer import (
     TransformerEncoder,
     TransformerOutput,
@@ -23,7 +23,7 @@ class VisionTransformer(nn.Module):
 
     Attributes:
         embeddings (nn.Module): Module that projects image pixels into embeddings.
-            See :py:class: ImageEmbeddings for interface.
+            See :py:class: PatchEmbeddings for interface.
         encoder (nn.Module): Module for transformer encoder. See :py:class: TransformerEncoder for interface.
         pooler (nn.Module, optional): Module for pooler to be applied after layernorm. Defaults to ``None``.
         weight_init_fn (Callable, optional): function for custom weight initialization of both the transformer
@@ -174,7 +174,7 @@ def vision_transformer(
         pooler (nn.Module, optional): Pooling function to be applied to the last hidden state from the transformer like avg pooling.
         Defaults to None
     """
-    image_embedding = ImageEmbeddings(
+    image_embedding = PatchEmbeddings(
         image_size=image_size,
         patch_size=patch_size,
         hidden_size=hidden_dim,

--- a/torchmultimodal/modules/layers/patch_embedding.py
+++ b/torchmultimodal/modules/layers/patch_embedding.py
@@ -17,13 +17,13 @@ from torchmultimodal.modules.masking.random_masking import (
 )
 
 
-class ImageEmbeddingsOutput(NamedTuple):
+class PatchEmbeddingsOutput(NamedTuple):
     embeddings: Tensor
     random_mask: Optional[Tensor] = None
     ids_restore: Optional[Tensor] = None
 
 
-class ImageEmbeddings(nn.Module):
+class PatchEmbeddings(nn.Module):
     """
     Construct the CLS token, position and patch embeddings for vision transformer
     Args:
@@ -97,7 +97,7 @@ class ImageEmbeddings(nn.Module):
         self,
         pixel_values: Tensor,
         image_patches_mask: Optional[Tensor] = None,
-    ) -> ImageEmbeddingsOutput:
+    ) -> PatchEmbeddingsOutput:
         batch_size, num_channels, height, width = pixel_values.shape
         if height != self.image_size[0] or width != self.image_size[1]:
             raise ValueError(
@@ -151,7 +151,7 @@ class ImageEmbeddings(nn.Module):
 
         embeddings = self.dropout(embeddings)
 
-        return ImageEmbeddingsOutput(
+        return PatchEmbeddingsOutput(
             embeddings=embeddings,
             random_mask=random_mask,
             ids_restore=ids_restore,


### PR DESCRIPTION
Summary: Give a more general name since these embeddings are used for other modalities besides just images

Reviewed By: ankitade

Differential Revision: D49553224


