### PR TITLE
Increase tolerance for audio MAE test

### DIFF
--- a/tests/models/masked_auto_encoder/test_model.py
+++ b/tests/models/masked_auto_encoder/test_model.py
@@ -253,7 +253,7 @@ class TestAudioMaskedAutoEncoder:
 
         pred = actual.decoder_pred
         assert_expected(pred.size(), (2, 512, 16 * 16 * 1))
-        assert_expected(pred.mean().item(), 513.0)
+        assert_expected(pred.mean().item(), 513.0, rtol=1e-4, atol=1e-4)
 
         labels = actual.label_patches
         assert_expected(labels, torch.ones(2, 512, 16 * 16 * 1))


### PR DESCRIPTION
Summary:
Audio MAE test is failing on CI due to some small rounding error. The unmasked test case already has atol=rtol=1e-4, so set the same values for the masked test case to fix the CI.

Test plan:
Confirm that test no longer fails on CI

