### PR TITLE
Drop torchtext dep in OSS CLIP transform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 DALL-E==0.1
 iopath
 attrs==23.1.0
+ftfy
+regex

--- a/tests/transforms/test_clip_transform.py
+++ b/tests/transforms/test_clip_transform.py
@@ -8,11 +8,7 @@ import pytest
 
 import torch
 from tests.test_utils import assert_expected, get_asset_path, set_rng_seed
-from torchmultimodal.transforms.clip_transform import (
-    CLIPImageTransform,
-    CLIPTextTransform,
-    CLIPTransform,
-)
+from torchmultimodal.transforms.clip_transform import CLIPImageTransform, CLIPTransform
 from torchvision.transforms import ToPILImage
 
 
@@ -152,9 +148,3 @@ class TestCLIPTransform:
         actual_image_size = transformed_image.size
         expected_image_size = (224, 224)
         assert_expected(actual_image_size, expected_image_size)
-
-    # Only text transforms require torchscripting for now based on user needs
-    def test_scripting_text_transform(self, text1, bpe_merges_file):
-        text_transform = CLIPTextTransform(text_bpe_merges_path=bpe_merges_file)
-        scripted_text_transform = torch.jit.script(text_transform)
-        assert_expected(text_transform(text1), scripted_text_transform(text1))

--- a/tests/transforms/test_text_transforms.py
+++ b/tests/transforms/test_text_transforms.py
@@ -1,0 +1,262 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from tests.test_utils import assert_expected
+from torchmultimodal.transforms.text_transforms import (
+    add_token,
+    AddToken,
+    PadTransform,
+    to_tensor,
+    ToTensor,
+    truncate,
+    Truncate,
+)
+
+
+class TestTransforms:
+    def _totensor(self, test_scripting):
+        padding_value = 0
+        transform = ToTensor(padding_value=padding_value)
+        if test_scripting:
+            transform = torch.jit.script(transform)
+        inputs = [[1, 2], [1, 2, 3]]
+
+        actual = transform(inputs)
+        expected = torch.tensor([[1, 2, 0], [1, 2, 3]], dtype=torch.long)
+        assert_expected(actual, expected)
+
+        inputs = [1, 2]
+        actual = transform(inputs)
+        expected = torch.tensor([1, 2], dtype=torch.long)
+        assert_expected(actual, expected)
+
+    def test_totensor(self) -> None:
+        """test tensorization on both single sequence and batch of sequence"""
+        self._totensor(test_scripting=False)
+
+    def test_totensor_jit(self) -> None:
+        """test tensorization with scripting on both single sequence and batch of sequence"""
+        self._totensor(test_scripting=True)
+
+    def _truncate(self, test_scripting):
+        max_seq_len = 2
+        transform = Truncate(max_seq_len=max_seq_len)
+        if test_scripting:
+            transform = torch.jit.script(transform)
+
+        inputs = [[1, 2], [1, 2, 3]]
+        actual = transform(inputs)
+        expected = [[1, 2], [1, 2]]
+        assert_expected(actual, expected)
+
+        inputs = [1, 2, 3]
+        actual = transform(inputs)
+        expected = [1, 2]
+        assert_expected(actual, expected)
+
+        inputs = [["a", "b"], ["a", "b", "c"]]
+        actual = transform(inputs)
+        expected = [["a", "b"], ["a", "b"]]
+        assert actual == expected
+
+        inputs = ["a", "b", "c"]
+        actual = transform(inputs)
+        expected = ["a", "b"]
+        assert actual == expected
+
+    def test_truncate(self) -> None:
+        """test truncation on both sequence and batch of sequence with both str and int types"""
+        self._truncate(test_scripting=False)
+
+    def test_truncate_jit(self) -> None:
+        """test truncation with scripting on both sequence and batch of sequence with both str and int types"""
+        self._truncate(test_scripting=True)
+
+    def _add_token(self, test_scripting):
+        token_id = 0
+        transform = AddToken(token_id, begin=True)
+        if test_scripting:
+            transform = torch.jit.script(transform)
+        inputs = [[1, 2], [1, 2, 3]]
+
+        actual = transform(inputs)
+        expected = [[0, 1, 2], [0, 1, 2, 3]]
+        assert_expected(actual, expected)
+
+        transform = AddToken(token_id, begin=False)
+        if test_scripting:
+            transform = torch.jit.script(transform)
+
+        actual = transform(inputs)
+        expected = [[1, 2, 0], [1, 2, 3, 0]]
+        assert_expected(actual, expected)
+
+        inputs = [1, 2]
+        actual = transform(inputs)
+        expected = [1, 2, 0]
+        assert_expected(actual, expected)
+
+        token_id = "0"
+        transform = AddToken(token_id, begin=True)
+        if test_scripting:
+            transform = torch.jit.script(transform)
+        inputs = [["1", "2"], ["1", "2", "3"]]
+
+        actual = transform(inputs)
+        expected = [["0", "1", "2"], ["0", "1", "2", "3"]]
+        assert actual == expected
+
+        transform = AddToken(token_id, begin=False)
+        if test_scripting:
+            transform = torch.jit.script(transform)
+
+        actual = transform(inputs)
+        expected = [["1", "2", "0"], ["1", "2", "3", "0"]]
+        assert actual == expected
+
+        inputs = ["1", "2"]
+        actual = transform(inputs)
+        expected = ["1", "2", "0"]
+        assert actual == expected
+
+    def test_add_token(self) -> None:
+        self._add_token(test_scripting=False)
+
+    def test_add_token_jit(self) -> None:
+        self._add_token(test_scripting=True)
+
+    def _pad_transform(self, test_scripting):
+        """
+        Test padding transform on 1D and 2D tensors.
+        When max_length < tensor length at dim -1, this should be a no-op.
+        Otherwise the tensor should be padded to max_length in dim -1.
+        """
+
+        inputs_1d_tensor = torch.ones(5)
+        inputs_2d_tensor = torch.ones((8, 5))
+        pad_long = PadTransform(max_length=7, pad_value=0)
+        if test_scripting:
+            pad_long = torch.jit.script(pad_long)
+        padded_1d_tensor_actual = pad_long(inputs_1d_tensor)
+        padded_1d_tensor_expected = torch.cat([torch.ones(5), torch.zeros(2)])
+        assert_expected(
+            padded_1d_tensor_actual,
+            padded_1d_tensor_expected,
+        )
+
+        padded_2d_tensor_actual = pad_long(inputs_2d_tensor)
+        padded_2d_tensor_expected = torch.cat(
+            [torch.ones(8, 5), torch.zeros(8, 2)], axis=-1
+        )
+        assert_expected(
+            padded_2d_tensor_actual,
+            padded_2d_tensor_expected,
+        )
+
+        pad_short = PadTransform(max_length=3, pad_value=0)
+        if test_scripting:
+            pad_short = torch.jit.script(pad_short)
+        padded_1d_tensor_actual = pad_short(inputs_1d_tensor)
+        padded_1d_tensor_expected = inputs_1d_tensor
+        assert_expected(
+            padded_1d_tensor_actual,
+            padded_1d_tensor_expected,
+        )
+
+        padded_2d_tensor_actual = pad_short(inputs_2d_tensor)
+        padded_2d_tensor_expected = inputs_2d_tensor
+        assert_expected(
+            padded_2d_tensor_actual,
+            padded_2d_tensor_expected,
+        )
+
+    def test_pad_transform(self) -> None:
+        self._pad_transform(test_scripting=False)
+
+    def test_pad_transform_jit(self) -> None:
+        self._pad_transform(test_scripting=True)
+
+
+class TestFunctional:
+    @pytest.mark.parametrize("test_scripting", [True, False])
+    @pytest.mark.parametrize(
+        "configs",
+        [
+            [[[1, 2], [1, 2, 3]], 0, [[1, 2, 0], [1, 2, 3]]],
+            [[[1, 2], [1, 2, 3]], 1, [[1, 2, 1], [1, 2, 3]]],
+            [[1, 2], 0, [1, 2]],
+        ],
+    )
+    def test_to_tensor(self, test_scripting, configs):
+        """test tensorization on both single sequence and batch of sequence"""
+        inputss, padding_value, expected_list = configs
+        func = to_tensor
+        if test_scripting:
+            func = torch.jit.script(func)
+
+        actual = func(inputss, padding_value=padding_value)
+        expected = torch.tensor(expected_list, dtype=torch.long)
+        assert_expected(actual, expected)
+
+    def test_to_tensor_assert_raises(self) -> None:
+        """test raise type error if inputs provided is not in Union[List[int],List[List[int]]]"""
+        with pytest.raises(TypeError):
+            to_tensor("test")
+
+    @pytest.mark.parametrize("test_scripting", [True, False])
+    @pytest.mark.parametrize(
+        "configs",
+        [
+            [[[1, 2], [1, 2, 3]], [[1, 2], [1, 2]]],
+            [[1, 2, 3], [1, 2]],
+            [[["a", "b"], ["a", "b", "c"]], [["a", "b"], ["a", "b"]]],
+            [["a", "b", "c"], ["a", "b"]],
+        ],
+    )
+    def test_truncate(self, test_scripting, configs):
+        """test truncation to max_seq_len length on both sequence and batch of sequence with both str/int types"""
+        inputss, expected = configs
+        max_seq_len = 2
+        func = truncate
+        if test_scripting:
+            func = torch.jit.script(func)
+
+        actual = func(inputss, max_seq_len=max_seq_len)
+        assert actual == expected
+
+    def test_truncate_assert_raises(self) -> None:
+        """test raise type error if inputs provided is not in Union[List[Union[str, int]], List[List[Union[str, int]]]]"""
+        with pytest.raises(TypeError):
+            truncate("test", max_seq_len=2)
+
+    @pytest.mark.parametrize("test_scripting", [True, False])
+    @pytest.mark.parametrize(
+        "configs",
+        [
+            # case: List[List[int]]
+            [[[1, 2], [1, 2, 3]], 0, [[0, 1, 2], [0, 1, 2, 3]], True],
+            [[[1, 2], [1, 2, 3]], 0, [[1, 2, 0], [1, 2, 3, 0]], False],
+            # case: List[int]
+            [[1, 2], 0, [0, 1, 2], True],
+            [[1, 2], 0, [1, 2, 0], False],
+            # case: List[List[str]]
+            [[["a", "b"], ["c", "d"]], "x", [["x", "a", "b"], ["x", "c", "d"]], True],
+            [[["a", "b"], ["c", "d"]], "x", [["a", "b", "x"], ["c", "d", "x"]], False],
+            # case: List[str]
+            [["a", "b"], "x", ["x", "a", "b"], True],
+            [["a", "b"], "x", ["a", "b", "x"], False],
+        ],
+    )
+    def test_add_token(self, test_scripting, configs):
+        inputss, token_id, expected, begin = configs
+        func = add_token
+        if test_scripting:
+            func = torch.jit.script(func)
+
+        actual = func(inputss, token_id=token_id, begin=begin)
+        assert actual == expected

--- a/torchmultimodal/transforms/clip_transform.py
+++ b/torchmultimodal/transforms/clip_transform.py
@@ -4,14 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, List, Optional, Tuple, Union
+import html
+from functools import lru_cache
+from typing import Callable, Dict, List, Optional, Set, Tuple, Union
+
+import ftfy
+import regex as re
 
 import torch
 from PIL.Image import Image
 from torch import nn, Tensor
 from torchmultimodal import _PATH_MANAGER
-from torchtext import transforms as text_transforms
-from torchtext.transforms import CLIPTokenizer
+from torchmultimodal.transforms import text_transforms
 from torchvision import transforms as image_transforms
 from torchvision.transforms import InterpolationMode
 
@@ -25,6 +29,217 @@ def convert_to_rgb(img: Image) -> Image:
     return img.convert("RGB")
 
 
+@lru_cache()
+def bytes_to_unicode() -> Dict[int, str]:
+    """
+    Returns list of utf-8 byte and a corresponding list of unicode strings.
+    The reversible bpe codes work on unicode strings.
+    This means you need a large # of unicode characters in your vocab if you want to avoid UNKs.
+    When you're at something like a 10B token dataset you end up needing around 5K for decent coverage.
+    This is a signficant percentage of your normal, say, 32K bpe vocab.
+    To avoid that, we want lookup tables between utf-8 bytes and unicode strings.
+    And avoids mapping to whitespace/control characters the bpe code barfs on.
+    """
+    bs = (
+        list(range(ord("!"), ord("~") + 1))
+        + list(range(ord("¡"), ord("¬") + 1))
+        + list(range(ord("®"), ord("ÿ") + 1))
+    )
+    cs = bs[:]
+    n = 0
+    for b in range(2**8):
+        if b not in bs:
+            bs.append(b)
+            cs.append(2**8 + n)
+            n += 1
+    cs = [chr(n) for n in cs]
+    return dict(zip(bs, cs))  # noqa
+
+
+def get_pairs(word: Tuple[str, ...]) -> Set[Tuple[str, str]]:
+    """
+    Return set of symbol pairs in a word.
+    Word is represented as tuple of symbols (symbols being variable-length strings).
+    """
+    pairs = set()
+    prev_char = word[0]
+    for char in word[1:]:
+        pairs.add((prev_char, char))
+        prev_char = char
+    return pairs
+
+
+def basic_clean(text: str) -> str:
+    text = ftfy.fix_text(text)
+    text = html.unescape(html.unescape(text))
+    return text.strip()
+
+
+def whitespace_clean(text: str) -> str:
+    text = re.sub(r"\s+", " ", text)
+    text = text.strip()
+    return text
+
+
+class CLIPBPETokenizer:
+    """
+    Construct a CLIP tokenizer. Based on byte-level Byte-Pair-Encoding.
+
+    This implementation is adapted from https://git.io/JDTuJ.
+    Example usage:
+    tokenizer = CLIPBPETokenizer()
+    sentence = "Hello I am using CLIP tokenizer."
+    tokens = tokenizer.encode(sentence)
+    tokens -> [3306, 328, 687, 1996, 9289, 32634, 23895, 269]
+    decoded_sentence = tokenizer.decode(tokens)
+    decoded_sentence -> "hello i am using clip tokenizer ."
+
+    Args:
+        bpe_path (str): path to the BPE file
+        bos_token (str): beginning of sentence token. Defaults to "<|startoftext|>".
+        eos_token (str): end of sentence token. Defaults to "<|endoftext|>".
+        num_merges (Optional[int]): number of merges.
+            If None, it will load all merges from the BPE file.
+    """
+
+    def __init__(
+        self,
+        bpe_path: str = CLIP_DEFAULT_VOCAB_BPE_PATH,
+        bos_token: str = "<|startoftext|>",
+        eos_token: str = "<|endoftext|>",
+        num_merges: Optional[int] = None,  # TODO: add docstring
+    ):
+        self._separator = "\u0001"
+        self.byte_encoder = bytes_to_unicode()
+        self.byte_decoder = {v: k for k, v in self.byte_encoder.items()}
+
+        with _PATH_MANAGER.open(bpe_path, "r", encoding="utf-8") as f:
+            bpe_merges = f.read().split("\n")[1:]
+        num_merges = num_merges or len(bpe_merges)
+        bpe_merges = bpe_merges[:num_merges]
+        self.bpe_merges = bpe_merges[:num_merges]
+        bpe_merges = [tuple(merge.split()) for merge in bpe_merges]
+        self.num_merges = num_merges
+        self.bpe_ranks = dict(zip(bpe_merges, range(len(bpe_merges))))  # noqa
+        bpe_vocab = list(bytes_to_unicode().values())
+        bpe_vocab = bpe_vocab + [v + "</w>" for v in bpe_vocab]
+        bpe_vocab.extend(
+            ["".join(merge_pair) for merge_pair in bpe_merges[:num_merges]]
+        )
+        special_tokens = [bos_token, eos_token]
+        bpe_vocab.extend(special_tokens)
+        self.bpe_vocab = bpe_vocab
+        self.encoder = {v: i for i, v in enumerate(bpe_vocab)}
+        self.decoder = {v: k for k, v in self.encoder.items()}
+        self.cache = {tok: tok for tok in special_tokens}
+        self.pat = re.compile(
+            r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+""",
+            re.IGNORECASE,
+        )
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.encoder)
+
+    def bpe(self, token: str) -> str:
+        if token in self.cache:
+            return self.cache[token]
+        word = tuple(token[:-1]) + (token[-1] + "</w>",)
+        pairs = get_pairs(word)
+        if not pairs:
+            return token + "</w>"
+
+        while True:
+            bigram = min(pairs, key=lambda pair: self.bpe_ranks.get(pair, float("inf")))
+            if bigram not in self.bpe_ranks:
+                break
+            first, second = bigram
+            new_word: List[str] = []
+            i = 0
+            while i < len(word):
+                try:
+                    j = word.index(first, i)
+                except ValueError:
+                    new_word.extend(word[i:])
+                    break
+                else:
+                    new_word.extend(word[i:j])
+                    i = j
+
+                if word[i] == first and i < len(word) - 1 and word[i + 1] == second:
+                    new_word.append(first + second)
+                    i += 2
+                else:
+                    new_word.append(word[i])
+                    i += 1
+            new_word = tuple(new_word)
+            word = new_word
+            if len(word) == 1:
+                break
+            else:
+                pairs = get_pairs(word)
+        word = " ".join(word)
+        self.cache[token] = word
+        return word
+
+    def encode(self, text: str) -> List[int]:
+        bpe_tokens: List[int] = []
+        text = text.lower().strip()
+        for token in re.findall(self.pat, text):
+            token = "".join(self.byte_encoder[b] for b in token.encode("utf-8"))
+            bpe_tokens.extend(
+                self.encoder[bpe_token] for bpe_token in self.bpe(token).split(" ")
+            )
+        return bpe_tokens
+
+    def decode(self, tokens: List[int]) -> str:
+        text = "".join([self.decoder[token] for token in tokens])
+        text = (
+            bytearray([self.byte_decoder[c] for c in text])
+            .decode("utf-8", errors="replace")
+            .replace("</w>", " ")
+        )
+        return text
+
+
+class CLIPBPETransform(nn.Module):
+    """
+    nn.Module wrapper around CLIPBPETokenizer. Supports either a single string
+    or list of strings for tokenization.
+
+    Args:
+        bpe_path (Optional[str]): path to the BPE file.
+            Defaults to CLIP_DEFAULT_VOCAB_BPE_PATH
+        bos_token (Optional[str]): beginning of sentence token.
+            Defaults to "<|startoftext|>".
+        eos_token (Optional[str]): end of sentence token.
+            Defaults to "<|endoftext|>".
+        num_merges (Optional[int]): number of merges.
+            If None, it will load all merges from the BPE file.
+    """
+
+    def __init__(
+        self,
+        bpe_path: Optional[str] = CLIP_DEFAULT_VOCAB_BPE_PATH,
+        bos_token: Optional[str] = "<|startoftext|>",
+        eos_token: Optional[str] = "<|endoftext|>",
+        num_merges: Optional[int] = None,
+    ):
+        super().__init__()
+        self.bpe = CLIPBPETokenizer(
+            bpe_path=bpe_path,
+            bos_token=bos_token,
+            eos_token=eos_token,
+            num_merges=num_merges,
+        )
+
+    def forward(self, text: Union[str, List[str]]) -> Union[List[int], List[List[int]]]:
+        if isinstance(text, str):
+            return self.bpe.encode(text)
+        else:
+            return [self.bpe.encode(t) for t in text]
+
+
 class CLIPTextTransform(nn.Module):
     """CLIP text transform
     CLIP BPE tokenizer transform, adds start and end tokens, then pads/truncates to text_max_length as necessary.
@@ -34,7 +249,6 @@ class CLIPTextTransform(nn.Module):
         text_start_token (str): Special start token passed to BPE tokenizer.
         text_end_token (str): Special end token passed to BPE tokenizer.
         text_bpe_merges_path (str): Location of BPE merges file for text transform.
-        text_encoder_json_path (str, optional): Location of BPE encoder JSON file.
         num_merges (int, optional): Number of merges to use from BPE merges file.
             Default: 48894 = 49152 (vocab size) - 256 (# bytes) - 2 (bos/eos tokens)
 
@@ -49,26 +263,24 @@ class CLIPTextTransform(nn.Module):
         text_start_token: str = "<|startoftext|>",
         text_end_token: str = "<|endoftext|>",
         text_bpe_merges_path: str = CLIP_DEFAULT_VOCAB_BPE_PATH,
-        text_encoder_json_path: Optional[str] = None,
         num_merges: Optional[int] = 48894,
     ) -> None:
 
         super().__init__()
         local_merges_path = _PATH_MANAGER.get_local_path(text_bpe_merges_path)
-        tokenizer = CLIPTokenizer(
-            local_merges_path, text_encoder_json_path, num_merges=num_merges
+        tokenizer = CLIPBPETransform(
+            local_merges_path, text_start_token, text_end_token, num_merges
         )
         text_start_token = tokenizer([text_start_token])[0][0]
         text_end_token = tokenizer([text_end_token])[0][0]
         text_max_length = text_max_length
 
-        self.text_transform = text_transforms.Sequential(
+        self.text_transform = nn.Sequential(
             *[
                 tokenizer,
                 text_transforms.Truncate(text_max_length - 2),
                 text_transforms.AddToken(text_start_token, begin=True),
                 text_transforms.AddToken(text_end_token, begin=False),
-                text_transforms.StrToIntTransform(),
                 text_transforms.ToTensor(padding_value=0),
                 text_transforms.PadTransform(max_length=text_max_length, pad_value=0),
             ]
@@ -154,7 +366,6 @@ class CLIPTransform(nn.Module):
         text_start_token (str): Special start token passed to BPE tokenizer.
         text_end_token (str): Special end token passed to BPE tokenizer.
         text_bpe_merges_path (str): Location of BPE merges file for text transform.
-        text_encoder_json_path (str, optional): Location of BPE encoder JSON file.
         num_merges (int, optional): Number of merges to use from BPE merges file.
             Default: 48894 = 49152 (vocab size) - 256 (# bytes) - 2 (bos/eos tokens)
 
@@ -176,7 +387,6 @@ class CLIPTransform(nn.Module):
         text_start_token: str = "<|startoftext|>",
         text_end_token: str = "<|endoftext|>",
         text_bpe_merges_path: str = CLIP_DEFAULT_VOCAB_BPE_PATH,
-        text_encoder_json_path: Optional[str] = None,
         num_merges: Optional[int] = 48894,
     ) -> None:
 
@@ -189,7 +399,6 @@ class CLIPTransform(nn.Module):
             text_start_token,
             text_end_token,
             text_bpe_merges_path,
-            text_encoder_json_path,
             num_merges,
         )
 

--- a/torchmultimodal/transforms/text_transforms.py
+++ b/torchmultimodal/transforms/text_transforms.py
@@ -1,0 +1,217 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, List, Optional, Union
+
+import torch
+from torch import nn, Tensor
+from torch.nn.utils.rnn import pad_sequence
+
+
+class Truncate(nn.Module):
+    r"""Truncate input sequence
+
+    :param max_seq_len: The maximum allowable length for input sequence
+    :type max_seq_len: int
+    """
+
+    def __init__(self, max_seq_len: int) -> None:
+        super().__init__()
+        self.max_seq_len = max_seq_len
+
+    def forward(self, x: Any) -> Any:
+        """
+        :param input: Input sequence or batch of sequence to be truncated
+        :type input: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+        :return: Truncated sequence
+        :rtype: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+        """
+        return truncate(x, self.max_seq_len)
+
+
+class AddToken(nn.Module):
+    """Add token to beginning or end of sequence
+
+    :param token: The token to be added
+    :type token: Union[int, str]
+    :param begin: Whether to insert token at start or end or sequence, defaults to True
+    :type begin: bool, optional
+    """
+
+    def __init__(self, token: Union[int, str], begin: bool = True) -> None:
+        super().__init__()
+        self.token = token
+        self.begin = begin
+
+    def forward(self, input: Any) -> Any:
+        """
+        :param input: Input sequence or batch
+        :type input: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+        """
+
+        return add_token(input, self.token, self.begin)
+
+
+class PadTransform(nn.Module):
+    """Pad tensor to a fixed length with given padding value.
+
+    :param max_length: Maximum length to pad to
+    :type max_length: int
+    :param pad_value: Value to pad the tensor with
+    :type pad_value: bool
+    """
+
+    def __init__(self, max_length: int, pad_value: int) -> None:
+        super().__init__()
+        self.max_length = max_length
+        self.pad_value = float(pad_value)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        :param x: The tensor to pad
+        :type x: Tensor
+        :return: Tensor padded up to max_length with pad_value
+        :rtype: Tensor
+        """
+        max_encoded_length = x.size(-1)
+        if max_encoded_length < self.max_length:
+            pad_amount = self.max_length - max_encoded_length
+            x = torch.nn.functional.pad(x, (0, pad_amount), value=self.pad_value)
+        return x
+
+
+class ToTensor(nn.Module):
+    r"""Convert input to torch tensor
+
+    :param padding_value: Pad value to make each input in the batch of length equal to the longest sequence in the batch.
+    :type padding_value: Optional[int]
+    :param dtype: :class:`torch.dtype` of output tensor
+    :type dtype: :class:`torch.dtype`
+    """
+
+    def __init__(
+        self, padding_value: Optional[int] = None, dtype: torch.dtype = torch.long
+    ) -> None:
+        super().__init__()
+        self.padding_value = padding_value
+        self.dtype = dtype
+
+    def forward(self, input: Any) -> Tensor:
+        """
+        :param input: Sequence or batch of token ids
+        :type input: Union[List[int], List[List[int]]]
+        :rtype: Tensor
+        """
+        return to_tensor(input, padding_value=self.padding_value, dtype=self.dtype)
+
+
+def to_tensor(
+    input: Any, padding_value: Optional[int] = None, dtype: torch.dtype = torch.long
+) -> Tensor:
+    r"""Convert input to torch tensor
+
+    :param padding_value: Pad value to make each input in the batch of length equal to the longest sequence in the batch.
+    :type padding_value: Optional[int]
+    :param dtype: :class:`torch.dtype` of output tensor
+    :type dtype: :class:`torch.dtype`
+    :param input: Sequence or batch of token ids
+    :type input: Union[List[int], List[List[int]]]
+    :rtype: Tensor
+    """
+    if torch.jit.isinstance(input, List[int]):
+        return torch.tensor(input, dtype=torch.long)
+    elif torch.jit.isinstance(input, List[List[int]]):
+        if padding_value is None:
+            output = torch.tensor(input, dtype=dtype)
+            return output
+        else:
+            output = pad_sequence(
+                [torch.tensor(ids, dtype=dtype) for ids in input],
+                batch_first=True,
+                padding_value=float(padding_value),
+            )
+            return output
+    else:
+        raise TypeError("Input type not supported")
+
+
+def truncate(input: Any, max_seq_len: int) -> Any:
+    """Truncate input sequence or batch
+
+    :param input: Input sequence or batch to be truncated
+    :type input: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+    :param max_seq_len: Maximum length beyond which input is discarded
+    :type max_seq_len: int
+    :return: Truncated sequence
+    :rtype: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+    """
+    if torch.jit.isinstance(input, List[int]):
+        return input[:max_seq_len]
+    elif torch.jit.isinstance(input, List[str]):
+        return input[:max_seq_len]
+    elif torch.jit.isinstance(input, List[List[int]]):
+        output_int: List[List[int]] = []
+        for ids in input:
+            output_int.append(ids[:max_seq_len])
+        return output_int
+    elif torch.jit.isinstance(input, List[List[str]]):
+        output_str: List[List[str]] = []
+        for ids in input:
+            output_str.append(ids[:max_seq_len])
+        return output_str
+    else:
+        raise TypeError("Input type not supported")
+
+
+def add_token(input: Any, token_id: Any, begin: bool = True) -> Any:
+    """Add token to start or end of sequence
+
+    :param input: Input sequence or batch
+    :type input: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+    :param token_id: token to be added
+    :type token_id: Union[str, int]
+    :param begin: Whether to insert token at start or end or sequence, defaults to True
+    :type begin: bool, optional
+    :return: sequence or batch with token_id added to begin or end or input
+    :rtype: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+    """
+    if torch.jit.isinstance(input, List[int]) and torch.jit.isinstance(token_id, int):
+        if begin:
+            return [token_id] + input
+        else:
+            return input + [token_id]
+    elif torch.jit.isinstance(input, List[str]) and torch.jit.isinstance(token_id, str):
+        if begin:
+            return [token_id] + input
+        else:
+            return input + [token_id]
+    elif torch.jit.isinstance(input, List[List[int]]) and torch.jit.isinstance(
+        token_id, int
+    ):
+        output_int: List[List[int]] = []
+
+        if begin:
+            for ids in input:
+                output_int.append([token_id] + ids)
+        else:
+            for ids in input:
+                output_int.append(ids + [token_id])
+
+        return output_int
+    elif torch.jit.isinstance(input, List[List[str]]) and torch.jit.isinstance(
+        token_id, str
+    ):
+        output_str: List[List[str]] = []
+        if begin:
+            for ids in input:
+                output_str.append([token_id] + ids)
+        else:
+            for ids in input:
+                output_str.append(ids + [token_id])
+
+        return output_str
+    else:
+        raise TypeError("Input type not supported")


### PR DESCRIPTION
Summary: Replace our OSS CLIP transform's tokenizer with a pure Python tokenizer we used previously instead of importing the one from torchtext. The goal here is to drop our torchtext dep in OSS to clear our failing CI.

Reviewed By: pikapecan

Differential Revision: D50481489


