### PR TITLE
Rename patch_embed and transformer_encoder fields in MAE model

### DIFF
--- a/tests/models/masked_auto_encoder/test_model.py
+++ b/tests/models/masked_auto_encoder/test_model.py
@@ -115,12 +115,12 @@ class TestImageMaskedAutoEncoder:
             image_size=(2, 2),
             patch_size=1,
         )
-        for p in model.patch_embed.position_embeddings:
+        for p in model.embeddings.position_embeddings:
             assert p.requires_grad is False
         for p in model.decoder_embed.position_embeddings:
             assert p.requires_grad is False
         assert_expected(
-            model.patch_embed.position_embeddings,
+            model.embeddings.position_embeddings,
             torch.Tensor(
                 [
                     [
@@ -307,12 +307,12 @@ class TestAudioMaskedAutoEncoder:
             input_size=(2, 3),
             patch_size=1,
         )
-        for p in model.patch_embed.position_embeddings:
+        for p in model.embeddings.position_embeddings:
             assert p.requires_grad is False
         for p in model.decoder_embed.position_embeddings:
             assert p.requires_grad is False
         assert_expected(
-            model.patch_embed.position_embeddings,
+            model.embeddings.position_embeddings,
             torch.Tensor(
                 [
                     [

--- a/torchmultimodal/models/masked_auto_encoder/model.py
+++ b/torchmultimodal/models/masked_auto_encoder/model.py
@@ -59,16 +59,16 @@ class MaskedAutoEncoder(nn.Module):
     ):
         super().__init__()
         self.patch_size = patch_size
-        self.patch_embed = PatchEmbeddings(
+        self.embeddings = PatchEmbeddings(
             image_size=input_size,
             patch_size=patch_size,
             num_channels=num_channels,
             hidden_size=embed_dim,
             patch_drop_rate=masking_ratio,
         )
-        self.patch_embed.position_embeddings.requires_grad = False
+        self.embeddings.position_embeddings.requires_grad = False
 
-        self.encoder_transformer = encoder_transformer
+        self.encoder = encoder_transformer
 
         self.decoder_embed = DecoderEmbeddings(
             encoder_embed_dim=embed_dim,
@@ -95,18 +95,18 @@ class MaskedAutoEncoder(nn.Module):
             input_h, input_w = input_size
         num_patches_h = input_h // self.patch_size
         num_patches_w = input_w // self.patch_size
-        self.patch_embed.position_embeddings.data = get_2d_sin_cos_embeddings(
+        self.embeddings.position_embeddings.data = get_2d_sin_cos_embeddings(
             encoder_embed_dim, (num_patches_w, num_patches_h)
         )
         self.decoder_embed.position_embeddings.data = get_2d_sin_cos_embeddings(
             decoder_embed_dim, (num_patches_w, num_patches_h)
         )
 
-        # initialize patch_embed like nn.Linear (instead of nn.Conv2d)
-        w = self.patch_embed.conv_projection.weight.data
+        # initialize embeddings like nn.Linear (instead of nn.Conv2d)
+        w = self.embeddings.conv_projection.weight.data
         torch.nn.init.xavier_uniform_(w.view([w.shape[0], -1]))
 
-        torch.nn.init.normal_(self.patch_embed.cls_token, std=0.02)
+        torch.nn.init.normal_(self.embeddings.cls_token, std=0.02)
         torch.nn.init.normal_(self.decoder_embed.mask_token, std=0.02)
 
         self.apply(self._init_weights)
@@ -150,8 +150,8 @@ class MaskedAutoEncoder(nn.Module):
             label_patches indicates the patchified ground truth pixels
 
         """
-        embedding_out = self.patch_embed(x)
-        encoder_out = self.encoder_transformer(embedding_out.embeddings)
+        embedding_out = self.embeddings(x)
+        encoder_out = self.encoder(embedding_out.embeddings)
         if not self.training:
             # TODO: check if error should be raised is masking ratio != 0 here
             return MAEOutput(encoder_out)


### PR DESCRIPTION
Summary: This way users can directly load pretrained MAE checkpoints into ViT class for fine-tuning using `strict=False`

Reviewed By: kartikayk

Differential Revision: D49561277


