### PR TITLE
Use log1p(x) instead of log(1+x)

### DIFF
--- a/torchmultimodal/models/masked_auto_encoder/swin_decoder.py
+++ b/torchmultimodal/models/masked_auto_encoder/swin_decoder.py
@@ -81,8 +81,8 @@ class WindowMultiHeadAttention(nn.Module):
             relative_coordinates.permute(1, 2, 0).reshape(-1, 2).float()
         )
 
-        relative_coordinates_log = torch.sign(relative_coordinates) * torch.log(
-            1.0 + relative_coordinates.abs()
+        relative_coordinates_log = torch.sign(relative_coordinates) * torch.log1p(
+            relative_coordinates.abs()
         )
         self.register_buffer(
             "relative_coordinates_log", relative_coordinates_log, persistent=False


### PR DESCRIPTION
This function is more accurate than torch.log() for small values of input - https://pytorch.org/docs/stable/generated/torch.log1p.html

Found with TorchFix https://github.com/pytorch-labs/torchfix/