### PR TITLE
Use scaled_dot_product_attention_with_weights utility

### DIFF
--- a/torchmultimodal/modules/layers/attention.py
+++ b/torchmultimodal/modules/layers/attention.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 from torch import nn, Tensor
 from torch.nn import functional as F
+from torch.nn.attention import scaled_dot_product_attention_with_weights
 from torchmultimodal.utils.common import shift_dim
 
 
@@ -215,6 +216,14 @@ def scaled_dot_product_attention(
     Returns:
         A tuple of output tensor and attention probabilities.
     """
+    if head_mask is None:
+        return scaled_dot_product_attention_with_weights(
+            q,
+            k,
+            v,
+            attn_mask=attention_mask == 1 if attention_mask is not None else None,
+            dropout_p=attn_dropout,
+        )
 
     # Take the dot product between "query" and "key" and scale to get the raw attention scores.
     attn = torch.matmul(q, k.transpose(-1, -2))


### PR DESCRIPTION
Summary: We have multiple implementations of attention in our codebase, making it hard to migrate between different hardware, pick up SOTA etc. This diff migrates torchmultimodal for the exact same implementation from SDPA. More details can be found here https://docs.google.com/document/d/1XCZkhLtBNXGhxoYZ2-47XVvH7bQDOzPXBNZyL7Q7Fqo/edit?tab=t.0#heading=h.gzjhznhk1ejy

Differential Revision: D92574396


