### PR TITLE
Add LDM VAE and its components to diffusion_labs

### DIFF
--- a/tests/diffusion_labs/test_vae.py
+++ b/tests/diffusion_labs/test_vae.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.distributions as tdist
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.diffusion_labs.models.vae.vae import ldm_variational_autoencoder
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(98765)
+
+
+@pytest.fixture
+def embedding_channels():
+    return 6
+
+
+@pytest.fixture
+def in_channels():
+    return 2
+
+
+@pytest.fixture
+def out_channels():
+    return 5
+
+
+@pytest.fixture
+def z_channels():
+    return 3
+
+
+@pytest.fixture
+def channels():
+    return 4
+
+
+@pytest.fixture
+def num_res_blocks():
+    return 2
+
+
+@pytest.fixture
+def channel_multipliers():
+    return (1, 2, 4)
+
+
+@pytest.fixture
+def norm_groups():
+    return 2
+
+
+@pytest.fixture
+def norm_eps():
+    return 1e-05
+
+
+@pytest.fixture
+def x(in_channels):
+    bsize = 2
+    height = 16
+    width = 16
+    return torch.randn(bsize, in_channels, height, width)
+
+
+@pytest.fixture
+def z(embedding_channels):
+    bsize = 2
+    height = 4
+    width = 4
+    return torch.randn(bsize, embedding_channels, height, width)
+
+
+class TestVariationalAutoencoder:
+    @pytest.fixture
+    def vae(
+        self,
+        in_channels,
+        out_channels,
+        embedding_channels,
+        z_channels,
+        channels,
+        norm_groups,
+        norm_eps,
+        channel_multipliers,
+        num_res_blocks,
+    ):
+        return ldm_variational_autoencoder(
+            embedding_channels=embedding_channels,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            z_channels=z_channels,
+            channels=channels,
+            num_res_blocks=num_res_blocks,
+            channel_multipliers=channel_multipliers,
+            norm_groups=norm_groups,
+            norm_eps=norm_eps,
+        )
+
+    def test_encode(self, vae, x, embedding_channels, channel_multipliers):
+        posterior = vae.encode(x)
+        expected_shape = torch.Size(
+            [
+                x.size(0),
+                embedding_channels,
+                x.size(2) // 2 ** (len(channel_multipliers) - 1),
+                x.size(3) // 2 ** (len(channel_multipliers) - 1),
+            ]
+        )
+        expected_mean = torch.tensor(-3.4872)
+        assert_expected(posterior.mean.size(), expected_shape)
+        assert_expected(posterior.mean.sum(), expected_mean, rtol=0, atol=1e-4)
+
+        expected_stddev = torch.tensor(193.3726)
+        assert_expected(posterior.stddev.size(), expected_shape)
+        assert_expected(posterior.stddev.sum(), expected_stddev, rtol=0, atol=1e-4)
+
+        # compute kl with standard gaussian
+        expected_kl = torch.tensor(9.8025)
+        torch_kl_divergence = tdist.kl_divergence(
+            posterior,
+            tdist.Normal(
+                torch.zeros_like(posterior.mean), torch.ones_like(posterior.stddev)
+            ),
+        ).sum()
+        assert_expected(torch_kl_divergence, expected_kl, rtol=0, atol=1e-4)
+
+        # compare sample shape
+        assert_expected(posterior.rsample().size(), expected_shape)
+
+    def test_decode(self, vae, z, out_channels, channel_multipliers):
+        actual = vae.decode(z)
+        expected = torch.tensor(-156.1534)
+        expected_shape = torch.Size(
+            [
+                z.size(0),
+                out_channels,
+                z.size(2) * 2 ** (len(channel_multipliers) - 1),
+                z.size(3) * 2 ** (len(channel_multipliers) - 1),
+            ]
+        )
+        assert_expected(actual.size(), expected_shape)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    @pytest.mark.parametrize(
+        "sample_posterior,expected_value", [(True, -153.6517), (False, -178.8593)]
+    )
+    def test_forward(self, vae, x, out_channels, sample_posterior, expected_value):
+        actual = vae(x, sample_posterior=sample_posterior).decoder_output
+        expected = torch.tensor(expected_value)
+        expected_shape = torch.Size(
+            [
+                x.size(0),
+                out_channels,
+                x.size(2),
+                x.size(3),
+            ]
+        )
+        assert_expected(actual.size(), expected_shape)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)

--- a/tests/diffusion_labs/test_vae_attention.py
+++ b/tests/diffusion_labs/test_vae_attention.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torch import nn
+from torchmultimodal.diffusion_labs.models.vae.attention import (
+    attention_res_block,
+    AttentionResBlock,
+    VanillaAttention,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(1234)
+
+
+@pytest.fixture
+def channels():
+    return 64
+
+
+@pytest.fixture
+def norm_groups():
+    return 16
+
+
+@pytest.fixture
+def norm_eps():
+    return 1e-05
+
+
+@pytest.fixture
+def x(channels):
+    bsize = 2
+    height = 16
+    width = 16
+    return torch.randn(bsize, channels, height, width)
+
+
+class TestVanillaAttention:
+    @pytest.fixture
+    def attn(self, channels):
+        return VanillaAttention(channels)
+
+    def test_forward(self, x, attn):
+        actual = attn(x)
+        expected = torch.tensor(32.0883)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+        assert_expected(actual.shape, x.shape)
+
+
+class TestAttentionResBlock:
+    @pytest.fixture
+    def attn(self, channels, norm_groups, norm_eps):
+        return AttentionResBlock(
+            channels,
+            attn_module=nn.Identity(),
+            norm_groups=norm_groups,
+            norm_eps=norm_eps,
+        )
+
+    def test_forward(self, x, attn):
+        actual = attn(x)
+        expected = torch.tensor(295.1067)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+        assert_expected(actual.shape, x.shape)
+
+    def test_channel_indivisible_norm_group_error(self):
+        with pytest.raises(ValueError):
+            _ = AttentionResBlock(64, nn.Identity(), norm_groups=30)
+
+
+def test_attention_res_block(channels, x):
+    attn = attention_res_block(channels)
+    expected = torch.tensor(69.692)
+    actual = attn(x)
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+    assert_expected(actual.shape, x.shape)

--- a/tests/diffusion_labs/test_vae_encoder_decoder.py
+++ b/tests/diffusion_labs/test_vae_encoder_decoder.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+import pytest
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+
+from torchmultimodal.diffusion_labs.models.vae.encoder_decoder import (
+    res_block,
+    res_block_stack,
+    ResNetDecoder,
+    ResNetEncoder,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(54321)
+
+
+@pytest.fixture
+def in_channels():
+    return 2
+
+
+@pytest.fixture
+def out_channels():
+    return 5
+
+
+@pytest.fixture
+def z_channels():
+    return 3
+
+
+@pytest.fixture
+def channels():
+    return 4
+
+
+@pytest.fixture
+def num_res_blocks():
+    return 2
+
+
+@pytest.fixture
+def channel_multipliers():
+    return (1, 2)
+
+
+@pytest.fixture
+def norm_groups():
+    return 2
+
+
+@pytest.fixture
+def norm_eps():
+    return 1e-05
+
+
+@pytest.fixture
+def x(in_channels):
+    bsize = 2
+    height = 16
+    width = 16
+    return torch.randn(bsize, in_channels, height, width)
+
+
+@pytest.fixture
+def z(z_channels):
+    bsize = 2
+    height = 4
+    width = 4
+    return torch.randn(bsize, z_channels, height, width)
+
+
+class TestResNetEncoder:
+    @pytest.fixture
+    def encoder(
+        self,
+        in_channels,
+        z_channels,
+        channels,
+        num_res_blocks,
+        channel_multipliers,
+        norm_groups,
+        norm_eps,
+    ):
+        return partial(
+            ResNetEncoder,
+            in_channels=in_channels,
+            z_channels=z_channels,
+            channels=channels,
+            num_res_blocks=num_res_blocks,
+            channel_multipliers=channel_multipliers,
+            norm_groups=norm_groups,
+            norm_eps=norm_eps,
+        )
+
+    @pytest.mark.parametrize("double_z", [True, False])
+    def test_forward_dims(self, encoder, x, z_channels, channel_multipliers, double_z):
+        encoder_module = encoder(double_z=double_z)
+        output = encoder_module(x)
+        assert_expected(
+            output.size(),
+            torch.Size(
+                [
+                    x.size(0),
+                    z_channels * (2 if double_z else 1),
+                    x.size(2) // 2 ** (len(channel_multipliers) - 1),
+                    x.size(3) // 2 ** (len(channel_multipliers) - 1),
+                ]
+            ),
+        )
+
+    def test_forward(self, encoder, x):
+        encoder_module = encoder()
+        actual = encoder_module(x)
+        expected = torch.tensor(126.5277)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_channel_indivisble_norm_group_error(self, encoder):
+        with pytest.raises(ValueError):
+            _ = encoder(norm_groups=7)
+
+
+class TestResNetDecoder:
+    @pytest.fixture
+    def decoder(
+        self,
+        out_channels,
+        z_channels,
+        channels,
+        num_res_blocks,
+        channel_multipliers,
+        norm_groups,
+        norm_eps,
+    ):
+        return partial(
+            ResNetDecoder,
+            out_channels=out_channels,
+            z_channels=z_channels,
+            channels=channels,
+            num_res_blocks=num_res_blocks,
+            channel_multipliers=channel_multipliers,
+            norm_groups=norm_groups,
+            norm_eps=norm_eps,
+        )
+
+    @pytest.mark.parametrize("output_alpha_channel", [True, False])
+    def test_forward_dims(
+        self, decoder, z, out_channels, channel_multipliers, output_alpha_channel
+    ):
+        decoder_module = decoder(output_alpha_channel=output_alpha_channel)
+        output = decoder_module(z)
+        assert_expected(
+            output.size(),
+            torch.Size(
+                [
+                    z.size(0),
+                    out_channels + (1 if output_alpha_channel else 0),
+                    z.size(2) * 2 ** (len(channel_multipliers) - 1),
+                    z.size(3) * 2 ** (len(channel_multipliers) - 1),
+                ]
+            ),
+        )
+
+    def test_forward(self, decoder, z):
+        decoder_module = decoder()
+        actual = decoder_module(z)
+        expected = torch.tensor(-10.0260)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_forward_alpha_channel(self, decoder, z):
+        decoder_module = decoder(output_alpha_channel=True)
+        actual = decoder_module(z)
+        expected = torch.tensor(-16.2157)
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+    def test_channel_indivisble_norm_group_error(self, decoder):
+        with pytest.raises(ValueError):
+            _ = decoder(norm_groups=7)
+
+
+@pytest.mark.parametrize("out_channels,expected_value", [(2, 52.2716), (4, 152.8285)])
+def test_res_block(x, out_channels, expected_value):
+    in_channels = x.size(1)
+    res_block_module = res_block(in_channels, out_channels, dropout=0.3, norm_groups=1)
+    actual = res_block_module(x)
+    expected = torch.tensor(expected_value)
+    assert_expected(
+        actual.size(),
+        torch.Size(
+            [
+                x.size(0),
+                out_channels,
+                x.size(2),
+                x.size(3),
+            ]
+        ),
+    )
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "needs_upsample,needs_downsample,expected_value",
+    [(False, True, 28.02428), (False, False, 382.8569), (True, False, 581.62414)],
+)
+def test_res_block_stack(
+    x,
+    in_channels,
+    channels,
+    num_res_blocks,
+    needs_upsample,
+    needs_downsample,
+    expected_value,
+):
+    res_block_stack_module = res_block_stack(
+        in_channels=in_channels,
+        out_channels=channels,
+        num_blocks=num_res_blocks,
+        dropout=0.1,
+        needs_upsample=needs_upsample,
+        needs_downsample=needs_downsample,
+        norm_groups=1,
+    )
+    actual = res_block_stack_module(x)
+    expected = torch.tensor(expected_value)
+    if needs_upsample:
+        size_multipler = 2
+    elif needs_downsample:
+        size_multipler = 0.5
+    else:
+        size_multipler = 1
+    assert_expected(
+        actual.size(),
+        torch.Size(
+            [
+                x.size(0),
+                channels,
+                int(x.size(2) * size_multipler),
+                int(x.size(3) * size_multipler),
+            ]
+        ),
+    )
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+
+def test_res_block_stack_exception(
+    in_channels,
+    channels,
+    num_res_blocks,
+):
+    with pytest.raises(ValueError):
+        _ = res_block_stack(
+            in_channels=in_channels,
+            out_channels=channels,
+            num_blocks=num_res_blocks,
+            needs_upsample=True,
+            needs_downsample=True,
+        )

--- a/tests/diffusion_labs/test_vae_residual_sampling.py
+++ b/tests/diffusion_labs/test_vae_residual_sampling.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+import pytest
+import torch
+from tests.test_utils import assert_expected, set_rng_seed
+from torchmultimodal.diffusion_labs.models.vae.residual_sampling import (
+    Downsample2D,
+    Upsample2D,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    set_rng_seed(54321)
+
+
+@pytest.fixture
+def in_channels():
+    return 2
+
+
+@pytest.fixture
+def x(in_channels):
+    bsize = 2
+    height = 16
+    width = 16
+    return torch.randn(bsize, in_channels, height, width)
+
+
+def test_upsample(in_channels, x):
+    upsampler = Upsample2D(channels=in_channels)
+    actual = upsampler(x)
+    expected = torch.tensor(-350.5232)
+    assert_expected(
+        actual.size(),
+        torch.Size(
+            [
+                x.size(0),
+                x.size(1),
+                x.size(2) * 2,
+                x.size(3) * 2,
+            ]
+        ),
+    )
+    assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)
+
+
+class TestDownsample:
+    @pytest.fixture
+    def downsampler_fn(self, in_channels):
+        return partial(Downsample2D, channels=in_channels)
+
+    @pytest.mark.parametrize(
+        "asymmetric_padding,expected_value", [(True, -18.3393), (False, -28.8385)]
+    )
+    def test_downsample(self, downsampler_fn, x, asymmetric_padding, expected_value):
+        downsampler = downsampler_fn(asymmetric_padding=asymmetric_padding)
+        actual = downsampler(x)
+        expected = torch.tensor(expected_value)
+        assert_expected(
+            actual.size(),
+            torch.Size(
+                [
+                    x.size(0),
+                    x.size(1),
+                    x.size(2) // 2,
+                    x.size(3) // 2,
+                ]
+            ),
+        )
+        assert_expected(actual.sum(), expected, rtol=0, atol=1e-4)

--- a/torchmultimodal/diffusion_labs/models/vae/__init__.py
+++ b/torchmultimodal/diffusion_labs/models/vae/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchmultimodal/diffusion_labs/models/vae/attention.py
+++ b/torchmultimodal/diffusion_labs/models/vae/attention.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import OrderedDict
+
+import torch
+from torch import nn, Tensor
+from torch.nn import functional as F
+from torchmultimodal.modules.layers.normalizations import Fp32GroupNorm
+
+
+class AttentionResBlock(nn.Module):
+    """Attention block in the LDM Autoencoder that consists of group norm, attention,
+    conv projection and a residual connection.
+
+    Follows the architecture described in "High-Resolution Image Synthesis with Latent
+    Diffusion Models" (https://arxiv.org/abs/2112.10752)
+
+    Code ref:
+    https://github.com/CompVis/latent-diffusion/blob/a506df5756472e2ebaf9078affdde2c4f1502cd4/ldm/modules/diffusionmodules/model.py#LL150C1-L150C6
+
+    Attributes:
+        num_channels (int): channel dim expected in input, determines embedding dim of
+            q, k, v in attention module. Needs to be divisible by norm_groups.
+        attn_module (nn.Module): Module of attention mechanism to use.
+        norm_groups (int): number of groups used in GroupNorm layer. Defaults to 32.
+        norm_eps (float): epsilon used in the GroupNorm layer. Defaults to 1e-6.
+
+    Args:
+        x (Tensor): input Tensor of shape [b, c, h, w]
+
+    Raises:
+        ValueError: If `num_channels` is not divisible by `norm_groups`.
+    """
+
+    def __init__(
+        self,
+        num_channels: int,
+        attn_module: nn.Module,
+        norm_groups: int = 32,
+        norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        torch._C._log_api_usage_once(f"torchmultimodal.{self.__class__.__name__}")
+
+        if num_channels % norm_groups != 0:
+            raise ValueError("Channel dims need to be divisible by norm_groups")
+
+        self.net = nn.Sequential(
+            OrderedDict(
+                [
+                    ("norm", Fp32GroupNorm(norm_groups, num_channels, norm_eps)),
+                    ("attn", attn_module),
+                    ("out", nn.Conv2d(num_channels, num_channels, kernel_size=1)),
+                ]
+            )
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.net(x) + x
+
+
+class VanillaAttention(nn.Module):
+    """Attention module used in the LDM Autoencoder. Similar to standard Q, k V attention,
+    but using 2d convolutions instead of linear projections for obtaining q, k, v tensors.
+
+    Follows the architecture described in "High-Resolution Image Synthesis with Latent
+    Diffusion Models" (https://arxiv.org/abs/2112.10752)
+
+    Code ref:
+    https://github.com/CompVis/latent-diffusion/blob/a506df5756472e2ebaf9078affdde2c4f1502cd4/ldm/modules/diffusionmodules/model.py#LL150C1-L150C6
+
+    Attributes:
+        num_channels (int): channel dim expected in input, determines embedding dim of q, k, v.
+
+    Args:
+        x (Tensor): input Tensor of shape [b, c, h, w]
+    """
+
+    def __init__(self, num_channels: int):
+        super().__init__()
+        torch._C._log_api_usage_once(f"torchmultimodal.{self.__class__.__name__}")
+
+        self.query = nn.Conv2d(num_channels, num_channels, kernel_size=1)
+        self.key = nn.Conv2d(num_channels, num_channels, kernel_size=1)
+        self.value = nn.Conv2d(num_channels, num_channels, kernel_size=1)
+
+    def forward(self, x: Tensor) -> Tensor:
+        q, k, v = self.query(x), self.key(x), self.value(x)
+        B, C, H, W = q.shape
+        # [B, C, H, W] -> [B, H*W, C]
+        q, k, v = (t.reshape(B, C, H * W).permute(0, 2, 1) for t in (q, k, v))
+        # [B, H*W, C]
+        out = F.scaled_dot_product_attention(q, k, v)
+        # [B, H*W, C] -> [B, C, H, W]
+        return out.permute(0, 2, 1).reshape(B, C, H, W)
+
+
+def attention_res_block(
+    channels: int,
+    norm_groups: int = 32,
+    norm_eps: float = 1e-6,
+) -> AttentionResBlock:
+    return AttentionResBlock(
+        channels, VanillaAttention(channels), norm_groups, norm_eps
+    )

--- a/torchmultimodal/diffusion_labs/models/vae/encoder_decoder.py
+++ b/torchmultimodal/diffusion_labs/models/vae/encoder_decoder.py
@@ -1,0 +1,312 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+from typing import Sequence
+
+import torch
+from torch import nn, Tensor
+from torchmultimodal.diffusion_labs.models.vae.attention import attention_res_block
+from torchmultimodal.diffusion_labs.models.vae.res_block import ResBlock
+from torchmultimodal.diffusion_labs.models.vae.residual_sampling import (
+    Downsample2D,
+    Upsample2D,
+)
+from torchmultimodal.modules.layers.normalizations import Fp32GroupNorm
+
+
+class ResNetEncoder(nn.Module):
+    """Resnet encoder used in the LDM Autoencoder that consists of a init convolution,
+    downsampling resnet blocks, middle resnet blocks with attention and output convolution block
+    with group normalization and nonlinearity.
+
+    Follows the architecture described in "High-Resolution Image Synthesis with Latent
+    Diffusion Models" (https://arxiv.org/abs/2112.10752)
+
+    Code ref:
+    https://github.com/CompVis/latent-diffusion/blob/a506df5756472e2ebaf9078affdde2c4f1502cd4/ldm/modules/diffusionmodules/model.py#L368
+
+    Attributes:
+        in_channels (int): number of input channels.
+        z_channels (int): number of latent channels.
+        channels (int): number of channels in the initial convolution layer.
+        num_res_block (int): number of residual blocks at each resolution.
+        channel_multipliers (Sequence[int]): list of channel multipliers. Defaults to [1, 2, 4, 8].
+        dropout (float): dropout probability. Defaults to 0.0.
+        double_z (bool): whether to use double z_channels for images or not. Defaults to True.
+        norm_groups (int): number of groups used in GroupNorm layer. Defaults to 32.
+        norm_eps (float): epsilon used in the GroupNorm layer. Defaults to 1e-6.
+
+    Args:
+        x (Tensor): input Tensor of shape [b, c, h, w]
+
+    Raises:
+        ValueError: If `channels` * `channel_multipliers[-1]` is not divisible by `norm_groups`.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        z_channels: int,
+        channels: int,
+        num_res_blocks: int,
+        channel_multipliers: Sequence[int] = (
+            1,
+            2,
+            4,
+            8,
+        ),
+        dropout: float = 0.0,
+        double_z: bool = True,
+        norm_groups: int = 32,
+        norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        torch._C._log_api_usage_once(f"torchmultimodal.{self.__class__.__name__}")
+
+        # initial convolution
+        self.init_conv = nn.Conv2d(in_channels, channels, kernel_size=3, padding=1)
+
+        # downsampling block
+        self.down_block = nn.Sequential()
+        channels_list = tuple(
+            [channels * multiplier for multiplier in [1] + list(channel_multipliers)]
+        )
+        num_resolutions = len(channel_multipliers)
+        for level_idx in range(num_resolutions):
+            block_in = channels_list[level_idx]
+            block_out = channels_list[level_idx + 1]
+            self.down_block.append(
+                res_block_stack(
+                    block_in,
+                    block_out,
+                    num_res_blocks,
+                    dropout,
+                    needs_downsample=True
+                    if level_idx != num_resolutions - 1
+                    else False,
+                    norm_groups=norm_groups,
+                    norm_eps=norm_eps,
+                )
+            )
+
+        mid_channels = channels_list[-1]
+        self.mid_block = nn.Sequential(
+            res_block(mid_channels, mid_channels, dropout, norm_groups, norm_eps),
+            attention_res_block(mid_channels, norm_groups, norm_eps),
+            res_block(mid_channels, mid_channels, dropout, norm_groups, norm_eps),
+        )
+
+        if mid_channels % norm_groups != 0:
+            raise ValueError(
+                "Channel dims obtained by multiplying channels with last"
+                " item in channel_multipliers needs to be divisible by norm_groups"
+            )
+
+        self.out_block = nn.Sequential(
+            Fp32GroupNorm(
+                num_groups=norm_groups, num_channels=mid_channels, eps=norm_eps
+            ),
+            nn.SiLU(),
+            nn.Conv2d(
+                mid_channels,
+                out_channels=2 * z_channels if double_z else z_channels,
+                kernel_size=3,
+                padding=1,
+            ),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        h = self.init_conv(x)
+        h = self.down_block(h)
+        h = self.mid_block(h)
+        h = self.out_block(h)
+        return h
+
+
+class ResNetDecoder(nn.Module):
+    """Resnet decoder used in the LDM Autoencoder that consists of a init convolution,
+    middle resnet blocks with attention, upsamling resnet blocks and output convolution
+    block with group normalization and nonlinearity. Optionally, also supports alpha
+    channel in output.
+
+    Follows the architecture described in "High-Resolution Image Synthesis with Latent
+    Diffusion Models" (https://arxiv.org/abs/2112.10752)
+
+    Code ref:
+    https://github.com/CompVis/latent-diffusion/blob/a506df5756472e2ebaf9078affdde2c4f1502cd4/ldm/modules/diffusionmodules/model.py#L462
+
+    Attributes:
+        out_channels (int): number of channels in output image.
+        z_channels (int): number of latent channels.
+        channels (int): number of channels to be used with channel multipliers.
+        num_res_block (int): number of residual blocks at each resolution.
+        channel_multipliers (Sequence[int]): list of channel multipliers used by the encoder.
+            Decoder uses them in reverse order. Defaults to [1, 2, 4, 8].
+        dropout (float): dropout probability. Defaults to 0.0.
+        norm_groups (int): number of groups used in GroupNorm layer. Defaults to 32.
+        norm_eps (float): epsilon used in the GroupNorm layer. Defaults to 1e-6.
+        output_alpha_channel (bool): whether to include an alpha channel in the output.
+            Defaults to False.
+
+    Args:
+        z (Tensor): input Tensor of shape [b, c, h, w]
+
+    Raises:
+        ValueError: If `channels` * `channel_multipliers[-1]` is not divisible by `norm_groups`.
+    """
+
+    def __init__(
+        self,
+        out_channels: int,
+        z_channels: int,
+        channels: int,
+        num_res_blocks: int,
+        channel_multipliers: Sequence[int] = (
+            1,
+            2,
+            4,
+            8,
+        ),
+        dropout: float = 0.0,
+        norm_groups: int = 32,
+        norm_eps: float = 1e-6,
+        output_alpha_channel: bool = False,
+    ):
+        super().__init__()
+        torch._C._log_api_usage_once(f"torchmultimodal.{self.__class__.__name__}")
+        self.output_alpha_channel = output_alpha_channel
+
+        channels_list = tuple(
+            reversed(
+                [
+                    channels * multiplier
+                    for multiplier in list(channel_multipliers)
+                    + [channel_multipliers[-1]]
+                ]
+            )
+        )
+        mid_channels = channels_list[0]
+
+        # initial convolution
+        self.init_conv = nn.Conv2d(z_channels, mid_channels, kernel_size=3, padding=1)
+
+        # middle block
+        self.mid_block = nn.Sequential(
+            res_block(mid_channels, mid_channels, dropout, norm_groups, norm_eps),
+            attention_res_block(mid_channels, norm_groups, norm_eps),
+            res_block(mid_channels, mid_channels, dropout, norm_groups, norm_eps),
+        )
+
+        # upsample block
+        self.up_block = nn.Sequential()
+        num_resolutions = len(channel_multipliers)
+        for level_idx in range(num_resolutions):
+            block_in = channels_list[level_idx]
+            block_out = channels_list[level_idx + 1]
+            self.up_block.append(
+                res_block_stack(
+                    block_in,
+                    block_out,
+                    # decoder creates 1 additional res block compared to encoder.
+                    # not sure about intuition, but seems to be used everywhere in OSS.
+                    num_res_blocks + 1,
+                    dropout,
+                    needs_upsample=True if level_idx != num_resolutions - 1 else False,
+                    norm_groups=norm_groups,
+                    norm_eps=norm_eps,
+                )
+            )
+
+        # output nonlinearity block
+        post_upsample_channels = channels_list[-1]
+        if post_upsample_channels % norm_groups != 0:
+            raise ValueError(
+                "Channel dims obtained by multiplying channels with first"
+                " item in channel_multipliers needs to be divisible by norm_groups"
+            )
+        self.out_nonlinearity_block = nn.Sequential(
+            Fp32GroupNorm(
+                num_groups=norm_groups,
+                num_channels=post_upsample_channels,
+                eps=norm_eps,
+            ),
+            nn.SiLU(),
+        )
+
+        # output projections
+        self.conv_out = nn.Conv2d(
+            post_upsample_channels, out_channels, kernel_size=3, padding=1
+        )
+        if self.output_alpha_channel:
+            self.alpha_conv_out = nn.Conv2d(
+                post_upsample_channels, 1, kernel_size=3, padding=1
+            )
+
+    def forward(self, z: Tensor) -> Tensor:
+        h = self.init_conv(z)
+        h = self.mid_block(h)
+        h = self.up_block(h)
+        h = self.out_nonlinearity_block(h)
+
+        # If alpha channel is required as output, compute it separately with its
+        # own conv layer and concatenate with the output from the out convolulution
+        if self.output_alpha_channel:
+            h = torch.cat((self.conv_out(h), self.alpha_conv_out(h)), dim=1)
+        else:
+            h = self.conv_out(h)
+
+        return h
+
+
+def res_block_stack(
+    in_channels: int,
+    out_channels: int,
+    num_blocks: int,
+    dropout: float = 0.0,
+    needs_upsample: bool = False,
+    needs_downsample: bool = False,
+    norm_groups: int = 32,
+    norm_eps: float = 1e-6,
+) -> nn.Module:
+    if needs_upsample and needs_downsample:
+        raise ValueError("Cannot use both upsample and downsample in res block")
+    block_in, block_out = in_channels, out_channels
+    block_stack = nn.Sequential()
+    for _ in range(num_blocks):
+        block_stack.append(
+            res_block(block_in, block_out, dropout, norm_groups, norm_eps)
+        )
+        block_in = block_out
+    if needs_downsample:
+        block_stack.append(Downsample2D(out_channels))
+    if needs_upsample:
+        block_stack.append(Upsample2D(out_channels))
+    return block_stack
+
+
+def res_block(
+    in_channels: int,
+    out_channels: int,
+    dropout: float = 0.0,
+    norm_groups: int = 32,
+    norm_eps: float = 1e-6,
+) -> ResBlock:
+    res_block_partial = partial(
+        ResBlock,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        pre_outconv_dropout=dropout,
+        scale_shift_conditional=False,
+        norm_groups=norm_groups,
+        norm_eps=norm_eps,
+    )
+    if in_channels != out_channels:
+        return res_block_partial(
+            skip_conv=nn.Conv2d(in_channels, out_channels, kernel_size=1)
+        )
+    else:
+        return res_block_partial()

--- a/torchmultimodal/diffusion_labs/models/vae/res_block.py
+++ b/torchmultimodal/diffusion_labs/models/vae/res_block.py
@@ -1,0 +1,221 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from torch import nn, Tensor
+from torchmultimodal.modules.layers.normalizations import Fp32GroupNorm
+
+
+class ResBlock(nn.Module):
+    """Residual block in the ADM net. Supports projecting a conditional embedding to add to the hidden state.
+    This typically contains the timestep embedding, but can also contain class embedding for classifier free guidance,
+    CLIP image embedding and text encoder output for text-to-image generation as in DALL-E 2, or anything you want to
+    condition the diffusion model on. If conditional embedding is not passed, the hidden state is simply passed through.
+
+    Follows the architecture described in "Diffusion Models Beat GANs on Image Synthesis"
+    (https://arxiv.org/abs/2105.05233) and BigGAN residual blocks (https://arxiv.org/abs/1809.11096).
+
+    Code ref:
+    https://github.com/openai/guided-diffusion/blob/22e0df8183507e13a7813f8d38d51b072ca1e67c/guided_diffusion/unet.py#L143
+
+
+    Attributes:
+        in_channels (int): num channels expected in input. Needs to be divisible by norm_groups.
+        out_channels (int): num channels desired in output. Needs to be divisible by norm_groups.
+        use_upsample (bool): include nn.Upsample layer before first conv on hidden state and on skip connection.
+            Defaults to False. Cannot be True if use_downsample is True.
+        use_downsample (bool): include nn.AvgPool2d layer before first conv on hidden state and on skip connection.
+            Defaults to False. Cannot be True if use_upsample is True.
+        activation (nn.Module): activation used before convs. Defaults to nn.SiLU().
+        skip_conv (nn.Module): module used for additional convolution on skip connection. Defaults to nn.Identity().
+        cond_proj (Optional[nn.Module]): module used for conditional embedding projection. Defaults to None.
+        rescale_skip_connection (bool): whether to rescale skip connection by 1/sqrt(2), as described in "Diffusion
+            Models Beat GANs on Image Synthesis" (https://arxiv.org/abs/2105.05233). Defaults to False.
+        scale_shift_conditional (bool): if True, splits conditional embedding into two separate projections,
+            and adds to hidden state as Norm(h)(w + 1) + b, as described in Appendix A in
+            "Improved Denoising Diffusion Probabilistic Models" (https://arxiv.org/abs/2102.09672).
+            Defaults to True.
+        pre_outconv_dropout (float): dropout probability before the second conv. Defaults to 0.1.
+        norm_groups (int): number of groups used in GroupNorm layer. Defaults to 32.
+        norm_eps (float): Epsilon used in the GroupNorm layer. Defaults to 1e-5.
+
+
+    Args:
+        x (Tensor): input Tensor of shape [B x C x H x W]
+        conditional_embedding (Tensor, optional): conditioning embedding vector of shape [B x C].
+            If None, hidden state is passed through.
+
+    Raises:
+        TypeError: When skip_conv is not defined and in_channels != out_channels.
+        TypeError: When use_upsample and use_downsample are both True.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        use_upsample: bool = False,
+        use_downsample: bool = False,
+        activation: nn.Module = nn.SiLU(),
+        skip_conv: nn.Module = nn.Identity(),
+        cond_proj: Optional[nn.Module] = None,
+        rescale_skip_connection: bool = False,
+        scale_shift_conditional: bool = True,
+        pre_outconv_dropout: float = 0.1,
+        norm_groups: int = 32,
+        norm_eps: float = 1e-05,
+    ):
+        super().__init__()
+        torch._C._log_api_usage_once(f"torchmultimodal.{self.__class__.__name__}")
+
+        if isinstance(skip_conv, nn.Identity) and in_channels != out_channels:
+            raise ValueError(
+                "You must specify a skip connection conv if out_channels != in_channels"
+            )
+
+        if in_channels % norm_groups != 0 or out_channels % norm_groups != 0:
+            raise ValueError("Channel dims need to be divisible by norm_groups")
+
+        if use_downsample and use_upsample:
+            raise ValueError("Cannot use both upsample and downsample in res block")
+        elif use_downsample:
+            hidden_updownsample_layer = nn.AvgPool2d(kernel_size=2, stride=2)
+            skip_updownsample_layer = nn.AvgPool2d(kernel_size=2, stride=2)
+        elif use_upsample:
+            hidden_updownsample_layer = nn.Upsample(scale_factor=2, mode="nearest")
+            skip_updownsample_layer = nn.Upsample(scale_factor=2, mode="nearest")
+        else:
+            hidden_updownsample_layer = nn.Identity()
+            skip_updownsample_layer = nn.Identity()
+
+        self.cond_proj = cond_proj
+        self.in_block = nn.Sequential(
+            Fp32GroupNorm(
+                norm_groups, in_channels, eps=norm_eps
+            ),  # groups = 32 from code ref
+            activation,
+            hidden_updownsample_layer,
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1),
+        )
+
+        self.out_group_norm = Fp32GroupNorm(norm_groups, out_channels, eps=norm_eps)
+        self.out_block = nn.Sequential(
+            activation,
+            nn.Dropout(pre_outconv_dropout),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1),
+        )
+        self.skip_block = nn.Sequential(
+            skip_updownsample_layer,
+            skip_conv,
+        )
+
+        self.scale_shift_conditional = scale_shift_conditional
+        self.rescale_skip_connection = rescale_skip_connection
+
+    def forward(
+        self,
+        x: Tensor,
+        conditional_embedding: Optional[Tensor] = None,
+    ) -> Tensor:
+        skip = self.skip_block(x)
+        h = self.in_block(x)
+
+        # Add conditional embedding to h, if they are passed and cond_proj is defined
+        if conditional_embedding is not None and self.cond_proj is not None:
+            t = self.cond_proj(conditional_embedding)
+            # [b, c] -> [b, c, 1, 1]
+            t = t.unsqueeze(-1).unsqueeze(-1)
+
+            # If specified, split conditional embedding into two separate projections.
+            # Use half to multiply with hidden state and half to add.
+            # This is typically done after normalization.
+            if self.scale_shift_conditional:
+                h = self.out_group_norm(h)
+                scale, shift = torch.chunk(t, 2, dim=1)
+                h = h * (1 + scale) + shift
+                h = self.out_block(h)
+            else:
+                h = self.out_block(self.out_group_norm(h + t))
+        else:
+            h = self.out_block(self.out_group_norm(h))
+
+        if self.rescale_skip_connection:
+            h = (skip + h) / 1.414
+        else:
+            h = skip + h
+        return h
+
+
+def adm_res_block(
+    in_channels: int,
+    out_channels: int,
+    dim_cond: int,
+    rescale_skip_connection: bool = False,
+) -> ResBlock:
+    if in_channels != out_channels:
+        return adm_res_skipconv_block(in_channels, out_channels, dim_cond)
+    return ResBlock(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        rescale_skip_connection=rescale_skip_connection,
+        cond_proj=adm_cond_proj(dim_cond, out_channels),
+    )
+
+
+def adm_res_downsample_block(
+    num_channels: int,
+    dim_cond: int,
+    rescale_skip_connection: bool = False,
+) -> ResBlock:
+    return ResBlock(
+        in_channels=num_channels,
+        out_channels=num_channels,
+        use_downsample=True,
+        rescale_skip_connection=rescale_skip_connection,
+        cond_proj=adm_cond_proj(dim_cond, num_channels),
+    )
+
+
+def adm_res_skipconv_block(
+    in_channels: int,
+    out_channels: int,
+    dim_cond: int,
+    rescale_skip_connection: bool = False,
+) -> ResBlock:
+    skip_conv = nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=1)
+    return ResBlock(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        skip_conv=skip_conv,
+        rescale_skip_connection=rescale_skip_connection,
+        cond_proj=adm_cond_proj(dim_cond, out_channels),
+    )
+
+
+def adm_res_upsample_block(
+    num_channels: int,
+    dim_cond: int,
+    rescale_skip_connection: bool = False,
+) -> ResBlock:
+    return ResBlock(
+        in_channels=num_channels,
+        out_channels=num_channels,
+        use_upsample=True,
+        rescale_skip_connection=rescale_skip_connection,
+        cond_proj=adm_cond_proj(dim_cond, num_channels),
+    )
+
+
+def adm_cond_proj(
+    dim_cond: int,
+    cond_channels: int,
+    scale_shift_conditional: bool = True,
+) -> nn.Module:
+    if scale_shift_conditional:
+        cond_channels *= 2
+    return nn.Sequential(nn.SiLU(), nn.Linear(dim_cond, cond_channels))

--- a/torchmultimodal/diffusion_labs/models/vae/residual_sampling.py
+++ b/torchmultimodal/diffusion_labs/models/vae/residual_sampling.py
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch import nn as nn, Tensor
+from torch.nn import functional as F
+
+
+class Upsample2D(nn.Module):
+    """2-Dimensional upsampling layer with nearest neighbor interpolation and
+    2D convolution, used for image decoders.
+
+    Code ref:
+    https://github.com/CompVis/latent-diffusion/blob/main/ldm/modules/diffusionmodules/openaimodel.py#L91
+
+    Attributes:
+        channels (int): Number of channels in the input.
+
+    Args:
+        x (Tensor): 2-D image input tensor with shape (n, c, h, w).
+    """
+
+    def __init__(self, channels: int):
+        super().__init__()
+        self.conv = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.conv(F.interpolate(x, scale_factor=2, mode="nearest"))
+
+
+class Downsample2D(nn.Module):
+    """2-Dimensional downsampling layer with zero padding and 2D convolution,
+    used for image encoders.
+
+    Code ref:
+    https://github.com/CompVis/latent-diffusion/blob/main/ldm/modules/diffusionmodules/openaimodel.py#L134
+
+    Attributes:
+        channels (int): Number of channels in the input.
+        asymmetric_padding (bool): Whether to use asymmetric padding.
+            Defaults to True.
+
+    Args:
+        x (Tensor): 2-D image input tensor with shape (n, c, h, w).
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        asymmetric_padding: bool = True,
+    ):
+        super().__init__()
+        if asymmetric_padding:
+            padding = (0, 1, 0, 1)
+        else:
+            padding = 1
+        self.op = nn.Sequential(
+            nn.ZeroPad2d(padding),
+            nn.Conv2d(channels, channels, kernel_size=3, stride=2),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.op(x)

--- a/torchmultimodal/diffusion_labs/models/vae/vae.py
+++ b/torchmultimodal/diffusion_labs/models/vae/vae.py
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import OrderedDict
+from typing import NamedTuple, Sequence
+
+import torch
+from torch import nn, Tensor
+from torch.distributions import Distribution, Normal
+from torchmultimodal.diffusion_labs.models.vae.encoder_decoder import (
+    ResNetDecoder,
+    ResNetEncoder,
+)
+
+
+class VAEOutput(NamedTuple):
+    posterior: Distribution
+    decoder_output: Tensor
+
+
+class VariationalAutoencoder(nn.Module):
+    """Variational Autoencoder (https://arxiv.org/abs/1906.02691) is a special type of autoencoder
+    where the encoder outputs the the parameters of the posterior latent distribution instead of
+    outputting fixed vectors in the latent space. The decoder consumes a sample from the latent
+    distribution to reconstruct the inputs.
+
+    Follows the architecture used in "High-Resolution Image Synthesis with Latent
+    Diffusion Models" (https://arxiv.org/abs/2112.10752)
+
+    Code ref:
+    https://github.com/CompVis/latent-diffusion/blob/main/ldm/models/autoencoder.py#L285
+
+    Attributes:
+        encoder (nn.Module): instance of encoder module.
+        decoder (nn.Module): instance of decoder module.
+
+    Args:
+        x (Tensor): input Tensor of shape [b, c, h, w]
+        sample_posterior (bool): if True, sample from posterior instead of distribution mpde.
+            Defaults to True.
+    """
+
+    def __init__(self, encoder: nn.Module, decoder: nn.Module):
+        super().__init__()
+        torch._C._log_api_usage_once(f"torchmultimodal.{self.__class__.__name__}")
+
+        self.encoder = encoder
+        self.decoder = decoder
+
+    def encode(self, x: Tensor) -> Distribution:
+        h = self.encoder(x)
+        # output of encoder is mean and log variaance of a normal distribution
+        mean, log_variance = torch.chunk(h, 2, dim=1)
+        # clamp logvariance to [-30. 20]
+        log_variance = torch.clamp(log_variance, -30.0, 20.0)
+        stddev = torch.exp(log_variance / 2.0)
+        posterior = Normal(mean, stddev)
+        return posterior
+
+    def decode(self, z: Tensor) -> Tensor:
+        return self.decoder(z)
+
+    def forward(self, x: Tensor, sample_posterior: bool = True) -> VAEOutput:
+        posterior = self.encode(x)
+        if sample_posterior:
+            z = posterior.rsample()
+        else:
+            z = posterior.mode
+        decoder_out = self.decode(z)
+        return VAEOutput(posterior=posterior, decoder_output=decoder_out)
+
+
+def ldm_variational_autoencoder(
+    *,
+    embedding_channels: int,
+    in_channels: int,
+    out_channels: int,
+    z_channels,
+    channels: int,
+    num_res_blocks: int,
+    channel_multipliers: Sequence[int] = (1, 2, 4, 8),
+    dropout: float = 0.0,
+    norm_groups: int = 32,
+    norm_eps: float = 1e-6,
+    output_alpha_channel: bool = False,
+):
+    encoder = nn.Sequential(
+        # pyre-ignore
+        OrderedDict(
+            [
+                (
+                    "resnet_encoder",
+                    ResNetEncoder(
+                        in_channels=in_channels,
+                        z_channels=z_channels,
+                        channels=channels,
+                        num_res_blocks=num_res_blocks,
+                        channel_multipliers=channel_multipliers,
+                        dropout=dropout,
+                        norm_groups=norm_groups,
+                        norm_eps=norm_eps,
+                        double_z=True,
+                    ),
+                ),
+                (
+                    "quant_conv",
+                    nn.Conv2d(2 * z_channels, 2 * embedding_channels, kernel_size=1),
+                ),
+            ]
+        )
+    )
+
+    decoder = nn.Sequential(
+        # pyre-ignore
+        OrderedDict(
+            [
+                (
+                    "post_quant_conv",
+                    nn.Conv2d(embedding_channels, z_channels, kernel_size=1),
+                ),
+                (
+                    "resnet_decoder",
+                    ResNetDecoder(
+                        out_channels=out_channels,
+                        z_channels=z_channels,
+                        channels=channels,
+                        num_res_blocks=num_res_blocks,
+                        channel_multipliers=channel_multipliers,
+                        dropout=dropout,
+                        norm_groups=norm_groups,
+                        norm_eps=norm_eps,
+                        output_alpha_channel=output_alpha_channel,
+                    ),
+                ),
+            ]
+        )
+    )
+
+    return VariationalAutoencoder(encoder=encoder, decoder=decoder)


### PR DESCRIPTION
Summary:
This diff moves LDM VAE and its components to diffusion_labs. Summary of changes:
1. Copy `ldm/autiencoder` files to `diffusion_labs/models/vae`.
1. Add sampling_layers.
1. Add residual_block
1. Add tests

Differential Revision: D50353769


