### PR TITLE
update mypy version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ black==22.12.0
 flake8-bugbear==22.4.25
 flake8==4.0.1
 iopath
-mypy==1.0.1
+mypy==1.8.0
 pep8-naming==0.12.1
 pre-commit
 pytest

--- a/torchmultimodal/utils/common.py
+++ b/torchmultimodal/utils/common.py
@@ -121,7 +121,7 @@ def momentum_update(model: nn.Module, model_m: nn.Module, momentum: float) -> No
 
 class ModelOutput(OrderedDict):
     def keys(self) -> Any:
-        for field in fields(self):
+        for field in fields(self):  # type: ignore
             yield field.name
 
     def __getitem__(self, key: Any) -> Any:
@@ -131,11 +131,11 @@ class ModelOutput(OrderedDict):
         yield from self.keys()
 
     def values(self) -> Any:
-        for field in fields(self):
+        for field in fields(self):  # type: ignore
             yield getattr(self, field.name)
 
     def items(self) -> Any:
-        for field in fields(self):
+        for field in fields(self):  # type: ignore
             yield field.name, getattr(self, field.name)
 
 


### PR DESCRIPTION
Summary:
Our CI is failing ([ex](https://github.com/facebookresearch/multimodal/actions/runs/7934357313/job/21665167793?pr=521)) due to a mismatch in the mypy version used with pytorch core. Update mypy version to fix it

Test plan:
Fresh install and run mypy

```
conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch-nightly -c nvidia
pip install -e ".[dev]"
mypy
Success: no issues found in 135 source files
```

CI is green now