### PR TITLE
Flip torchmultimodal to Pillow 12.2.0

### DIFF
--- a/examples/mugen/data/coinrun/construct_from_json.py
+++ b/examples/mugen/data/coinrun/construct_from_json.py
@@ -242,7 +242,7 @@ class Asset:
 
         # flip if needed (for facing left/right)
         if self.flip:
-            self.asset = self.asset.transpose(Image.FLIP_LEFT_RIGHT)
+            self.asset = self.asset.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
 
         if self.binarize_alpha:
             self.asset = binarize_alpha_channel(self.asset)
@@ -356,7 +356,7 @@ def get_transparent_asset(input_asset, transparency):
     np_asset = np.array(input_asset, dtype=np.int16)
     np_asset[:, :, 3] -= transparency
     np_asset[:, :, 3] = np.clip(np_asset[:, :, 3], 0, None)
-    return Image.fromarray(np_asset.astype(np.uint8))
+    return Image.fromarray(np.asarray(np_asset.astype(np.uint8)))
 
 
 # return rect in integer values, floor for x1,y1, ceil for x2,y2 or w,h
@@ -419,7 +419,7 @@ def paint_color_in_rect_with_mask(
     # in some cases, mask size doesn't match the rect (e.g. monster dying)
     if rect[2] != w or rect[3] != h:
         if not gen_original:
-            mask = mask.resize((rect[2], rect[3]), resample=Image.NEAREST)
+            mask = mask.resize((rect[2], rect[3]), resample=Image.Resampling.NEAREST)
         else:
             mask = mask.resize((rect[2], rect[3]))
         w, h = mask.size

--- a/torchmultimodal/diffusion_labs/transforms/inpainting_transform.py
+++ b/torchmultimodal/diffusion_labs/transforms/inpainting_transform.py
@@ -202,9 +202,9 @@ def brush_stroke_mask_image(im: Tensor) -> Tensor:
         draw_strokes(mask, vertex, width)
 
     if np.random.normal() > 0:
-        mask.transpose(Image.FLIP_LEFT_RIGHT)
+        mask.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
     if np.random.normal() > 0:
-        mask.transpose(Image.FLIP_TOP_BOTTOM)
+        mask.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
 
     mask = np.reshape(mask, (1, img_height, img_width))
     mask = torch.tensor(mask, dtype=im.dtype).permute(0, 1, 2)

--- a/torchmultimodal/diffusion_labs/utils/common.py
+++ b/torchmultimodal/diffusion_labs/utils/common.py
@@ -31,12 +31,12 @@ def cascaded_resize(pil_image: Image, resolution: int) -> Image:
     """
     while min(*pil_image.size) >= 2 * resolution:
         pil_image = pil_image.resize(
-            tuple(x // 2 for x in pil_image.size), resample=PIL.Image.BOX
+            tuple(x // 2 for x in pil_image.size), resample=PIL.Image.Resampling.BOX
         )
     scale = resolution / min(*pil_image.size)
     pil_image = pil_image.resize(
         tuple(round(x * scale) for x in pil_image.size),
-        resample=PIL.Image.BICUBIC,
+        resample=PIL.Image.Resampling.BICUBIC,
     )
 
     return pil_image

--- a/torchmultimodal/transforms/mae_transform.py
+++ b/torchmultimodal/transforms/mae_transform.py
@@ -46,7 +46,7 @@ class ImageEvalTransform:
     def __init__(
         self,
         input_size: int,
-        interpolation: int = Image.BICUBIC,
+        interpolation: int = Image.Resampling.BICUBIC,
         mean: Tuple[float, float, float] = (0.485, 0.456, 0.406),
         std: Tuple[float, float, float] = (0.229, 0.224, 0.225),
     ):
@@ -95,7 +95,7 @@ class ImagePretrainTransform:
         self,
         input_size: int,
         scale: Tuple[float, float] = (0.2, 1.0),
-        interpolation: int = Image.BICUBIC,
+        interpolation: int = Image.Resampling.BICUBIC,
         mean: Tuple[float, float, float] = (0.485, 0.456, 0.406),
         std: Tuple[float, float, float] = (0.229, 0.224, 0.225),
     ) -> None:
@@ -250,7 +250,7 @@ class RandAug:
 
     MAX_MAG = 10
     FILL_COLOR = (124, 116, 104)
-    INTERPOLATIONS = (Image.BILINEAR, Image.BICUBIC)
+    INTERPOLATIONS = (Image.Resampling.BILINEAR, Image.Resampling.BICUBIC)
 
     def __init__(
         self,
@@ -382,7 +382,7 @@ class RandAug:
                 interpolation = random.choice(self.INTERPOLATIONS)
                 x = x.transform(
                     x.size,
-                    Image.AFFINE,
+                    Image.Transform.AFFINE,
                     (1, shear, 0, 0, 1, 0),
                     fillcolor=self.FILL_COLOR,
                     resample=interpolation,
@@ -393,7 +393,7 @@ class RandAug:
                 interpolation = random.choice(self.INTERPOLATIONS)
                 x = x.transform(
                     x.size,
-                    Image.AFFINE,
+                    Image.Transform.AFFINE,
                     (1, 0, 0, shear, 1, 0),
                     fillcolor=self.FILL_COLOR,
                     resample=interpolation,
@@ -405,7 +405,7 @@ class RandAug:
                 interpolation = random.choice(self.INTERPOLATIONS)
                 x = x.transform(
                     x.size,
-                    Image.AFFINE,
+                    Image.Transform.AFFINE,
                     (1, 0, translate, 0, 1, 0),
                     fillcolor=self.FILL_COLOR,
                     resample=interpolation,
@@ -418,7 +418,7 @@ class RandAug:
                 interpolation = random.choice(self.INTERPOLATIONS)
                 x = x.transform(
                     x.size,
-                    Image.AFFINE,
+                    Image.Transform.AFFINE,
                     (1, 0, 0, 0, 1, translate),
                     fillcolor=self.FILL_COLOR,
                     resample=interpolation,


### PR DESCRIPTION
Summary: Part of the Pillow 9.4.0 -> 12.2.0 migration (T274839644). Flips the `pypi/pillow` pin in `fbcode/torchmultimodal/PACKAGE` 9.4.0 -> 12.2.0 (nearest-PACKAGE-wins scopes it to this subtree). First-pass 12.2.0-stub code changes (consts renamed: 20, fromarray wrapped: 3): `Image.fromarray`->`np.asarray(...)`, removed resampling/transform/quantize/palette/dither consts -> namespaced `Image.Resampling/Transpose/...` enums (runtime no-ops / dual-compatible).

Reviewed By: fried

Differential Revision: D110804234


