### PR TITLE
Remaining fixes to unblock nightly build

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, NamedTuple, Optional, Tuple, Union
 
+import numpy as np
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -240,6 +242,50 @@ def split_tensor_for_distributed_test(
     if move_to_device:
         x = x.to(device=device_id)
     return x
+
+
+def fixed_init_tensor(
+    shape: torch.Size,
+    min_val: Union[float, int] = 0.0,
+    max_val: Union[float, int] = 1.0,
+    nonlinear: bool = False,
+    dtype: torch.dtype = torch.float,
+):
+    """
+    Utility for generating deterministic tensors of a given shape. In general stuff
+    like torch.ones, torch.eye, etc can result in trivial outputs. This utility
+    generates a range tensor [min_val, max_val) of a specified dtype, applies
+    a sine function if nonlinear=True, then reshapes to the appropriate shape.
+    """
+    n_elements = np.prod(shape)
+    step_size = (max_val - min_val) / n_elements
+    x = torch.arange(min_val, max_val, step_size, dtype=dtype).reshape(shape)
+    if nonlinear:
+        return torch.sin(x)
+    return x
+
+
+@torch.no_grad
+def fixed_init_model(
+    model: nn.Module,
+    min_val: Union[float, int] = 0.0,
+    max_val: Union[float, int] = 1.0,
+    nonlinear: bool = False,
+):
+    """
+    This utility initializes all parameters of a model deterministically using the
+    function fixed_init_tensor above. See that docstring for details of each parameter.
+    """
+    for name, param in model.named_parameters():
+        param.copy_(
+            fixed_init_tensor(
+                param.shape,
+                min_val=min_val,
+                max_val=max_val,
+                nonlinear=nonlinear,
+                dtype=param.dtype,
+            )
+        )
 
 
 def skip_if_no_ffmpeg(message="Requires ffmpeg"):

--- a/tests/transforms/test_mae_transform.py
+++ b/tests/transforms/test_mae_transform.py
@@ -10,7 +10,12 @@ import numpy as np
 import pytest
 import torch
 from PIL import Image
-from tests.test_utils import assert_expected, get_asset_path, set_rng_seed
+from tests.test_utils import (
+    assert_expected,
+    get_asset_path,
+    set_rng_seed,
+    skip_if_no_ffmpeg,
+)
 from torchmultimodal.transforms.mae_transform import (
     AudioEvalTransform,
     AudioFineTuneTransform,
@@ -275,11 +280,13 @@ class TestAudioEvalTransform:
     def transform(self):
         return AudioEvalTransform()
 
+    @skip_if_no_ffmpeg()
     def test_transform(self, transform, wav):
         actual = transform(wav)
         assert_expected(actual.size(), (1, 1024, 128))
         assert_expected(actual.sum().item(), 52000.8828, atol=0.0001, rtol=0.0)
 
+    @skip_if_no_ffmpeg()
     def test_transform_list(self, transform, wav):
         actual = transform([wav])
         assert_expected(actual.size(), (1, 1, 1024, 128))
@@ -295,11 +302,13 @@ class TestAudioPretrainTransform:
     def transform(self):
         return AudioPretrainTransform()
 
+    @skip_if_no_ffmpeg()
     def test_transform(self, transform, wav):
         actual = transform(wav)
         assert_expected(actual.size(), (1, 1024, 128))
         assert_expected(actual.sum().item(), 52072.4531, atol=0.0001, rtol=0.0001)
 
+    @skip_if_no_ffmpeg()
     def test_transform_list(self, transform, wav):
         actual = transform([wav])
         assert_expected(actual.size(), (1, 1, 1024, 128))
@@ -316,16 +325,19 @@ class TestAudioFinetuneTransform:
     def transform(self):
         return AudioFineTuneTransform()
 
+    @skip_if_no_ffmpeg()
     def test_transform(self, transform, wav):
         actual = transform(wav)
         assert_expected(actual.size(), (1, 1024, 128))
         assert_expected(actual.sum().item(), 53656.75, atol=0.0001, rtol=0.0001)
 
+    @skip_if_no_ffmpeg()
     def test_transform_list(self, transform, wav):
         actual = transform([wav])
         assert_expected(actual.size(), (1, 1, 1024, 128))
         assert_expected(actual.sum().item(), 53656.75, atol=0.0001, rtol=0.0001)
 
+    @skip_if_no_ffmpeg()
     def test_transform_with_mixup(self, transform, wav):
         with open(get_asset_path("sinewave.wav"), "rb") as f:
             bfr = f.read()

--- a/torchmultimodal/models/video_gpt/__init__.py
+++ b/torchmultimodal/models/video_gpt/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Two more changes to fix our nightly builds:

1) Add \_\_init\_\_.py to `torchmultimodal/models/video_gpt/` to fix import failures.
2) Define a new test util to skip unit tests if ffmpeg is not installed. Per discussions with @mthrok torchaudio does not come with ffmpeg installed, though when we use conda install it will be included with torchvision. As a result, the pip install command in our nightly builds does not have ffmpeg, which causes some of our audio MAE transform tests to fail. We also do not want to install it directly with our library due to licensing. As a result, we add a test utility to skip these tests if ffmpeg is not installed.

Test plan:
Create a new conda env and follow the steps in nightly_build.yaml to install our deps with pip (so no ffmpeg).

```
conda create -n tmm-10-24-23-no-ffmpeg python=3.8
conda activate tmm-10-24-23-no-ffmpeg
python -m pip install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
python -m  pip install -r requirements.txt
python -m pip install pytest pytest-mock pytest-cov
python -m pytest -v tests/transforms
...
============ 58 passed, 7 skipped in 2.79s =========
```

Also confirmed that by removing one of the `skip_if_no_mmpeg` decorator from one of the tests in the same environment causes it to fail.
