### PR TITLE
Consolidate VideoGPT components

### DIFF
--- a/examples/mugen/generation/text_video_gpt.py
+++ b/examples/mugen/generation/text_video_gpt.py
@@ -12,7 +12,7 @@ from examples.mugen.generation.video_vqvae import video_vqvae_mugen
 
 from torch import nn, Tensor
 
-from torchmultimodal.models.gpt import (
+from torchmultimodal.models.video_gpt.gpt import (
     MultimodalGPT,
     MultimodalTransformerDecoder,
     RightShift,
@@ -69,7 +69,7 @@ def text_video_gpt(
             new frame will be of shape ``(8, 8, 8)`` with each dim divided by the rate of downsample. Defaults to
             ``(4, 32, 32)``.
         d_model (int): Dimension of the underlying transformer decoder.
-            See :py:class:`torchmultimodal.models.gpt.TransformerDecoderLayer`. Defaults to ``768``.
+            See :py:class:`torchmultimodal.models.video_gpt.gpt.TransformerDecoderLayer`. Defaults to ``768``.
         n_head (int): Number of attention heads used by the transformer decoder. Defaults to ``8``.
         dropout (float): Dropout probability used by the projection layer of the transformer decoder.
             Defaults to ``0.2``.
@@ -93,7 +93,7 @@ def text_video_gpt(
             Defaults to ``None``.
 
     Returns:
-        An instance of :py:class:`torchmultimodal.models.gpt.MultimodalGPT`.
+        An instance of :py:class:`torchmultimodal.models.video_gpt.gpt.MultimodalGPT`.
     """
 
     # builds text tokenizer from pre-trained
@@ -195,7 +195,7 @@ class TextTokenizer(nn.Module):
     """Converts between text and tokens / embedings
 
     Wrapper around the tokenizer to be consistent with the API required by
-    :py:class:`torchmultimodal.models.gpt.MultimodalGPT`. It also contains the
+    :py:class:`torchmultimodal.models.video_gpt.gpt.MultimodalGPT`. It also contains the
     embedding layer to enable lookup by token ids.
     """
 

--- a/examples/mugen/generation/video_vqvae.py
+++ b/examples/mugen/generation/video_vqvae.py
@@ -6,7 +6,7 @@
 
 from typing import Optional
 
-from torchmultimodal.models.video_vqvae import (
+from torchmultimodal.models.video_gpt.video_vqvae import (
     preprocess_int_conv_params,
     VideoDecoder,
     VideoEncoder,
@@ -50,7 +50,7 @@ def video_vqvae_mugen(
         n_res_layers (int, optional): Number of ``AttentionResidualBlocks`` to include in encoder and decoder.
             Defaults to ``4``.
         attn_hidden_dim (int, optional): Size of hidden dim of
-            :class:`~torchmultimodal.models.video_vqvae.AttentionResidualBlocks`. Defaults to ``240``.
+            :class:`~torchmultimodal.models.video_gpt.video_vqvae.AttentionResidualBlocks`. Defaults to ``240``.
         num_embeddings (int, optional): Number of embedding vectors used in
             :class:`~torchmultimodal.modules.layers.codebook.Codebook`. Defaults to ``2048``.
         embedding_dim (int, optional): Dimensionality of embedding vectors in
@@ -63,8 +63,8 @@ def video_vqvae_mugen(
 
     Returns:
         An instance of :class:`~torchmultimodal.models.vqvae.VQVAE` constructed with:
-            * :class:`~torchmultimodal.model.video_vqvae.VideoEncoder`
-            * :class:`~torchmultimodal.model.video_vqvae.VideoDecoder`
+            * :class:`~torchmultimodal.model.video_gpt.video_vqvae.VideoEncoder`
+            * :class:`~torchmultimodal.model.video_gpt.video_vqvae.VideoDecoder`
     """
     encoder_strides = ((2, 2, 2), (2, 2, 2), (1, 2, 2), (1, 2, 2), (1, 2, 2), (1, 1, 1))
     decoder_strides = ((2, 2, 2), (2, 2, 2), (1, 2, 2), (1, 2, 2), (1, 2, 2))

--- a/tests/models/test_gpt.py
+++ b/tests/models/test_gpt.py
@@ -11,7 +11,7 @@ import torch
 from tests.test_utils import assert_expected, assert_expected_namedtuple, set_rng_seed
 from torch import nn
 from torch.nn import functional as F
-from torchmultimodal.models.gpt import (
+from torchmultimodal.models.video_gpt.gpt import (
     MultimodalGPT,
     MultimodalGPTOutput,
     MultimodalTransformerDecoder,
@@ -257,7 +257,7 @@ class TestMultimodalGPT:
         # Testing mean and std of the initialized weights data requires a large
         # amount samples to be statistically stable. Here we just test whether
         # the method in question has been called to avoid test flakiness.
-        mock_init = mocker.patch("torchmultimodal.models.gpt.Tensor.normal_")
+        mock_init = mocker.patch("torchmultimodal.models.video_gpt.gpt.Tensor.normal_")
         gpt = gpt(use_gpt_init=True)
         mock_init.assert_called()
 

--- a/tests/models/test_video_gpt.py
+++ b/tests/models/test_video_gpt.py
@@ -10,7 +10,7 @@ import torch
 
 from tests.test_utils import assert_expected, set_rng_seed
 
-from torchmultimodal.models.video_gpt import video_gpt, video_vqvae
+from torchmultimodal.models.video_gpt.model import video_gpt, video_vqvae
 
 
 @pytest.fixture(autouse=True)

--- a/tests/utils/test_generate.py
+++ b/tests/utils/test_generate.py
@@ -10,7 +10,7 @@ import torch
 
 from tests.test_utils import assert_expected, set_rng_seed
 
-from torchmultimodal.models.video_gpt import video_gpt
+from torchmultimodal.models.video_gpt.model import video_gpt
 from torchmultimodal.utils.generate import (
     GenerationUtil,
     get_logits_mask,

--- a/torchmultimodal/models/video_gpt/gpt.py
+++ b/torchmultimodal/models/video_gpt/gpt.py
@@ -17,7 +17,7 @@ from torchmultimodal.utils.common import checkpoint_wrapper, get_clones
 
 
 class TransformerDecoderOutput(NamedTuple):
-    """Outputs from :class:`~torchmultimodal.models.gpt.TransformerDecoder`.
+    """Outputs from :class:`~torchmultimodal.models.video_gpt.gpt.TransformerDecoder`.
 
     Attributes:
         last_hidden_states (Tensor): Output from the last layer of the transformer.
@@ -36,7 +36,7 @@ class TransformerDecoderOutput(NamedTuple):
 
 
 class TransformerLayerOutput(NamedTuple):
-    """Outputs from :class:`~torchmultimodal.models.gpt.TransformerDecoderLayer`.
+    """Outputs from :class:`~torchmultimodal.models.video_gpt.gpt.TransformerDecoderLayer`.
 
     Attributes:
         hidden_states (Tensor): Output from the current layer.
@@ -52,7 +52,7 @@ class TransformerLayerOutput(NamedTuple):
 
 
 class MultimodalGPTOutput(NamedTuple):
-    """Outputs from :meth:`~torchmultimodal.models.gpt.MultimodalGPT.forward`.
+    """Outputs from :meth:`~torchmultimodal.models.video_gpt.gpt.MultimodalGPT.forward`.
 
     Attributes:
         decoder_output (TransformerDeocoderOutput): Contains output from the multimodal transformer decoder.
@@ -200,7 +200,7 @@ class MultimodalGPT(nn.Module):
                 Defaults to ``False``.
 
         Returns:
-            An instance of :class:`~torchmultimodal.models.gpt.MultimodalGPTOutput`.
+            An instance of :class:`~torchmultimodal.models.video_gpt.gpt.MultimodalGPTOutput`.
         """
         decoder_output = self.fwd(
             in_tokens=in_tokens,
@@ -462,7 +462,7 @@ class MultimodalTransformerDecoder(nn.Module):
                 Defaults to ``False``.
 
         Returns:
-            An instace of :class:`~torchmultimodal.models.gpt.TransformerDecoderOutput`.
+            An instace of :class:`~torchmultimodal.models.video_gpt.gpt.TransformerDecoderOutput`.
         """
         if (in_modality is None) and (out_modality is None):
             raise ValueError(
@@ -562,7 +562,7 @@ class TransformerDecoder(nn.Module):
                 Defaults to ``False``.
 
         Returns:
-            An instance of :class:`~torchmultimodal.models.gpt.TransformerDecoderOutput`.
+            An instance of :class:`~torchmultimodal.models.video_gpt.gpt.TransformerDecoderOutput`.
         """
         if attn_mask is not None and attn_mask.dim() == 2:
             attn_mask = attn_mask[
@@ -680,7 +680,7 @@ class TransformerDecoderLayer(nn.Module):
                 Defaults to ``False``.
 
         Returns:
-            An instance of :class:`~torchmultimodal.models.gpt.TransformerLayerOutput`.
+            An instance of :class:`~torchmultimodal.models.video_gpt.gpt.TransformerLayerOutput`.
         """
         attn_probs = None
         past_key_values = None

--- a/torchmultimodal/models/video_gpt/model.py
+++ b/torchmultimodal/models/video_gpt/model.py
@@ -7,14 +7,14 @@
 from typing import Tuple
 
 from torch import nn
-from torchmultimodal.models.gpt import (
+from torchmultimodal.models.video_gpt.gpt import (
     MultimodalGPT,
     MultimodalTransformerDecoder,
     RightShift,
     TransformerDecoder,
     TransformerDecoderLayer,
 )
-from torchmultimodal.models.video_vqvae import VideoDecoder, VideoEncoder
+from torchmultimodal.models.video_gpt.video_vqvae import VideoDecoder, VideoEncoder
 from torchmultimodal.models.vqvae import VQVAE
 
 from torchmultimodal.modules.layers.attention import SelfAttention
@@ -46,14 +46,14 @@ def video_gpt(
             Defaults to ``(16, 64, 64)``.
         latent_shape (Tuple[int, int, int]): Shape of the encoded video data. This should be consistent with
             the actual latent shape inferred by the video encoder.
-            See :class:`~torchmultimodal.models.video_vqvae.VideoEncoder`.
+            See :class:`~torchmultimodal.models.video_gpt.video_vqvae.VideoEncoder`.
             Defaults to ``(8, 32, 32)``.
         d_model (int): Dimension of the underlying transformer decoder.
             Value taken from: https://github.com/wilson1yan/VideoGPT/blob/master/videogpt/gpt.py#L177
             Note that this is different from the paper due to
             :class:`~torchmultimodal.modules.layers.position_embedding.BroadcastedPositionEmbedding`
             requires that ``d_model`` is a multiple of ``len(latent_shape)``.
-            See :py:class:`torchmultimodal.models.gpt.TransformerDecoderLayer`. Defaults to ``576``.
+            See :py:class:`torchmultimodal.models.video_gpt.gpt.TransformerDecoderLayer`. Defaults to ``576``.
         n_head (int): Number of attention heads used by the transformer decoder. Defaults to ``4``.
         dropout (float): Dropout probability used by the projection layer of the transformer decoder.
             Defaults to ``0.2``.
@@ -61,10 +61,10 @@ def video_gpt(
             Defaults to ``0.3``.
         num_decoder_layers (int): Number of transformer decoder layers. Defaults to ``16``.
         use_gpt_init (bool): Whether to use weight initialization of GPT model.
-            See :class:`~torchmultimodal.models.gpt.MultimodalGPT`. Defaults to ``True``.
+            See :class:`~torchmultimodal.models.video_gpt.gpt.MultimodalGPT`. Defaults to ``True``.
 
     Returns:
-        An instance of :class:`~torchmultimodal.models.gpt.MultimodalGPT`.
+        An instance of :class:`~torchmultimodal.models.video_gpt.gpt.MultimodalGPT`.
     """
     # constructs in and out tokenizers
     in_tokenizer = video_vqvae()
@@ -138,7 +138,7 @@ def video_vqvae(
             Dimension-wise strides of the last conv layer of the encoder. Defaults to ``(1, 1, 1)``.
         in_channel_dim (int, optional): Size of channel dim in input. Defaults to ``3``.
         encoder_hidden_dim (int, optional): Size of channel dims in encoder conv layers. Defaults to ``240``.
-        n_res_layers (int, optional): Number of :class:`~torchmultimodal.models.video_vqvae.AttentionResidualBlocks`
+        n_res_layers (int, optional): Number of :class:`~torchmultimodal.models.video_gpt.video_vqvae.AttentionResidualBlocks`
             to include in encoder and decoder. Defaults to ``4``.
         attn_hidden_dim (int, optional): Size of hidden dim of ``AttentionResidualBlocks``. Defaults to ``240``.
         num_embeddings (int, optional): Number of embedding vectors used in ``Codebook``. Defaults to ``1024``.
@@ -156,8 +156,8 @@ def video_vqvae(
 
     Returns:
         An instance of :class:`~torchmultimodal.models.vqvae.VQVAE` constructed with:
-            * :class:`~torchmultimodal.model.video_vqvae.VideoEncoder`
-            * :class:`~torchmultimodal.model.video_vqvae.VideoDecoder`
+            * :class:`~torchmultimodal.model.video_gpt.video_vqvae.VideoEncoder`
+            * :class:`~torchmultimodal.model.video_gpt.video_vqvae.VideoDecoder`
     """
     encoder_kernel_sizes = conv_filter_sizes + (encoder_filter_size,)
     encoder_strides = conv_filter_strides + (encoder_filter_stride,)

--- a/torchmultimodal/models/video_gpt/video_vqvae.py
+++ b/torchmultimodal/models/video_gpt/video_vqvae.py
@@ -6,13 +6,138 @@
 
 from typing import Any, cast, List, Optional, Tuple, Union
 
+import torch
+
 from torch import nn, Size, Tensor
 
 from torchmultimodal.models.vqvae import VQVAE
-from torchmultimodal.modules.layers.attention import AxialAttentionBlock
+from torchmultimodal.modules.layers.attention import (
+    MultiHeadAttention,
+    scaled_dot_product_attention,
+)
 from torchmultimodal.modules.layers.conv import SamePadConv3d, SamePadConvTranspose3d
 from torchmultimodal.utils.assertion import assert_equal_lengths
-from torchmultimodal.utils.common import to_tuple_tuple
+from torchmultimodal.utils.common import shift_dim, to_tuple_tuple
+
+
+class AxialAttention(nn.Module):
+    """Computes attention over a single axis of the input. Other dims are flattened into the batch dimension.
+
+    Args:
+        axial_dim (int): Dimension to compute attention on, indexed by input dimensions
+            (i.e., ``0`` for first input dimension, ``1`` for second).
+        attn_dropout (float): Probability of dropout after softmax. Default is ``0.0``.
+    """
+
+    def __init__(self, axial_dim: int, attn_dropout: float = 0.0) -> None:
+        super().__init__()
+        self.axial_dim = axial_dim + 2  # account for batch, head
+        self.attn_dropout = attn_dropout
+
+    def forward(
+        self,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        attention_mask: Optional[Tensor] = None,
+        head_mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        """
+        Args:
+            q (Tensor): Query input of shape ``(b, h, d1, ..., dn, dim_q)`` where ``h`` is the number of
+                attention heads, ``(d1, ..., dn)`` are the query latent dimensions and ``dim_q`` is the dimension
+                of the query embeddings.
+            k, v (Tensor): Key/value input of shape ``(b, h, d1', ..., dn', dim_kv)`` where ``h`` is the number
+                of attention heads, ``(d1', ..., dn')`` are the key/value latent dimensions and ``dim_kv`` is
+                the dimension of the key/value embeddings.
+            attention_mask (Tensor, optional): Tensor of shape ``(b, h, d1, ..., q_dn, k_dn)`` where ``q_dn`` is
+                the dimension of the axis to compute attention on of the query and ``k_dn`` that of the key.
+                Contains 1s for positions to attend to and 0s for masked positions.
+            head_mask (Tensor, optional): Tensor of shape ``(b, h, d1, ..., q_dn, k_dn)``.
+                Contains 1s for positions to attend to and 0s for masked positions.
+
+        Returns:
+            A tuple of output tensor and attention probabilities.
+        """
+        # Ensure axial dim is within right dimensions, should be between head dim and embedding dim
+        if self.axial_dim >= len(q.shape) - 1:
+            raise ValueError("axial dim does not match input shape")
+
+        # flatten all dims into batch dimension except chosen axial dim and channel dim
+        # b, h, d1, ..., dn, dim_q/dim_kv -> (b, h, d1, ..., dn-1), axial_dim, dim_q/dim_kv
+        q = shift_dim(q, self.axial_dim, -2).flatten(end_dim=-3)
+        k = shift_dim(k, self.axial_dim, -2).flatten(end_dim=-3)
+        v = shift_dim(v, self.axial_dim, -2)
+        old_shape = list(v.shape)
+        v = v.flatten(end_dim=-3)
+
+        out, attn_probs = scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attention_mask=attention_mask,
+            head_mask=head_mask,
+            attn_dropout=self.attn_dropout if self.training else 0.0,
+        )
+        out = out.view(*old_shape)
+        out = shift_dim(out, -2, self.axial_dim)
+        return out, attn_probs
+
+
+class AxialAttentionBlock(nn.Module):
+    """Computes multihead axial attention across all dims of the input.
+
+    Axial attention is an alternative to standard full attention, where instead
+    of computing attention across the entire flattened input, you compute it for
+    each dimension. To capture the global context that full attention does, stacking
+    multiple axial attention layers will allow information to propagate among the
+    multiple dimensions of the input. This enables attention calculations on high
+    dimensional inputs (images, videos) where full attention would be computationally
+    expensive and unfeasible. For more details, see `"Axial Attention in
+    Multidimensional Transformers (Ho et al. 2019)"<https://arxiv.org/pdf/1912.12180.pdf>`_
+    and `"CCNet: Criss-Cross Attention for Semantic Segmentation (Huang et al. 2019)
+    "<https://arxiv.org/pdf/1811.11721.pdf>`_.
+
+    Follows implementation by VideoGPT:
+        https://github.com/wilson1yan/VideoGPT/blob/master/videogpt/vqvae.py
+
+    Args:
+        n_dims (int): Dimensionality of input data, not including batch or embedding dims.
+        qkv_dim (int): Dimensionality of query/key/value embedding vectors.
+        n_head (int): Number of heads in multihead attention. Must divide into ``qkv_dim``
+            evenly.
+    """
+
+    def __init__(self, n_dims: int, qkv_dim: int, n_head: int) -> None:
+        super().__init__()
+        self.qkv_dim = qkv_dim
+        self.mha_attns = nn.ModuleList(
+            [
+                MultiHeadAttention(
+                    dim_q=qkv_dim,
+                    dim_kv=qkv_dim,
+                    n_head=n_head,
+                    attn_module=AxialAttention(d),
+                    add_bias=False,
+                )
+                for d in range(n_dims)
+            ]
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        n_channel = x.shape[1]
+        if n_channel != self.qkv_dim:
+            raise ValueError(
+                f"Input channel dimension is {n_channel}, expected {self.qkv_dim}"
+            )
+
+        h = shift_dim(x, 1, -1)  # (b, c, d1, ..., dn) -> (b, d1, ..., dn, c)
+        attn_out = torch.zeros_like(h)
+        for mha_attn in self.mha_attns:
+            attn_out += mha_attn(h, causal=False)
+        h = attn_out
+        h = shift_dim(h, -1, 1)  # (b, d1, ..., dn, c) -> (b, c, d1, ..., dn)
+        return h
 
 
 def video_vqvae(


### PR DESCRIPTION
Summary:
Condolidating all of the VideoGPT components and models into a single folder which follows our general convention. This change also removes model-specific components like AxialAttention from the general library to reduce confusion for users.

Full set of changes include:
- Move gpt.y, video_gpt.py and video_vqvae.py to models/video_gpt/
- Rename video_gpt.py to model.py to follow convention
- Move AxialAttention and AxialAttentionBlock to video_vqvae.py
- Update all tests
- Update code in examples/mugen

Reviewed By: ebsmothers, pikapecan

Differential Revision: D49753884

