### PR TITLE
Replace torch.jit.instance with instance to assist torch.compile

### DIFF
--- a/torchmultimodal/modules/layers/transformer.py
+++ b/torchmultimodal/modules/layers/transformer.py
@@ -381,9 +381,8 @@ class TransformerDecoderLayer(nn.Module):
             # TODO: figure out caching for cross-attention
             use_cache=False,
         )
-        assert torch.jit.isinstance(
-            output, Tensor
-        ), "cross-attention output must be Tensor."
+        assert isinstance(output, Tensor), "cross-attention output must be Tensor."
+
         attention_output = self.cross_attention_dropout(output)
         return attention_output
 


### PR DESCRIPTION
Summary: torch.jit.instance is mainly needed to refine Generics, but in this case instance is sufficient, instance unlike torch.jit.instance is also playing nicely with torch.compile

Differential Revision: D53797660


